### PR TITLE
Add user view and template

### DIFF
--- a/opentreemap/opentreemap/urls.py
+++ b/opentreemap/opentreemap/urls.py
@@ -2,6 +2,8 @@ from django.conf.urls import patterns, include, url
 from django.conf import settings
 from django.views.generic import RedirectView
 
+from treemap.views import user_view
+
 from django.contrib import admin
 admin.autodiscover()
 
@@ -14,6 +16,7 @@ urlpatterns = patterns(
     url(r'^', include('geocode.urls')),
     url(r'^(?P<instance_id>\d+)/', include('treemap.urls')),
     url(r'^(?P<instance_id>\d+)/eco/', include('ecobenefits.urls')),
+    url(r'^users/(?P<username>\w+)/', user_view),
     url(r'^api/v2/', include('api.urls')),
     url(r'^accounts/', include('registration_backend.urls')),
 )

--- a/opentreemap/treemap/templates/treemap/user.html
+++ b/opentreemap/treemap/templates/treemap/user.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h2>User</h2>
+<div>Username: {{ username }}</div>
+<div>Name: {{ first_name }} {{ last_name }}</div>
+<div>Email: {{ email }}</div>
+<div>Reputation: {{ reputation }}</div>
+<div>Instance: {{ instance_id }}</div>
+{% endblock content %}

--- a/opentreemap/treemap/tests/views.py
+++ b/opentreemap/treemap/tests/views.py
@@ -6,6 +6,7 @@ import json
 
 from django.test import TestCase
 from django.test.client import RequestFactory
+from django.http import Http404
 
 from django.contrib.gis.geos import Point
 
@@ -14,7 +15,8 @@ from treemap.audit import Role, Audit, approve_or_reject_audit_and_apply
 from treemap.models import Instance, Species, User, Plot, Tree
 
 from treemap.views import (species_list, boundary_to_geojson,
-                           boundary_autocomplete, audits, search_tree_benefits)
+                           boundary_autocomplete, audits, search_tree_benefits,
+                           user, instance_user_view)
 
 from treemap.tests import (ViewTestCase, make_instance, make_system_user,
                            make_commander_role, make_officer_role,
@@ -432,3 +434,52 @@ class SearchTreeBenefitsTests(ViewTestCase):
 
         self.assertEqual(benefits['basis']['percent'], 0.6)
         self.assertGreater(self, value_with_extrapolation, value_without_extrapolation)
+
+
+class UserViewTests(ViewTestCase):
+
+    def setUp(self):
+        super(UserViewTests, self).setUp()
+        self.system_user = make_system_user()
+
+    def test_get_by_username(self):
+        context = user(self._make_request(), self.system_user.username)
+        self.assertEquals(self.system_user.username, context['username'],
+                          'the user view should return a dict with '
+                          '"username" set to %s ' % self.system_user.username)
+
+    def test_get_with_invalid_username_returns_404(self):
+        self.assertRaises(Http404, user, self._make_request(),
+                          'no_way_this_is_a_username')
+
+
+class InstanceUserViewTests(ViewTestCase):
+
+    def setUp(self):
+        super(InstanceUserViewTests, self).setUp()
+        self.system_user = make_system_user()
+
+    def test_get_by_username_redirects(self):
+        res = instance_user_view(self._make_request(),
+                                 self.instance.id,
+                                 self.system_user.username)
+        expected_url = '/users/%s/?instance_id=%d' %\
+            (self.system_user.username, self.instance.id)
+        self.assertEquals(res.status_code, 302, "should be a 302 Found \
+            temporary redirect")
+        self.assertEquals(expected_url, res['Location'],
+                          'the view should redirect to %s not %s ' %
+                          (expected_url, res['Location']))
+
+    def test_get_with_invalid_username_redirects(self):
+        test_instance_id, test_username = 9999999999999, 'no_way_username'
+        res = instance_user_view(self._make_request(),
+                                 test_instance_id,
+                                 test_username)
+        expected_url = '/users/%s/?instance_id=%d' %\
+            (test_username, test_instance_id)
+        self.assertEquals(res.status_code, 302, "should be a 302 Found \
+            temporary redirect")
+        self.assertEquals(expected_url, res['Location'],
+                          'the view should redirect to %s not %s ' %
+                          (expected_url, res['Location']))

--- a/opentreemap/treemap/urls.py
+++ b/opentreemap/treemap/urls.py
@@ -7,7 +7,7 @@ from django.conf.urls import patterns, url
 from treemap.views import (boundary_to_geojson_view, index_view, trees_view,
                            plot_detail_view, settings_js_view, audits_view,
                            search_tree_benefits_view, species_list_view,
-                           boundary_autocomplete_view)
+                           boundary_autocomplete_view, instance_user_view)
 
 urlpatterns = patterns(
     '',
@@ -21,4 +21,5 @@ urlpatterns = patterns(
     url(r'^trees/(?P<plot_id>\d+)/$', plot_detail_view),
     url(r'^config/settings.js$', settings_js_view),
     url(r'^benefit/search$', search_tree_benefits_view),
+    url(r'^users/(?P<username>\w+)/', instance_user_view),
 )

--- a/opentreemap/treemap/views.py
+++ b/opentreemap/treemap/views.py
@@ -6,7 +6,8 @@ import urllib
 from PIL import Image
 
 from django.shortcuts import get_object_or_404
-from django.http import HttpResponse, HttpResponseServerError
+from django.http import (HttpResponse, HttpResponseServerError,
+                         HttpResponseRedirect)
 
 from django.views.decorators.http import etag
 
@@ -284,6 +285,18 @@ def search_tree_benefits(request, instance, region='PiedmtCLT'):
     return rslt
 
 
+def user(request, username):
+    context = get_object_or_404(User, username=username).__dict__
+    context['instance_id'] = request.GET.get('instance_id', None)
+    return context
+
+
+def instance_user_view(request, instance_id, username):
+    url = '/users/%(username)s/?instance_id=%(instance_id)s' %\
+        {'username': username, 'instance_id': instance_id}
+    return HttpResponseRedirect(url)
+
+
 audits_view = instance_request(
     render_template('treemap/recent_edits.html', audits))
 
@@ -310,3 +323,5 @@ search_tree_benefits_view = instance_request(
     render_template('treemap/eco_benefits.html', search_tree_benefits))
 
 species_list_view = json_api_call(instance_request(species_list))
+
+user_view = render_template("treemap/user.html", user)


### PR DESCRIPTION
I have mounted the user page under both /users/{username} because users
are global to the application. I have also created a redirect view that
sends /{instanceid}/users/{username} to
/users/{username}/?instance_id={instanceid}.

We anticipate using url rewriting so that
  http://philly.opentreemap.com/
maps to
  http://opentreemap.com/1/
and therefore
  http://philly.opentreemap.com/users/jwalgran
would map to
  http://opentreemap.com/1/users/jwalgran
and then redirect to
  http://opentreemap.com/users/jwalgran/?instance_id=1

When viewing the user page "under" an instance, all the activity,
badges, etc. can be filtered by that instance. If there is no
instance_id query param, the activity would be unfiltered.
