### PR TITLE
Boost vagrant vm memory and add a processor

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,5 +13,5 @@ Vagrant::Config.run do |config|
 
   config.vm.provision :shell, :path => "scripts/bootstrap.sh"
 
-  config.vm.customize ["modifyvm", :id, "--memory", 1024]
+  config.vm.customize ["modifyvm", :id, "--memory", 2048, "--cpus", "2"]
 end


### PR DESCRIPTION
Building the node mapnik bindings takes an extremely long time unless you
give the VM some room to move.
