### PR TITLE
Remove 'created_by' from trees and plots

### DIFF
--- a/opentreemap/api/test_utils.py
+++ b/opentreemap/api/test_utils.py
@@ -12,7 +12,7 @@ import django.shortcuts
 
 
 def mkPlot(instance, user, geom=Point(50, 50)):
-    p = Plot(geom=geom, instance=instance, created_by=user)
+    p = Plot(geom=geom, instance=instance)
     p.save_with_user(user)
 
     return p
@@ -27,7 +27,7 @@ def mkTree(instance, user, plot=None, species=None):
     else:
         s = species
 
-    t = Tree(plot=plot, instance=instance, species=s, created_by=user)
+    t = Tree(plot=plot, instance=instance, species=s)
     t.save_with_user(user)
 
     return t

--- a/opentreemap/api/tests.py
+++ b/opentreemap/api/tests.py
@@ -640,7 +640,7 @@ class CreatePlotAndTree(TestCase):
         self.assertEqual(plot_count + 1, Plot.objects.count())
         # Assert that reputation went up
         reloaded_user_rep = User.objects.get(pk=self.user.pk).reputation
-        self.assertEqual(reputation_count + 10, reloaded_user_rep)
+        self.assertEqual(reputation_count + 8, reloaded_user_rep)
 
         response_json = loads(response.content)
         self.assertTrue("id" in response_json)
@@ -713,7 +713,7 @@ class CreatePlotAndTree(TestCase):
         self.assertEqual(plot_count + 1, Plot.objects.count())
         # Assert that reputation was added
         reloaded_user_rep = User.objects.get(pk=self.user.pk).reputation
-        self.assertEqual(reputation_count + 10, reloaded_user_rep)
+        self.assertEqual(reputation_count + 8, reloaded_user_rep)
 
         response_json = loads(response.content)
         self.assertTrue("id" in response_json)

--- a/opentreemap/api/views.py
+++ b/opentreemap/api/views.py
@@ -995,8 +995,7 @@ def update_plot_and_tree(request, instance, plot_id):
         if ((tree_field.name in request_dict and
              tree_field.name in tree_field_whitelist)):
             if tree is None:
-                tree = Tree(plot=plot, instance=instance,
-                            created_by=request.user)
+                tree = Tree(plot=plot, instance=instance)
 
                 tree.plot = plot
                 tree.last_updated_by = request.user

--- a/opentreemap/ecobenefits/tests.py
+++ b/opentreemap/ecobenefits/tests.py
@@ -32,8 +32,7 @@ class EcoTest(TestCase):
 
         p1 = Point(-8515941.0, 4953519.0)
         self.plot = Plot(geom=p1,
-                         instance=self.instance,
-                         created_by=self.user)
+                         instance=self.instance)
 
         self.plot.save_with_user(self.user)
 
@@ -41,8 +40,7 @@ class EcoTest(TestCase):
                          instance=self.instance,
                          readonly=False,
                          species=self.species,
-                         diameter=1630,
-                         created_by=self.user)
+                         diameter=1630)
 
         self.tree.save_with_user(self.user)
 

--- a/opentreemap/treemap/audit.py
+++ b/opentreemap/treemap/audit.py
@@ -218,7 +218,7 @@ class Authorizable(UserTrackable):
     def __init__(self, *args, **kwargs):
         super(Authorizable, self).__init__(*args, **kwargs)
 
-        self._exempt_field_names = {'instance', 'created_by', 'id'}
+        self._exempt_field_names = {'instance', 'id'}
         self._has_been_clobbered = False
 
     def _write_perm_comparison_sets(self, user):

--- a/opentreemap/treemap/management/commands/random_trees.py
+++ b/opentreemap/treemap/management/commands/random_trees.py
@@ -65,7 +65,7 @@ class Command(BaseCommand):
             user.roles.add(r)
             user.save()
 
