### PR TITLE
Read UTF grid plot ID key from config

### DIFF
--- a/opentreemap/treemap/js/src/app.js
+++ b/opentreemap/treemap/js/src/app.js
@@ -165,7 +165,7 @@ module.exports = {
 
         var clickedIdStream = utfGridClickControl
             .asEventStream('click')
-            .map('.id');
+            .map('.' + config.utfGrid.plotIdKey);
 
         var popupHtmlStream = clickedIdStream
             .map(truthyOrError) // Prevents making requests if id is undefined

--- a/opentreemap/treemap/templates/treemap/settings.js
+++ b/opentreemap/treemap/templates/treemap/settings.js
@@ -2,6 +2,10 @@
 var otm = otm || {};
 otm.settings = otm.settings || {};
 
+otm.settings.utfGrid = {
+    plotIdKey: 'the_plot_id'
+}
+
 otm.settings.urls = {
     'filterQueryArgumentName': 'q'
 }


### PR DESCRIPTION
The name of the plot id field in the UTF grid changed, so rather than just update it, I moved the field name out to settings.js.
