### PR TITLE
Fix url pattern to stop requiring two trailing slashes.

### DIFF
--- a/opentreemap/treemap/urls.py
+++ b/opentreemap/treemap/urls.py
@@ -8,6 +8,6 @@ from treemap.views import index, settings
 
 urlpatterns = patterns(
     '',
-    url(r'^/$', index),
+    url(r'^$', index),
     url(r'^config/settings.js$', settings)
 )


### PR DESCRIPTION
In order to match this urlpattern, I had to make a request
to localhost:6060/1// with two trailing slashes required.