-        for field in ('geom', 'created_by', 'import_event'):
+        for field in ('geom', 'import_event'):
             _, c = FieldPermission.objects.get_or_create(
                 model_name='Plot',
                 field_name=field,
@@ -75,7 +75,7 @@ class Command(BaseCommand):
             if c:
                 print('Created plot permission for field "%s"' % field)
 
-        for field in ('plot', 'created_by'):
+        for field in ('plot',):
             _, c = FieldPermission.objects.get_or_create(
                 model_name='Tree',
                 field_name=field,
@@ -121,7 +121,6 @@ class Command(BaseCommand):
 
             plot = Plot(instance=instance,
                         geom=Point(x, y),
-                        created_by=user,
                         import_event=import_event)
 
             plot.save_with_user(user)
@@ -129,7 +128,6 @@ class Command(BaseCommand):
 
             if mktree:
                 tree = Tree(plot=plot,
-                            created_by=user,
                             import_event=import_event,
                             instance=instance)
                 tree.save_with_user(user)

--- a/opentreemap/treemap/migrations/0013_auto__del_field_tree_created_by__del_field_plot_created_by.py
+++ b/opentreemap/treemap/migrations/0013_auto__del_field_tree_created_by__del_field_plot_created_by.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'Tree.created_by'
+        db.delete_column(u'treemap_tree', 'created_by_id')
+
+        # Deleting field 'Plot.created_by'
+        db.delete_column(u'treemap_plot', 'created_by_id')
+
+
+    def backwards(self, orm):
+
+        # User chose to not deal with backwards NULL issues for 'Tree.created_by'
+        raise RuntimeError("Cannot reverse this migration. 'Tree.created_by' and its values cannot be restored.")
+
+        # User chose to not deal with backwards NULL issues for 'Plot.created_by'
+        raise RuntimeError("Cannot reverse this migration. 'Plot.created_by' and its values cannot be restored.")
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'treemap.audit': {
+            'Meta': {'object_name': 'Audit'},
+            'action': ('django.db.models.fields.IntegerField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'current_value': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'field': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']", 'null': 'True', 'blank': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'model_id': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'previous_value': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'ref_id': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Audit']", 'null': 'True'}),
+            'requires_auth': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.boundary': {
+            'Meta': {'object_name': 'Boundary'},
+            'category': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'geom': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857', 'db_column': "u'the_geom_webmercator'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'sort_order': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.fieldpermission': {
+            'Meta': {'object_name': 'FieldPermission'},
+            'field_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'model_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'permission_level': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Role']"})
+        },
+        u'treemap.importevent': {
+            'Meta': {'object_name': 'ImportEvent'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'imported_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"}),
+            'imported_on': ('django.db.models.fields.DateField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        u'treemap.instance': {
+            'Meta': {'object_name': 'Instance'},
+            'basemap_data': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'basemap_type': ('django.db.models.fields.CharField', [], {'default': "u'google'", 'max_length': '255'}),
+            'boundaries': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['treemap.Boundary']", 'null': 'True', 'blank': 'True'}),
+            'center': ('django.contrib.gis.db.models.fields.PointField', [], {'srid': '3857'}),
+            'default_role': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'default_role'", 'to': u"orm['treemap.Role']"}),
+            'geo_rev': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'treemap.instancespecies': {
+            'Meta': {'object_name': 'InstanceSpecies'},
+            'common_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'species': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Species']"})
+        },
+        u'treemap.plot': {
+            'Meta': {'object_name': 'Plot'},
+            'address_city': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'address_street': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'address_zip': ('django.db.models.fields.CharField', [], {'max_length': '30', 'null': 'True', 'blank': 'True'}),
+            'geom': ('django.contrib.gis.db.models.fields.PointField', [], {'srid': '3857', 'db_column': "u'the_geom_webmercator'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'import_event': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.ImportEvent']", 'null': 'True', 'blank': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'length': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'owner_orig_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'readonly': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'width': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'treemap.reputationmetric': {
+            'Meta': {'object_name': 'ReputationMetric'},
+            'action': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'approval_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'denial_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'direct_write_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']", 'null': 'True', 'blank': 'True'}),
+            'model_name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'treemap.role': {
+            'Meta': {'object_name': 'Role'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'rep_thresh': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.species': {
+            'Meta': {'object_name': 'Species'},
+            'bloom_period': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'common_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'cultivar_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'fact_sheet': ('django.db.models.fields.URLField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'fall_conspicuous': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'flower_conspicuous': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'fruit_period': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'gender': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'genus': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'itree_code': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'max_dbh': ('django.db.models.fields.IntegerField', [], {'default': '200'}),
+            'max_height': ('django.db.models.fields.IntegerField', [], {'default': '800'}),
+            'native_status': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'palatable_human': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'plant_guide': ('django.db.models.fields.URLField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'species': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'symbol': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'wildlife_value': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'treemap.tree': {
+            'Meta': {'object_name': 'Tree'},
+            'canopy_height': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'date_planted': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_removed': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'diameter': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'height': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'import_event': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.ImportEvent']", 'null': 'True', 'blank': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'plot': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Plot']"}),
+            'readonly': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'species': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Species']", 'null': 'True', 'blank': 'True'})
+        },
+        u'treemap.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'reputation': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'roles': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['treemap.Role']", 'null': 'True', 'blank': 'True'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        }
+    }
+
+    complete_apps = ['treemap']

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -203,7 +203,6 @@ class Plot(Authorizable, Auditable, models.Model):
     address_zip = models.CharField(max_length=30, blank=True, null=True)
 
     import_event = models.ForeignKey(ImportEvent, null=True, blank=True)
-    created_by = models.ForeignKey(User)
     owner_orig_id = models.CharField(max_length=255, null=True, blank=True)
     readonly = models.BooleanField(default=False)
 
@@ -250,7 +249,6 @@ class Tree(Authorizable, Auditable, models.Model):
 
     plot = models.ForeignKey(Plot)
     species = models.ForeignKey(Species, null=True, blank=True)
-    created_by = models.ForeignKey(User)
     import_event = models.ForeignKey(ImportEvent, null=True, blank=True)
 
     readonly = models.BooleanField(default=False)

--- a/opentreemap/treemap/tests.py
+++ b/opentreemap/treemap/tests.py
@@ -229,7 +229,7 @@ class HashModelTest(TestCase):
         self.p2 = Point(-7615441.0, 5953519.0)
 
     def test_changing_fields_changes_hash(self):
-        plot = Plot(geom=self.p1, instance=self.instance, created_by=self.user)
+        plot = Plot(geom=self.p1, instance=self.instance)
         plot.save_with_user(self.user)
 
         #
@@ -256,8 +256,7 @@ class HashModelTest(TestCase):
         h1 = plot.hash
         tree = Tree(plot=plot,
                     instance=self.instance,
-                    readonly=False,
-                    created_by=self.user)
+                    readonly=False)
         tree.save_with_user(self.user)
         h2 = plot.hash
 
@@ -305,8 +304,7 @@ class GeoRevIncr(TestCase):
         rev1h, rev1 = self.hash_and_rev()
 
         # Create
-        plot1 = Plot(geom=self.p1, instance=self.instance,
-                     created_by=self.user)
+        plot1 = Plot(geom=self.p1, instance=self.instance)
 
         plot1.save_with_user(self.user)
 
@@ -315,8 +313,7 @@ class GeoRevIncr(TestCase):
         self.assertNotEqual(rev1h, rev2h)
         self.assertEqual(rev1 + 1, rev2)
 
-        plot2 = Plot(geom=self.p2, instance=self.instance,
-                     created_by=self.user)
+        plot2 = Plot(geom=self.p2, instance=self.instance)
 
         plot2.save_with_user(self.user)
 
@@ -372,13 +369,11 @@ class UserRoleFieldPermissionTest(TestCase):
         self.anonymous = User(username="")
         self.anonymous.save_with_user(system_user)
 
-        self.plot = Plot(geom=self.p1, instance=self.instance,
-                         created_by=self.officer)
+        self.plot = Plot(geom=self.p1, instance=self.instance)
 
         self.plot.save_with_user(self.officer)
 
-        self.tree = Tree(plot=self.plot, instance=self.instance,
-                         created_by=self.officer)
+        self.tree = Tree(plot=self.plot, instance=self.instance)
 
         self.tree.save_with_user(self.officer)
 
@@ -419,25 +414,21 @@ class UserRoleFieldPermissionTest(TestCase):
 
     def test_save_new_object_authorized(self):
         '''Save two new objects with authorized user, nothing should happen'''
-        plot = Plot(geom=self.p1, instance=self.instance,
-                    created_by=self.officer)
+        plot = Plot(geom=self.p1, instance=self.instance)
 
         plot.save_with_user(self.officer)
 
-        tree = Tree(plot=plot, instance=self.instance,
-                    created_by=self.officer)
+        tree = Tree(plot=plot, instance=self.instance)
 
         tree.save_with_user(self.officer)
 
     def test_save_new_object_unauthorized(self):
-        plot = Plot(geom=self.p1, instance=self.instance,
-                    created_by=self.outlaw)
+        plot = Plot(geom=self.p1, instance=self.instance)
 
         self.assertRaises(AuthorizeException,
                           plot.save_with_user, self.outlaw)
 
-        tree = Tree(plot=plot, instance=self.instance,
-                    created_by=self.outlaw)
+        tree = Tree(plot=plot, instance=self.instance)
 
         self.assertRaises(AuthorizeException,
                           tree.save_with_user, self.outlaw)
@@ -564,26 +555,22 @@ class ScopeModelTest(TestCase):
                             role=self.global_role,
                             instance=i).save()
 
-        self.plot1 = Plot(geom=p1, instance=self.instance1,
-                          created_by=self.user)
+        self.plot1 = Plot(geom=p1, instance=self.instance1)
 
         self.plot1.save_with_user(self.user)
 
-        self.plot2 = Plot(geom=p2, instance=self.instance2,
-                          created_by=self.user)
+        self.plot2 = Plot(geom=p2, instance=self.instance2)
 
         self.plot2.save_with_user(self.user)
 
         tree_combos = itertools.product(
             [self.plot1, self.plot2],
             [self.instance1, self.instance2],
-            [True, False],
-            [self.user])
+            [True, False])
 
         for tc in tree_combos:
