### PR TITLE
Use absolute path in grunt.file.setBase()

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,7 +41,7 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-browserify');
     grunt.loadNpmTasks('grunt-contrib-jshint');
 
-    grunt.file.setBase('opentreemap', 'treemap');
+    grunt.file.setBase('/usr/local/otm/app/opentreemap/treemap');
 
     grunt.registerTask('check', ['jshint']);
     grunt.registerTask('default', ['browserify']);


### PR DESCRIPTION
...so it will work from any folder (and I can run it outside of my Windows share which doesn't support symlinks)
