### PR TITLE
Add scope_model method to Instance

### DIFF
--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -64,6 +64,10 @@ class Instance(models.Model):
     def center_lat_lng(self):
         return self.center.transform(4326,clone=True)
 
+    def scope_model(self, model):
+        qs = model.objects.filter(instance=self)
+        return qs
+
 class Species(models.Model):
     """
     http://plants.usda.gov/adv_search.html


### PR DESCRIPTION
Each instance can filter down any model with an instance field down
to records from that instance. The recommended usage is to apply
this method on the instance that is hanging off of a request.

If an model doesn't have an instance field, Django would raise a
FieldError, just like when using the ORM.