-            plot, instance, readonly, created_by = tc
-            t = Tree(plot=plot, instance=instance, readonly=readonly,
-                     created_by=created_by)
+            plot, instance, readonly = tc
+            t = Tree(plot=plot, instance=instance, readonly=readonly)
 
             t.save_with_user(self.user)
 
@@ -671,7 +658,7 @@ class AuditTest(TestCase):
 
     def test_cant_use_regular_methods(self):
         p = Point(-8515222.0, 4953200.0)
-        plot = Plot(geom=p, instance=self.instance, created_by=self.user1)
+        plot = Plot(geom=p, instance=self.instance)
         self.assertRaises(UserTrackingException, plot.save)
         self.assertRaises(UserTrackingException, plot.delete)
 
@@ -681,7 +668,7 @@ class AuditTest(TestCase):
 
     def test_basic_audit(self):
         p = Point(-8515222.0, 4953200.0)
-        plot = Plot(geom=p, instance=self.instance, created_by=self.user1)
+        plot = Plot(geom=p, instance=self.instance)
         plot.save_with_user(self.user1)
 
         self.assertAuditsEqual([
@@ -691,12 +678,9 @@ class AuditTest(TestCase):
             self.make_audit(plot.pk, 'readonly', None, 'False',
                             model='Plot'),
             self.make_audit(plot.pk, 'geom', None, str(plot.geom),
-                            model='Plot'),
-            self.make_audit(plot.pk, 'created_by', None, self.user1.pk,
                             model='Plot')], plot.audits())
 
