### PR TITLE
Add filterable OTM tile layer

### DIFF
--- a/opentreemap/treemap/static/js/src/app.js
+++ b/opentreemap/treemap/static/js/src/app.js
@@ -1,6 +1,7 @@
 /* app.js */
 
 //= require OpenLayers
+//= require openlayers.layer.otm
 //= require Search
 
 /*globals $,OpenLayers,otm,document,Search*/
@@ -49,11 +50,11 @@ var app = (function ($,OL,Search,config) {
         },
 
         createPlotTileLayer: function(config) {
-            return new OL.Layer.XYZ(
+            return new OL.Layer.OTM(
                 'tiles',
                 this.getPlotLayerURL(config, 'png'),
-            { isBaseLayer: false });
-
+            { isBaseLayer: false,
+              filterQueryArgumentName: config.urls.filterQueryArgumentName });
         },
 
         createPlotUTFLayer: function(config) {
@@ -121,7 +122,7 @@ var app = (function ($,OL,Search,config) {
             map.setCenter(config.instance.center, zoom);
 
             Search.init($("#perform-search")
-                        .asEventStream("click"));
+                        .asEventStream("click"), plotLayer);
         }
     };
 }($, OpenLayers, Search, otm.settings));

--- a/opentreemap/treemap/static/js/src/openlayers.layer.otm.js
+++ b/opentreemap/treemap/static/js/src/openlayers.layer.otm.js
@@ -1,0 +1,62 @@
+//= require openlayers
+//= require underscore
+
+/*jslint indent: 4, white: true, nomen: true */
+/*globals OpenLayers, _*/
+
+(function (OL, _) {
+    "use strict";
+
+    function filterObjectIsEmpty(o) {
+        if (o) {
+            return _.keys(o).length === 0;
+        } else {
+            return true;
+        }
+    }
+
+    function uriEncodeFilterObject(o) {
+        return encodeURIComponent(JSON.stringify(o));
+    }
+
+    var _urlTemplate = _.template('<%= originalUrl %>?<%= filterQueryArgumentName %>=<%= uriEncodedFilterObject %>');
+
+    OL.Layer.OTM = OL.Layer.OTM || OL.Class(OL.Layer.XYZ, {
+        originalUrl: null,
+        filter: null,
+        filterQueryArgumentName: null,
+
+        initialize: function(name, url, options) {
+            var newArgs;
+            options = OL.Util.applyDefaults({
+                    sphericalMercator: true,
+                    url: url
+                }, options);
+            newArgs = [name, null, options];
+            OL.Layer.XYZ.prototype.initialize.apply(this, newArgs);
+            this.url = url;
+            this.originalUrl = url;
+            this.filterQueryArgumentName = options.filterQueryArgumentName;
+        },
+
+        clearFilter: function() {
+            this.filter = undefined;
+            this.url = this.originalUrl;
+            this.redraw();
+        },
+
+        setFilter: function(filter) {
+            if (filterObjectIsEmpty(filter)) {
+                this.clearFilter();
+            } else {
+                this.filter = filter;
+                this.url = _urlTemplate({
+                    originalUrl: this.originalUrl,
+                    filterQueryArgumentName: this.filterQueryArgumentName,
+                    uriEncodedFilterObject: uriEncodeFilterObject(filter)
+                });
+                this.redraw();
+            }
+        }
+    });
+}(OpenLayers, _));

--- a/opentreemap/treemap/static/js/src/search.js
+++ b/opentreemap/treemap/static/js/src/search.js
@@ -53,9 +53,22 @@ var Search = (function ($,Bacon,config) {
         $("#search-results").html(html);
     }
 
-    exports.init = function(start_search_stream) {
-        return start_search_stream
-            .map(buildSearch)
+    // Arguments
+    //
+    // triggerEventStream: a Bacon.js EventStream. The value
+    //   of the item will be ignored and, instead, the current
+    //   values of the search form fields will be scraped.
+    //
+    // plotLayer: An OpenLayers.Layer.OTM instance with the
+    // `url` argument initialized to the unfiltered tile url.
+    exports.init = function(triggerEventStream, plotLayer) {
+        var searchStream = triggerEventStream.map(buildSearch);
+
+        // binding is required to save the context of the plotLayer
+        // `setFilter` instance method
+        searchStream.onValue(_.bind(plotLayer.setFilter, plotLayer));
+
+        searchStream
             .flatMap(executeSearch)
             .onValue(displaySearch);
     };

--- a/opentreemap/treemap/templates/treemap/settings.js
+++ b/opentreemap/treemap/templates/treemap/settings.js
@@ -2,6 +2,10 @@
 var otm = otm || {};
 otm.settings = otm.settings || {};
 
+otm.settings.urls = {
+    'filterQueryArgumentName': 'q'
+}
+
 otm.settings.instance = {
     'id': '{{ request.instance.id }}',
     'name': '{{ request.instance.name }}',


### PR DESCRIPTION
I encapsulated the manipulation of the tile layer URL in a custom subclass
of OpenLayers.Layer.XYZ so that the application can call a simple setFilter
method on the layer when the user changes filter arguments.
