### PR TITLE
Force tree layer to refresh on filter change

### DIFF
--- a/opentreemap/treemap/js/src/openlayers.layer.otm.js
+++ b/opentreemap/treemap/js/src/openlayers.layer.otm.js
@@ -38,7 +38,7 @@ OL.Layer.OTM = OL.Layer.OTM || OL.Class(OL.Layer.XYZ, {
     clearFilter: function() {
         this.filter = undefined;
         this.url = this.originalUrl;
-        this.redraw();
+        this.redraw({force: true});
     },
 
     setFilter: function(filter) {
@@ -51,7 +51,7 @@ OL.Layer.OTM = OL.Layer.OTM || OL.Class(OL.Layer.XYZ, {
                 filterQueryArgumentName: this.filterQueryArgumentName,
                 uriEncodedFilterObject: uriEncodeFilterObject(filter)
             });
-            this.redraw();
+            this.redraw({force: true});
         }
     }
 });


### PR DESCRIPTION
Without {force: true} the layer was not updating until the map was panned or zoomed.