-        t = Tree(plot=plot, instance=self.instance, readonly=True,
-                 created_by=self.user1)
+        t = Tree(plot=plot, instance=self.instance, readonly=True)
 
         t.save_with_user(self.user1)
 
@@ -704,7 +688,6 @@ class AuditTest(TestCase):
             self.make_audit(t.pk, 'id', None, str(t.pk)),
             self.make_audit(t.pk, 'instance', None, t.instance.pk),
             self.make_audit(t.pk, 'readonly', None, True),
-            self.make_audit(t.pk, 'created_by', None, self.user1.pk),
             self.make_audit(t.pk, 'plot', None, plot.pk)]
 
         self.assertAuditsEqual(expected_audits, t.audits())
@@ -746,8 +729,7 @@ class PendingTest(TestCase):
         self.observer_user.roles.add(make_observer_role(self.instance))
 
         self.p1 = Point(-7615441.0, 5953519.0)
-        self.plot = Plot(geom=self.p1, instance=self.instance,
-                         created_by=self.system_user)
+        self.plot = Plot(geom=self.p1, instance=self.instance)
         self.plot.save_with_user(self.direct_user)
 
     def test_reject(self):
@@ -877,8 +859,7 @@ class ReputationTest(TestCase):
         self.unprivileged_user.roles.add(make_apprentice_role(self.instance))
 
         self.p1 = Point(-7615441.0, 5953519.0)
-        self.plot = Plot(geom=self.p1, instance=self.instance,
-                         created_by=self.system_user)
+        self.plot = Plot(geom=self.p1, instance=self.instance)
 
         self.plot.save_with_user(self.system_user)
 
@@ -890,7 +871,7 @@ class ReputationTest(TestCase):
     def test_reputations_increase_for_direct_writes(self):
         self.assertEqual(self.privileged_user.reputation, 0)
         t = Tree(plot=self.plot, instance=self.instance,
-                 readonly=True, created_by=self.privileged_user)
+                 readonly=True)
         t.save_with_user(self.privileged_user)
         self.assertGreater(self.privileged_user.reputation, 0)
 
