### PR TITLE
Move ecobenefit search to treemap app

### DIFF
--- a/opentreemap/ecobenefits/urls.py
+++ b/opentreemap/ecobenefits/urls.py
@@ -4,10 +4,9 @@ from __future__ import division
 
 from django.conf.urls import patterns, include, url
 
-from ecobenefits.views import tree_benefits, group_tree_benefits
+from ecobenefits.views import tree_benefits
 
 urlpatterns = patterns(
     '',
     url(r'^benefit/tree/(?P<tree_id>\d+)/$', tree_benefits),
-    url(r'^benefit/search$', group_tree_benefits)
 )

--- a/opentreemap/treemap/urls.py
+++ b/opentreemap/treemap/urls.py
@@ -5,7 +5,7 @@ from __future__ import division
 from django.conf.urls import patterns, include, url
 
 from treemap.views import boundary_to_geojson, index, trees,\
-    plot_detail, settings_js, audits
+    plot_detail, settings_js, audits, search_tree_benefits
 
 urlpatterns = patterns(
     '',
@@ -14,5 +14,6 @@ urlpatterns = patterns(
     url(r'^recentedits', audits),
     url(r'^trees/$', trees),
     url(r'^trees/(?P<plot_id>\d+)/$', plot_detail),
-    url(r'^config/settings.js$', settings_js)
+    url(r'^config/settings.js$', settings_js),
+    url(r'^benefit/search$', search_tree_benefits),
 )

--- a/opentreemap/treemap/views.py
+++ b/opentreemap/treemap/views.py
@@ -4,7 +4,7 @@ from __future__ import division
 
 from django.shortcuts import render_to_response, get_object_or_404
 from django.template import RequestContext
-from django.http import HttpResponse, HttpResponseBadRequest
+from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseServerError
 
 from django.views.decorators.http import etag
 
@@ -157,3 +157,58 @@ def audits(request):
 def boundary_to_geojson(request, boundary_id):
     boundary = Boundary.objects.get(pk=boundary_id)
     return HttpResponse(boundary.geom.geojson)
+
+#
+# DUMMY FUNCTION - to be replaced when we have filtering
+# working
+#
+def _execute_filter(instance, filter_str):
+    return Tree.objects.filter(instance=instance)
+
+@instance_request
+def search_tree_benefits(request, region='SoCalCSMA'):
+    try:
+        filter_str = request.REQUEST['filter']
+    except KeyError:
+        return HttpResponseServerError("Please supply a 'filter' parameter")
+        
+    trees = _execute_filter(request.instance, filter_str)
+
+    num_calculated_trees = 0
+
+    benefits = {'energy': 0.0, 'stormwater': 0.0,
+                'co2': 0.0, 'airquality': 0.0}
+
+    for tree in trees:
+        if tree.diameter and tree.species:
+            tree_benefits = _benefits_for_tree_dbh_and_species(
+                tree.diameter, tree.species, region)
+
+            for key in benefits:
+                benefits[key] = tree_benefits[key]['value']
+
+            num_calculated_trees += 1
+
+    total_trees = len(trees)
+    if num_calculated_trees > 0 and total_trees > 0:
+
+        # Extrapolate an average over the rest of the urban forest
+        trees_without_benefit_data = total_trees - num_calculated_trees
+        for benefit in benefits:
+            avg_benefit = benefits[benefit] / num_calculated_trees
+            extrp_benefit = avg_benefit * trees_without_benefit_data
+
+            benefits[benefit] += extrp_benefit
+
+        rslt = {'benefits': benefits,
+                'basis': {'n_calc': num_calculated_trees,
+                          'n_total': total_trees,
+                          'percent': float(num_calculated_trees)/total_trees }}
+    else:
+        rslt = {'benefits': benefits,
+                'basis': {'n_calc': num_calculated_trees,
+                          'n_total': total_trees,
+                          'percent': 0}}
+
+    return HttpResponse(json.dumps(rslt), content_type='application/json')
+


### PR DESCRIPTION
The initial thought a long time ago was that tree benefits calcuations
would have their own url, so that when you do a search, you would get
back tree benefits. As we continued to develop searching api and it
turned out that we will want to return more than ecobenfits. We may
want species data, tree counts, etc. So, we don't want this whole
other endpoint just for searching. As we kept adding more stuff, we
realized this doesn't really belong here anymore, it's not just going
to be eco benefits. So, we are moving it to the regular app. It's
going to grow into the main search function.

However, it may be useful down the road to again factor out the
portion that calculates eco benefits and but that back in
ecobenefits.views or in a utility function library like
ecobenefits.utils.
