### PR TITLE
Set the default vagrant box to precise64

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,8 +4,8 @@
 Vagrant::Config.run do |config|
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "precise32"
-  config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+  config.vm.box = "precise64"
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
   config.vm.forward_port 80, 6060
 


### PR DESCRIPTION
We will be developing on and deploying to exclusively 64-bit machines.