@@ -979,13 +960,11 @@ class RecentEditsViewTest(TestCase):
         self.p1 = Point(-7615441.0, 5953519.0)
         self.factory = RequestFactory()
 
-        self.plot = Plot(geom=self.p1, instance=self.instance,
-                         created_by=self.system_user)
+        self.plot = Plot(geom=self.p1, instance=self.instance)
 
         self.plot.save_with_user(self.system_user)
 
-        self.tree = Tree(plot=self.plot, instance=self.instance,
-                         created_by=self.officer)
+        self.tree = Tree(plot=self.plot, instance=self.instance)
 
         self.tree.save_with_user(self.officer)
 
@@ -1418,13 +1397,11 @@ class SearchTests(TestCase):
         self.p1 = Point(-7615441.0, 5953519.0)
 
     def create_tree_and_plot(self):
-        plot = Plot(geom=self.p1, instance=self.instance,
-                    created_by=self.system_user)
+        plot = Plot(geom=self.p1, instance=self.instance)
 
         plot.save_with_user(self.system_user)
 
-        tree = Tree(plot=plot, instance=self.instance,
-                    created_by=self.system_user)
+        tree = Tree(plot=plot, instance=self.instance)
 
         tree.save_with_user(self.system_user)
 
@@ -1490,12 +1467,9 @@ class SearchTests(TestCase):
             category='whatever',
             sort_order=1)
 
-        plot1 = Plot(geom=Point(0.9, 0.9), instance=self.instance,
-                     created_by=self.system_user)
-        plot2 = Plot(geom=Point(1.1, 1.1), instance=self.instance,
-                     created_by=self.system_user)
-        plot3 = Plot(geom=Point(2.5, 2.5), instance=self.instance,
-                     created_by=self.system_user)
+        plot1 = Plot(geom=Point(0.9, 0.9), instance=self.instance)
+        plot2 = Plot(geom=Point(1.1, 1.1), instance=self.instance)
+        plot3 = Plot(geom=Point(2.5, 2.5), instance=self.instance)
 
         for p in (plot1, plot2, plot3):
             p.save_with_user(self.system_user)
@@ -1571,20 +1545,16 @@ class SearchTests(TestCase):
         near_point = Point(-7615444.0, 5953521.0)
         far_point = Point(-9615444.0, 8953521.0)
 
-        near_plot = Plot(geom=near_point, instance=self.instance,
-                         created_by=self.system_user)
+        near_plot = Plot(geom=near_point, instance=self.instance)
         near_plot.save_with_user(self.system_user)
-        near_tree = Tree(plot=near_plot, instance=self.instance,
-                         created_by=self.system_user)
+        near_tree = Tree(plot=near_plot, instance=self.instance)
         near_tree.save_with_user(self.system_user)
 
         # just to make sure that the geospatial
         # query actually filters by distance
-        far_plot = Plot(geom=far_point, instance=self.instance,
-                        created_by=self.system_user)
+        far_plot = Plot(geom=far_point, instance=self.instance)
         far_plot.save_with_user(self.system_user)
-        far_tree = Tree(plot=far_plot, instance=self.instance,
-                        created_by=self.system_user)
+        far_tree = Tree(plot=far_plot, instance=self.instance)
         far_tree.save_with_user(self.system_user)
 
         radius_filter = json.dumps(
@@ -1634,7 +1604,7 @@ class SpeciesViewTests(ViewTestCase):
             {'common_name': 'thing', 'genus': 'elmitius'},
             {'common_name': 'xmas', 'genus': 'christmas',
              'species': 'tree', 'cultivar_name': 'douglass'},
-            {'common_name': 'x-mas tree', 'genus': 'xmas',
+            {'common_name': 'xmas tree', 'genus': 'xmas',
              'species': 'tree', 'cultivar_name': 'douglass'},
         ]
         self.species_json = []

--- a/opentreemap/treemap/views.py
+++ b/opentreemap/treemap/views.py
@@ -88,11 +88,11 @@ def create_plot(user, instance, *args, **kwargs):
     else:
         geom = Point(50, 50)
 
-    p = Plot(geom=geom, instance=instance, created_by=user)
+    p = Plot(geom=geom, instance=instance)
     p.save_with_user(user)
 
     if 'height' in kwargs:
-        t = Tree(plot=p, instance=instance, created_by=user)
+        t = Tree(plot=p, instance=instance)
         t.height = kwargs['height']
 
         if t.height > 1000:


### PR DESCRIPTION
This field isn't really useful in OTM2 since the audit system will
automatically record an INSERT whenever a new audited object is created.
