### PR TITLE
Refactor settings.js templating to support root pages

### DIFF
--- a/opentreemap/opentreemap/context_processors.py
+++ b/opentreemap/opentreemap/context_processors.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+def global_settings(request):
+    return {'SITE_ROOT':  settings.SITE_ROOT}

--- a/opentreemap/opentreemap/settings.py
+++ b/opentreemap/opentreemap/settings.py
@@ -62,6 +62,9 @@ STATIC_ROOT = ''
 # Example: "http://example.com/static/", "http://static.example.com/"
 STATIC_URL = '/static/'
 
+# Root URL for the application
+SITE_ROOT = '/'
+
 # Additional locations of static files
 STATICFILES_DIRS = (
     # Put strings here, like "/home/html/static" or "C:/www/django/static".
@@ -118,6 +121,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     'django.core.context_processors.tz',
     'django.contrib.messages.context_processors.messages',
     'django.core.context_processors.request',
+    'opentreemap.context_processors.global_settings',
 )
 
 INSTALLED_APPS = (

--- a/opentreemap/opentreemap/urls.py
+++ b/opentreemap/opentreemap/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import patterns, include, url
 from django.conf import settings
 from django.views.generic import RedirectView
 
-from treemap.views import user_view
+from treemap.views import user_view, root_settings_js_view
 
 from django.contrib import admin
 admin.autodiscover()
@@ -16,6 +16,7 @@ urlpatterns = patterns(
     url(r'^', include('geocode.urls')),
     url(r'^(?P<instance_id>\d+)/', include('treemap.urls')),
     url(r'^(?P<instance_id>\d+)/eco/', include('ecobenefits.urls')),
+    url(r'^config/settings.js$', root_settings_js_view),
     url(r'^users/(?P<username>\w+)/', user_view),
     url(r'^api/v2/', include('api.urls')),
     url(r'^accounts/', include('registration_backend.urls')),

--- a/opentreemap/treemap/templates/base.html
+++ b/opentreemap/treemap/templates/base.html
@@ -12,10 +12,17 @@
     {% block content %}
     {% endblock content %}
 
-    {% block base_scripts %}
-      <script src="{{ ROOT_URL }}/{{ request.instance.id }}/config/settings.js"></script>
-      <script src="{{ STATIC_URL }}/js/treemap.js"></script>
-    {% endblock base_scripts %}
+    {% block config_scripts %}
+      {% if request.instance %}
+        <script src="{{ SITE_ROOT }}{{ request.instance.id }}/config/settings.js"></script>
+      {% else %}
+        <script src="{{ SITE_ROOT }}config/settings.js"></script>
+      {% endif %}
+    {% endblock config_scripts %}
+
+    {% block global_scripts %}
+      <script src="{{ STATIC_URL }}js/treemap.js"></script>
+    {% endblock global_scripts %}
 
     {% block scripts %}
     {% endblock scripts %}

--- a/opentreemap/treemap/templates/treemap/settings.js
+++ b/opentreemap/treemap/templates/treemap/settings.js
@@ -6,14 +6,16 @@ otm.settings.urls = {
     'filterQueryArgumentName': 'q'
 }
 
-otm.settings.instance = {
-    'id': '{{ request.instance.id }}',
-    'name': '{{ request.instance.name }}',
-    'rev': '{{ request.instance.geo_rev_hash }}',
-    'center': [{{ request.instance.center.x }}, {{ request.instance.center.y }}],
-    'basemap': {
-        'type': '{{ request.instance.basemap_type }}',
-        'data': '{{ request.instance.basemap_data }}',
-        'bing_api_key': '{{ BING_API_KEY }}'
+{% if request.instance %}
+    otm.settings.instance = {
+        'id': '{{ request.instance.id }}',
+        'name': '{{ request.instance.name }}',
+        'rev': '{{ request.instance.geo_rev_hash }}',
+        'center': [{{ request.instance.center.x }}, {{ request.instance.center.y }}],
+        'basemap': {
+            'type': '{{ request.instance.basemap_type }}',
+            'data': '{{ request.instance.basemap_data }}',
+            'bing_api_key': '{{ BING_API_KEY }}'
+        }
     }
-}
+{% endif %}

--- a/opentreemap/treemap/urls.py
+++ b/opentreemap/treemap/urls.py
@@ -5,7 +5,7 @@ from __future__ import division
 from django.conf.urls import patterns, url
 
 from treemap.views import (boundary_to_geojson_view, index_view, trees_view,
-                           plot_detail_view, settings_js_view, audits_view,
+                           plot_detail_view, instance_settings_js_view, audits_view,
                            search_tree_benefits_view, species_list_view,
                            boundary_autocomplete_view, instance_user_view)
 
@@ -19,7 +19,7 @@ urlpatterns = patterns(
     url(r'^species/$', species_list_view),
     url(r'^trees/$', trees_view),
     url(r'^trees/(?P<plot_id>\d+)/$', plot_detail_view),
-    url(r'^config/settings.js$', settings_js_view),
+    url(r'^config/settings.js$', instance_settings_js_view),
     url(r'^benefit/search$', search_tree_benefits_view),
     url(r'^users/(?P<username>\w+)/', instance_user_view),
 )

--- a/opentreemap/treemap/views.py
+++ b/opentreemap/treemap/views.py
@@ -309,10 +309,14 @@ trees_view = instance_request(
 plot_detail_view = instance_request(etag(_plot_hash)(
     render_template('treemap/plot_detail.html', plot_detail)))
 
-settings_js_view = instance_request(
+root_settings_js_view = render_template('treemap/settings.js',
+                    {'BING_API_KEY': settings.BING_API_KEY},
+                    mimetype='application/javascript')
+
+instance_settings_js_view = instance_request(
     render_template('treemap/settings.js',
                     {'BING_API_KEY': settings.BING_API_KEY},
-                    mimetype='application/x-javascript'))
+                    mimetype='application/javascript'))
 
 
 boundary_to_geojson_view = json_api_call(boundary_to_geojson)


### PR DESCRIPTION
The previous settings.js templating assumed that the URL always contained
an instance ID. Now that we are starting to add 'top-level' pages (e.g.
user page) we need a settings.js template that works without an
instance.

As part of this change I fixed script src urls with double slashes and
added a simple context processor to make the SITE_ROOT setting from
settings.py available to all templates.

I changed mimetypes from application/x-javascript to the now standard
application/javascript (reference: http://stackoverflow.com/a/9664327)
