### PR TITLE
Move jshint options into a separate file

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,10 @@
+{
+    "indent": 4,
+    "globalstrict": true,
+    "browser": true,
+    "globals": {
+        "require": false,
+        "module": true,
+        "exports": true
+    }
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,14 +32,7 @@ module.exports = function(grunt) {
         },
         jshint: {
             options: {
-                indent: 4,
-                globalstrict: true, // Node.js modules are inherently wrapped in functions
-                browser: true,
-                globals: {
-                    require: false,
-                    module: true,
-                    exports: true
-                }
+                jshintrc: "../../.jshintrc"
             },
             treemap: ['../../Gruntfile.js', 'js/src/**/*.js']
         }
@@ -49,6 +42,7 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-jshint');
 
     grunt.file.setBase('opentreemap', 'treemap');
-    grunt.registerTask('default', ['browserify']);
+
     grunt.registerTask('check', ['jshint']);
+    grunt.registerTask('default', ['browserify']);
 };


### PR DESCRIPTION
When jshint is called from the shell it looks for in it's own directory and
then recursively up for a .jshintrc configuration file.

By moving the jshint options into a separate file the config can be shared
by grunt and jshint, so that jshint can be called directly.
