### PR TITLE
Add in scalar user defined fields

### DIFF
--- a/opentreemap/treemap/audit.py
+++ b/opentreemap/treemap/audit.py
@@ -86,7 +86,7 @@ def approve_or_reject_audit_and_apply(audit, user, approved):
 
         TheModel = _lkp_model(audit.model)
         obj = TheModel.objects.get(pk=audit.model_id)
-        setattr(obj, audit.field, audit.current_value)
+        obj.apply_change(audit.field, audit.current_value)
 
         # Not sure this is really great here, but we want to
         # bypass all of the safety measures and simply apply
@@ -163,6 +163,8 @@ class UserTrackingException(Exception):
 
 class UserTrackable(object):
     def __init__(self, *args, **kwargs):
+        self._do_not_track = []
+
         super(UserTrackable, self).__init__(*args, **kwargs)
 
         if self.pk is None:
@@ -171,21 +173,25 @@ class UserTrackable(object):
             # "initial" state is empty so we clear it here
             self._previous_state = {}
         else:
-            self._previous_state = self._dict()
+            self._previous_state = self.as_dict()
 
-    def _dict(self):
+    def as_dict(self):
         return model_to_dict(self, fields=[field.name for field in
                                            self._meta.fields])
 
+    def apply_change(self, key, orig_value):
+        setattr(self, key, orig_value)
+
     def _updated_fields(self):
         updated = {}
-        d = self._dict()
+        d = self.as_dict()
         for key in d:
-            old = self._previous_state.get(key, None)
-            new = d.get(key, None)
+            if key not in self._do_not_track:
+                old = self._previous_state.get(key, None)
+                new = d.get(key, None)
 
-            if new != old:
-                updated[key] = [old, new]
+                if new != old:
+                    updated[key] = [old, new]
 
         return updated
 
@@ -199,7 +205,7 @@ class UserTrackable(object):
 
     def save_with_user(self, user, *args, **kwargs):
         self.save_base(self, *args, **kwargs)
-        self._previous_state = self._dict()
+        self._previous_state = self.as_dict()
 
     def save(self, *args, **kwargs):
         raise UserTrackingException(
@@ -267,7 +273,7 @@ class Authorizable(UserTrackable):
     def __init__(self, *args, **kwargs):
         super(Authorizable, self).__init__(*args, **kwargs)
 
-        self._exempt_field_names = {'instance', 'id'}
+        self._exempt_field_names = {'instance', 'id', 'udf_scalar_values'}
         self._has_been_clobbered = False
 
     def _write_perm_comparison_sets(self, user):
@@ -367,7 +373,8 @@ class Authorizable(UserTrackable):
         if self.pk is not None:
             writable_perms, _ = self._write_perm_comparison_sets(user)
             for field in self._updated_fields():
-                if field not in writable_perms:
+                if ((field not in writable_perms and
+                     field not in self._exempt_field_names)):
                     raise AuthorizeException("Can't edit field %s on %s" %
                                             (field, self._model_name))
 
@@ -446,7 +453,7 @@ class Auditable(UserTrackable):
 
                 # Clear changes to object
                 oldval = updates[pending_field][0]
-                setattr(self, pending_field, oldval)
+                self.apply_change(pending_field, oldval)
 
                 # If a field is a "pending field" then it should
                 # be logically removed from the fields that are being

--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -1,5 +1,8 @@
 from django.contrib.gis.db import models
 
+import hashlib
+
+
 class Instance(models.Model):
     """
     Each "Tree Map" is a single instance

--- a/opentreemap/treemap/migrations/0015_auto__add_userdefinedfielddefinition__add_field_tree_udf_scalar_values.py
+++ b/opentreemap/treemap/migrations/0015_auto__add_userdefinedfielddefinition__add_field_tree_udf_scalar_values.py
@@ -1,0 +1,220 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'UserDefinedFieldDefinition'
+        db.create_table(u'treemap_userdefinedfielddefinition', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('instance', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['treemap.Instance'])),
+            ('model_type', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('datatype', self.gf('django.db.models.fields.TextField')()),
+            ('iscollection', self.gf('django.db.models.fields.BooleanField')(default=False)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255)),
+        ))
+        db.send_create_signal(u'treemap', ['UserDefinedFieldDefinition'])
+
+        # Adding field 'Tree.udf_scalar_values'
+        db.add_column(u'treemap_tree', 'udf_scalar_values',
+                      self.gf('treemap.udf.UDFField')(default='', db_index=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Plot.udf_scalar_values'
+        db.add_column(u'treemap_plot', 'udf_scalar_values',
+                      self.gf('treemap.udf.UDFField')(default='', db_index=True, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting model 'UserDefinedFieldDefinition'
+        db.delete_table(u'treemap_userdefinedfielddefinition')
+
+        # Deleting field 'Tree.udf_scalar_values'
+        db.delete_column(u'treemap_tree', 'udf_scalar_values')
+
+        # Deleting field 'Plot.udf_scalar_values'
+        db.delete_column(u'treemap_plot', 'udf_scalar_values')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'treemap.audit': {
+            'Meta': {'object_name': 'Audit'},
+            'action': ('django.db.models.fields.IntegerField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'current_value': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'field': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']", 'null': 'True', 'blank': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'db_index': 'True'}),
+            'model_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'db_index': 'True'}),
+            'previous_value': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'ref_id': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Audit']", 'null': 'True'}),
+            'requires_auth': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'updated': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"})
+        },
+        u'treemap.boundary': {
+            'Meta': {'object_name': 'Boundary'},
+            'category': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'geom': ('django.contrib.gis.db.models.fields.MultiPolygonField', [], {'srid': '3857', 'db_column': "u'the_geom_webmercator'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'sort_order': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.fieldpermission': {
+            'Meta': {'object_name': 'FieldPermission'},
+            'field_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'model_name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'permission_level': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'role': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Role']"})
+        },
+        u'treemap.importevent': {
+            'Meta': {'object_name': 'ImportEvent'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'imported_by': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.User']"}),
+            'imported_on': ('django.db.models.fields.DateField', [], {'auto_now_add': 'True', 'blank': 'True'})
+        },
+        u'treemap.instance': {
+            'Meta': {'object_name': 'Instance'},
+            'basemap_data': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'basemap_type': ('django.db.models.fields.CharField', [], {'default': "'google'", 'max_length': '255'}),
+            'boundaries': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['treemap.Boundary']", 'null': 'True', 'blank': 'True'}),
+            'center': ('django.contrib.gis.db.models.fields.PointField', [], {'srid': '3857'}),
+            'default_role': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'default_role'", 'to': u"orm['treemap.Role']"}),
+            'geo_rev': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'treemap.instancespecies': {
+            'Meta': {'object_name': 'InstanceSpecies'},
+            'common_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'species': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Species']"})
+        },
+        u'treemap.plot': {
+            'Meta': {'object_name': 'Plot'},
+            'address_city': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'address_street': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'address_zip': ('django.db.models.fields.CharField', [], {'max_length': '30', 'null': 'True', 'blank': 'True'}),
+            'geom': ('django.contrib.gis.db.models.fields.PointField', [], {'srid': '3857', 'db_column': "u'the_geom_webmercator'"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'import_event': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.ImportEvent']", 'null': 'True', 'blank': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'length': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'owner_orig_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'readonly': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'udf_scalar_values': ('treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'}),
+            'width': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'treemap.reputationmetric': {
+            'Meta': {'object_name': 'ReputationMetric'},
+            'action': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'approval_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'denial_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'direct_write_score': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']", 'null': 'True', 'blank': 'True'}),
+            'model_name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'treemap.role': {
+            'Meta': {'object_name': 'Role'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'rep_thresh': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'treemap.species': {
+            'Meta': {'object_name': 'Species'},
+            'bloom_period': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'common_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True'}),
+            'cultivar_name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'fact_sheet': ('django.db.models.fields.URLField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'fall_conspicuous': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'flower_conspicuous': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'fruit_period': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'gender': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'genus': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'itree_code': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'max_dbh': ('django.db.models.fields.IntegerField', [], {'default': '200'}),
+            'max_height': ('django.db.models.fields.IntegerField', [], {'default': '800'}),
+            'native_status': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'palatable_human': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'}),
+            'plant_guide': ('django.db.models.fields.URLField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'species': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'blank': 'True'}),
+            'symbol': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'wildlife_value': ('django.db.models.fields.NullBooleanField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'treemap.tree': {
+            'Meta': {'object_name': 'Tree'},
+            'canopy_height': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'date_planted': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'date_removed': ('django.db.models.fields.DateField', [], {'null': 'True', 'blank': 'True'}),
+            'diameter': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'height': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'import_event': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.ImportEvent']", 'null': 'True', 'blank': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'plot': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Plot']"}),
+            'readonly': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'species': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Species']", 'null': 'True', 'blank': 'True'}),
+            'udf_scalar_values': ('treemap.udf.UDFField', [], {'db_index': 'True', 'blank': 'True'})
+        },
+        u'treemap.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'reputation': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'roles': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['treemap.Role']", 'null': 'True', 'blank': 'True'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'treemap.userdefinedfielddefinition': {
+            'Meta': {'object_name': 'UserDefinedFieldDefinition'},
+            'datatype': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'instance': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['treemap.Instance']"}),
+            'iscollection': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'model_type': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        }
+    }
+
+    complete_apps = ['treemap']

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -14,7 +14,7 @@ from treemap.audit import Auditable, Authorizable, FieldPermission, Role
 import hashlib
 import re
 
-from treemap.udf import UserDefinedFieldDefinition, UDFField, UDFModel
+from treemap.udf import UDFModel, GeoHStoreManager
 from treemap.instance import Instance
 
 
@@ -140,7 +140,7 @@ class ImportEvent(models.Model):
 #TODO:
 # Exclusion Zones
 # Proximity validation
-class Plot(Authorizable, Auditable, models.Model):
+class Plot(Authorizable, Auditable, UDFModel):
     instance = models.ForeignKey(Instance)
     geom = models.PointField(srid=3857, db_column='the_geom_webmercator')
 
@@ -155,7 +155,7 @@ class Plot(Authorizable, Auditable, models.Model):
     owner_orig_id = models.CharField(max_length=255, null=True, blank=True)
     readonly = models.BooleanField(default=False)
 
-    objects = models.GeoManager()
+    objects = GeoHStoreManager()
 
     def current_tree(self):
         """
@@ -198,7 +198,7 @@ class Plot(Authorizable, Auditable, models.Model):
         return ', '.join(components)
 
 
-class Tree(Authorizable, Auditable, models.Model):
+class Tree(Authorizable, Auditable, UDFModel):
     """
     Represents a single tree, belonging to an instance
     """
@@ -215,7 +215,7 @@ class Tree(Authorizable, Auditable, models.Model):
     date_planted = models.DateField(null=True, blank=True)
     date_removed = models.DateField(null=True, blank=True)
 
-    objects = models.GeoManager()
+    objects = GeoHStoreManager()
 
     def __unicode__(self):
         diameter_chunk = ("Diameter: %s, " % self.diameter

--- a/opentreemap/treemap/tests/__init__.py
+++ b/opentreemap/treemap/tests/__init__.py
@@ -4,6 +4,7 @@ from __future__ import division
 
 from django.test import TestCase
 from django.test.client import RequestFactory
+from django.conf import settings
 
 from django.contrib.gis.geos import Point, Polygon
 
@@ -85,15 +86,16 @@ def make_god_role(instance):
         ('Tree', 'canopy_height', FieldPermission.WRITE_DIRECTLY),
         ('Tree', 'date_planted', FieldPermission.WRITE_DIRECTLY),
         ('Tree', 'date_removed', FieldPermission.WRITE_DIRECTLY))
+
     return make_loaded_role(instance, 'god', 3, permissions)
 
 
-def make_commander_role(instance):
+def make_commander_role(instance, extra_plot_fields=None):
     """
     The commander role has permission to modify all model fields
     directly for all models under test.
     """
-    permissions = (
+    permissions = [
         ('Plot', 'geom', FieldPermission.WRITE_DIRECTLY),
         ('Plot', 'width', FieldPermission.WRITE_DIRECTLY),
         ('Plot', 'length', FieldPermission.WRITE_DIRECTLY),
@@ -111,7 +113,12 @@ def make_commander_role(instance):
         ('Tree', 'height', FieldPermission.WRITE_DIRECTLY),
         ('Tree', 'canopy_height', FieldPermission.WRITE_DIRECTLY),
         ('Tree', 'date_planted', FieldPermission.WRITE_DIRECTLY),
-        ('Tree', 'date_removed', FieldPermission.WRITE_DIRECTLY))
+        ('Tree', 'date_removed', FieldPermission.WRITE_DIRECTLY)]
+
+    if extra_plot_fields:
+        for field in extra_plot_fields:
+            permissions.append(('Plot', field, FieldPermission.WRITE_DIRECTLY))
+
     return make_loaded_role(instance, 'commander', 3, permissions)
 
 
@@ -186,7 +193,7 @@ def create_mock_system_user():
         system_user = User.objects.get(username="system_user")
     except Exception:
         system_user = User(username="system_user")
-        system_user.save_base()
+        system_user.id = settings.SYSTEM_USER_ID
 
     User._system_user = system_user
 
@@ -226,6 +233,7 @@ class RequestTestCase(TestCase):
 
 create_mock_system_user()
 
+from udfs import *    # NOQA
 from audit import *   # NOQA
 from auth import *    # NOQA
 from models import *  # NOQA

--- a/opentreemap/treemap/tests/udfs.py
+++ b/opentreemap/treemap/tests/udfs.py
@@ -1,0 +1,326 @@
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+import json
+from datetime import datetime
+
+from django.test import TestCase
+from django.db import connection
+from django.core.exceptions import ValidationError
+
+from django.contrib.gis.geos import Point
+
+from treemap.tests import make_instance, make_commander_role
+
+from treemap.udf import UserDefinedFieldDefinition
+from treemap.models import User, Plot
+from treemap.audit import (AuthorizeException, FieldPermission,
+                           approve_or_reject_audit_and_apply)
+
+import psycopg2
+
+
+class ScalarUDFAuditTest(TestCase):
+    def setUp(self):
+        self.instance = make_instance()
+        self.commander_user = User(username='commander', password='pw')
+        self.commander_user.save()
+        self.commander_user.roles.add(
+            make_commander_role(self.instance,
+                                extra_plot_fields=['Test choice']))
+
+        self.p = Point(-8515941.0, 4953519.0)
+
+        UserDefinedFieldDefinition.objects.create(
+            instance=self.instance,
+            model_type='Plot',
+            datatype=json.dumps({'type': 'choice',
+                                 'choices': ['a', 'b', 'c']}),
+            iscollection=False,
+            name='Test choice')
+
+        UserDefinedFieldDefinition.objects.create(
+            instance=self.instance,
+            model_type='Plot',
+            datatype=json.dumps({'type': 'string'}),
+            iscollection=False,
+            name='Test unauth')
+
+        self.plot = Plot(geom=self.p, instance=self.instance)
+        self.plot.save_with_user(self.commander_user)
+
+        psycopg2.extras.register_hstore(connection.cursor(), globally=True)
+
+    def test_update_field_creates_audit(self):
+        self.plot.udf_scalar_values['Test choice'] = 'b'
+        self.plot.save_with_user(self.commander_user)
+
+        last_audit = list(self.plot.audits())[-1]
+
+        self.assertEqual(last_audit.model, 'Plot')
+        self.assertEqual(last_audit.model_id, self.plot.pk)
+        self.assertEqual(last_audit.field, 'Test choice')
+        self.assertEqual(last_audit.previous_value, None)
+        self.assertEqual(last_audit.current_value, 'b')
+
+        self.plot.udf_scalar_values['Test choice'] = 'c'
+        self.plot.save_with_user(self.commander_user)
+
+        last_audit = list(self.plot.audits())[-1]
+
+        self.assertEqual(last_audit.model, 'Plot')
+        self.assertEqual(last_audit.model_id, self.plot.pk)
+        self.assertEqual(last_audit.field, 'Test choice')
+        self.assertEqual(last_audit.previous_value, 'b')
+        self.assertEqual(last_audit.current_value, 'c')
+
+    def test_cant_edit_unathorized_field(self):
+        self.plot.udf_scalar_values['Test unauth'] = 'c'
+        self.assertRaises(AuthorizeException,
+                          self.plot.save_with_user, self.commander_user)
+
+        self.commander_user.roles = [
+            make_commander_role(self.instance,
+                                extra_plot_fields=['Test unauth'])]
+
+        self.plot.udf_scalar_values['Test unauth'] = 'c'
+        self.plot.save_with_user(self.commander_user)
+
+    def test_create_and_apply_pending(self):
+        pending = self.plot.audits().filter(requires_auth=True)
+
+        self.assertEqual(len(pending), 0)
+
+        role = self.commander_user.roles.all()[0]
+        fp, _ = FieldPermission.objects.get_or_create(
+            model_name='Plot', field_name='Test unauth',
+            permission_level=FieldPermission.WRITE_WITH_AUDIT,
+            role=role, instance=self.instance)
+
+        self.plot.udf_scalar_values['Test unauth'] = 'c'
+        self.plot.save_with_user(self.commander_user)
+
+        reloaded_plot = Plot.objects.get(pk=self.plot.pk)
+
+        self.assertEqual(
+            reloaded_plot.udf_scalar_values['Test unauth'],
+            None)
+
+        pending = self.plot.audits().filter(requires_auth=True)
+
+        self.assertEqual(len(pending), 1)
+
+        fp.permission_level = FieldPermission.WRITE_DIRECTLY
+        fp.save()
+
+        approve_or_reject_audit_and_apply(pending[0],
+                                          self.commander_user,
+                                          True)
+
+        reloaded_plot = Plot.objects.get(pk=self.plot.pk)
+
+        self.assertEqual(
+            reloaded_plot.udf_scalar_values['Test unauth'],
+            'c')
+
+
+class ScalarUDFDefTest(TestCase):
+
+    def setUp(self):
+        self.instance = make_instance()
+
+    def _create_and_save_with_datatype(
+            self, d, model_type='Plot', name='Blah'):
+        return UserDefinedFieldDefinition.objects.create(
+            instance=self.instance,
+            model_type=model_type,
+            datatype=json.dumps(d),
+            iscollection=False,
+            name=name)
+
+    def test_cannot_create_datatype_with_invalid_model(self):
+        self.assertRaises(
+            ValidationError,
+            self._create_and_save_with_datatype,
+            {'type': 'string'},
+            model_type='InvalidModel')
+
+    def test_cannot_create_datatype_with_nonudf(self):
+        self.assertRaises(
+            ValidationError,
+            self._create_and_save_with_datatype,
+            {'type': 'string'},
+            model_type='Species')
+
+    def test_cannot_create_duplicate_udfs(self):
+        self._create_and_save_with_datatype(
+            {'type': 'string'},
+            name='random')
+
+        self.assertRaises(
+            ValidationError,
+            self._create_and_save_with_datatype,
+            {'type': 'string'},
+            name='random')
+
+        self._create_and_save_with_datatype(
+            {'type': 'string'},
+            name='random2')
+
+    def test_cannot_create_datatype_with_existing_field(self):
+        self.assertRaises(
+            ValidationError,
+            self._create_and_save_with_datatype,
+            {'type': 'string'},
+            name='width')
+
+        self.assertRaises(
+            ValidationError,
+            self._create_and_save_with_datatype,
+            {'type': 'string'},
+            name='id')
+
+        self._create_and_save_with_datatype(
+            {'type': 'string'},
+            name='random')
+
+    def test_must_have_type_key(self):
+        self.assertRaises(
+            ValidationError,
+            self._create_and_save_with_datatype, {})
+
+    def test_invalid_type(self):
+        self.assertRaises(
+            ValidationError,
+            self._create_and_save_with_datatype, {'type': 'woohoo'})
+
+        self._create_and_save_with_datatype({'type': 'float'})
+
+    def test_description_op(self):
+        self._create_and_save_with_datatype(
+            {'type': 'float',
+             'description': 'this is a float field'})
+
+    def test_choices_not_empty_or_missing(self):
+        self.assertRaises(
+            ValidationError,
+            self._create_and_save_with_datatype,
+            {'type': 'choice'})
+
+        self.assertRaises(
+            ValidationError,
+            self._create_and_save_with_datatype,
+            {'type': 'choice',
+             'choices': []})
+
+        self._create_and_save_with_datatype(
+            {'type': 'choice',
+             'choices': ['a choice', 'another']})
+
+
+class ScalarUDFTest(TestCase):
+
+    def setUp(self):
+        self.instance = make_instance()
+        self.p = Point(-8515941.0, 4953519.0)
+
+        def make_and_save_type(dtype):
+            UserDefinedFieldDefinition.objects.create(
+                instance=self.instance,
+                model_type='Plot',
+                datatype=json.dumps({'type': dtype}),
+                iscollection=False,
+                name='Test %s' % dtype)
+
+        allowed_types = 'float', 'int', 'string', 'user', 'date'
+
+        addl_fields = ['Test %s' % ttype for ttype in allowed_types]
+        addl_fields.append('Test choice')
+
+        self.commander_user = User(username='commander', password='pw')
+        self.commander_user.save()
+        self.commander_user.roles.add(
+            make_commander_role(self.instance, extra_plot_fields=addl_fields))
+
+        for dtype in allowed_types:
+            make_and_save_type(dtype)
+
+        UserDefinedFieldDefinition.objects.create(
+            instance=self.instance,
+            model_type='Plot',
+            datatype=json.dumps({'type': 'choice',
+                                 'choices': ['a', 'b', 'c']}),
+            iscollection=False,
+            name='Test choice')
+
+        self.plot = Plot(geom=self.p, instance=self.instance)
+        self.plot.save_with_user(self.commander_user)
+
+        psycopg2.extras.register_hstore(connection.cursor(), globally=True)
+
+    def _test_datatype(self, field, value):
+        self.plot.udf_scalar_values[field] = value
+        self.plot.save_with_user(self.commander_user)
+
+        self.plot = Plot.objects.get(pk=self.plot.pk)
+
+        self.assertEqual(
+            self.plot.udf_scalar_values[field], value)
+
+    def test_int_datatype(self):
+        self._test_datatype('Test int', 4)
+
+    def test_int_validation_non_integer(self):
+        self.assertRaises(ValidationError,
+                          self._test_datatype, 'Test int', 42.3)
+
+        self.assertRaises(ValidationError,
+                          self._test_datatype, 'Test int', 'blah')
+
+    def test_float_datatype(self):
+        self._test_datatype('Test float', 4.4)
+
+    def test_float_validation(self):
+        self.assertRaises(ValidationError,
+                          self._test_datatype, 'Test float', 'blah')
+
+    def test_choice_datatype(self):
+        self._test_datatype('Test choice', 'a')
+
+    def test_choice_validation(self):
+        self.assertRaises(ValidationError,
+                          self._test_datatype, 'Test choice', 'bad choice')
+
+    def test_user_datatype(self):
+        self._test_datatype('Test user', self.commander_user)
+
+    def test_date_datatype(self):
+        d = datetime.now().replace(microsecond=0)
+
+        self._test_datatype('Test date', d)
+
+    def test_string_datatype(self):
+        self._test_datatype('Test string', 'Sweet Plot')
+
+    def test_user_validation_invalid_id(self):
+        self.assertRaises(ValidationError,
+                          self._test_datatype, 'Test user', 349949)
+
+    def test_user_validation_non_integer(self):
+        self.assertRaises(ValidationError,
+                          self._test_datatype, 'Test user', 'zztop')
+
+    def test_in_operator(self):
+        self.assertEqual('Test string' in self.plot.udf_scalar_values,
+                         True)
+        self.assertEqual('RanDoM NAme' in self.plot.udf_scalar_values,
+                         False)
+
+    def test_returns_none_for_empty_but_valid_udfs(self):
+        self.assertEqual(self.plot.udf_scalar_values['Test string'],
+                         None)
+
+    def test_raises_keyerror_for_invalid_udf(self):
+        self.assertRaises(KeyError,
+                          lambda: self.plot.udf_scalar_values['RaNdoName'])

--- a/opentreemap/treemap/udf.py
+++ b/opentreemap/treemap/udf.py
@@ -1,0 +1,310 @@
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+import json
+from datetime import datetime
+
+from django.core.exceptions import ValidationError
+from django.utils.translation import ugettext_lazy as _
+
+from django.contrib.gis.db import models
+
+from djorm_hstore.fields import DictionaryField, HStoreDictionary
+from djorm_hstore.models import HStoreManager, HStoreQueryset
+
+from treemap.instance import Instance
+from treemap.audit import UserTrackable
+
+
+class UserDefinedFieldDefinition(models.Model):
+    """
+    These models represent user defined fields that are attached to
+    specific model types. For instance, if a user wanted to record
+    a planting date for a tree she should create a UDFD to support
+    that.
+    """
+
+    """
+    The instance that this field is bound to
+    """
+    instance = models.ForeignKey(Instance)
+
+    """
+    The type of model that this should bind to
+    """
+    model_type = models.CharField(max_length=255)
+
+    """
+    Datatype is a json string. It must be an array of dictionary
+    objects if 'ismulti' is true, or a single dictionary otherwise.
+    Each dictionary object has the following required keys:
+
+    'type' - Field type (float, int, string, user, choice, date)
+
+    All types allow a 'description' key:
+
+    'description' - A text description of the field
+
+    In addition, if the 'type' is 'choice' a 'choices' key is
+    required:
+
+    'choices' - An array of choice options
+    """
+    datatype = models.TextField()
+
+    """
+    If this is set to True the UDFD represents a 'Collection' of data,
+    if set to False the UDFD represents a scalar value
+
+    Depending on this flag, the values for the UDFD will either live
+    on the model or in a collections value table
+    """
+    iscollection = models.BooleanField()
+
+    """
+    Name of the UDFD
+    """
+    name = models.CharField(max_length=255)
+
+    def validate(self):
+        model_type = self.model_type
+
+        # All of our models live in 'treemap.models', so
+        # we can start with that namespace
+        models_module = __import__('treemap.models')
+
+        if not hasattr(models_module.models, model_type):
+            raise ValidationError(_('invalid model type'))
+
+        model_class = getattr(models_module.models, model_type)
+
+        # It must have be a UDF subclass
+        if not isinstance(model_class(), UDFModel):
+            raise ValidationError(_('invalid model type - must subclass '
+                                    'UDFModel'))
+
+        field_names = [field.name for field in model_class._meta.fields]
+
+        if self.name in field_names:
+            raise ValidationError(_('cannot use fields that already '
+                                    'exist on the model'))
+
+        existing_objects = UserDefinedFieldDefinition.objects.filter(
+            model_type=model_type,
+            name=self.name)
+
+        if existing_objects.count() != 0:
+            raise ValidationError(_('a field already exists on this model '
+                                    'with that name'))
+
+        datatype = self.datatype_dict
+
+        if 'type' not in datatype:
+            raise ValidationError(_('type required data type definition'))
+
+        if datatype['type'] not in ['float', 'int', 'string',
+                                    'user', 'choice', 'date']:
+            raise ValidationError(_('invalid datatype'))
+
+        if datatype['type'] == 'choice':
+            choices = datatype.get('choices', None)
+
+            if choices is None:
+                raise ValidationError(_('missing choices key for key'))
+
+            if len(choices) == 0:
+                raise ValidationError(_('empty choice list'))
+
+    def save(self, *args, **kwargs):
+        self.validate()
+        super(UserDefinedFieldDefinition, self).save(*args, **kwargs)
+
+    @property
+    def datatype_dict(self):
+        return json.loads(self.datatype)
+
+    def from_string_to_python(self, value):
+        """
+        Given a value for this data type, validate and return the
+        correct python/django representation.
+
+        For instance, this is a 'user' field this function will take
+        in a user id (as a string) from the UDF dictionary and return
+        a 'User' object.
+
+        If that user doesn't exist a ValidationError will be raised
+        """
+        from treemap.models import User  # Circular ref issue
+
+        if self.datatype_dict['type'] == 'float':
+            try:
+                return float(value)
+            except ValueError:
+                raise ValidationError(_('%(fieldname)s '
+                                        'must be a real number') %
+                                      {'fieldname': self.name})
+        elif self.datatype_dict['type'] == 'int':
+            try:
+                return int(value)
+            except ValueError:
+                raise ValidationError(_('%(fieldname)s '
+                                        'must be an integer') %
+                                      {'fieldname': self.name})
+        elif self.datatype_dict['type'] == 'user':
+            return User.objects.get(pk=value)
+        elif self.datatype_dict['type'] == 'date':
+            return datetime.strptime(value, '%Y%m%d%H%M%S')
+        elif self.datatype_dict['type'] == 'choice':
+            if value in self.datatype_dict['choices']:
+                return value
+            else:
+                raise ValidationError(_('Invalid choice'))
+        else:
+            return value
+
+    def from_python_to_string(self, value):
+        """
+        Given a value for this data type, return a string representation
+        to be stored in the hstore.
+        """
+        from treemap.models import User  # Circular ref issue
+
+        # We only support scalar UDFs right now
+        # so we can just grab the first one
+        if self.datatype_dict['type'] == 'user':
+            if isinstance(value, User):
+                return str(value.pk)
+            else:
+                raise ValidationError(_('Expected a User object'))
+        elif self.datatype_dict['type'] == 'date':
+            return value.strftime('%Y%m%d%H%M%S')
+        else:
+            return str(value)
+
+
+class UDFDictionary(HStoreDictionary):
+
+    def __init__(self, value, field, obj, *args, **kwargs):
+        super(UDFDictionary, self).__init__(value, field, *args, **kwargs)
+        self.model = field.model
+        self.instance = obj
+
+        self._fields = None
+
+    @property
+    def fields(self):
+        # Django loads fields in the order they're defined on a given
+        # class. For instance,
+        #
+        # class A(models.Model):
+        #   a = models.IntField()
+        #   b = models.IntField()
+        #
+        # Will first load 'a', create the attribute dictionary, add it
+        # to the object and continue.
+        #
+        # Since UDFModel specifies the UDFField first, no other fields
+        # are available on the subclassed object (Plot, Tree, etc) in
+        # the constructor
+        #
+        # The solution is to simply cache the instance and grab the data
+        # in a lazy way
+        if self._fields is None:
+            self._fields = self.instance.get_user_defined_fields()
+
+        return self._fields
+
+    def _get_udf_or_error(self, key):
+        for field in self.fields:
+            if field.name == key:
+                return field
+
+        raise KeyError("Couldn't find UDF for field '%s'" % key)
+
+    def __contains__(self, key):
+        return key in [field.name for field in self.fields]
+
+    def __getitem__(self, key):
+        udf = self._get_udf_or_error(key)
+        if super(UDFDictionary, self).__contains__(key):
+            return udf.from_string_to_python(
+                super(UDFDictionary, self).__getitem__(key))
+        else:
+            return None
+
+    def __setitem__(self, key, val):
+        udf = self._get_udf_or_error(key)
+        val = udf.from_python_to_string(val)
+        super(UDFDictionary, self).__setitem__(key, val)
+
+    def raw_items(self):
+        "Get iterable string key, values"
+        return super(UDFDictionary, self).iteritems()
+
+    def set_raw(self, key, val):
+        "Set a key to a string value without conversion"
+        super(UDFDictionary, self).__setitem__(key, val)
+
+
+class UDFField(DictionaryField):
+
+    _attribute_class = UDFDictionary
+
+    # Overriden because we do our own string transformations
+    # directly via the UDFDictionary
+    def get_prep_value(self, data):
+        return data
+
+
+from south.modelsinspector import add_introspection_rules
+add_introspection_rules([], ["^treemap\.udf\.UDFField"])
+
+
+class UDFModel(UserTrackable, models.Model):
+    """
+    Classes that extend this model gain support for scalar UDF
+    fields via the `udf_scalar_values` field.
+
+    This model works correctly with the Auditable and
+    Authorizable mixins
+    """
+
+    udf_scalar_values = UDFField(db_index=True, blank=True)
+
+    class Meta:
+        abstract = True
+
+    def __init__(self, *args, **kwargs):
+        super(UDFModel, self).__init__(*args, **kwargs)
+
+        self._do_not_track = ['udf_scalar_values']
+
+    def get_user_defined_fields(self):
+        return UserDefinedFieldDefinition.objects.filter(
+            instance=self.instance,
+            model_type=self._model_name)
+
+    def apply_change(self, key, oldval):
+        if key in [field.name for field in self.get_user_defined_fields()]:
+            self.udf_scalar_values.set_raw(key, oldval)
+        else:
+            super(UDFModel, self).apply_change(key, oldval)
+
+    def as_dict(self, *args, **kwargs):
+        base_model_dict = super(UDFModel, self).as_dict(*args, **kwargs)
+
+        for (name, val) in self.udf_scalar_values.raw_items():
+            base_model_dict[name] = val
+
+        return base_model_dict
+
+
+class GeoHStoreQuerySet(models.query.GeoQuerySet, HStoreQueryset):
+    pass
+
+
+class GeoHStoreManager(models.GeoManager, HStoreManager):
+
+    def get_query_set(self):
+        return GeoHStoreQuerySet(self.model, using=self._db)


### PR DESCRIPTION
Scalar user defined fields can be added to any model by using a parent
class of: UDFModel (from treemap.udf).

UDFModel provides the `udf_scalar_values` field. This field allows udfs
defined using a `UserDefinedFieldDefinition` to be accessed using
standard python square-bracket syntax.

For example, if we have a `UserDefinedFieldDefinition` defined like:

```
datatype = [{'type': 'int'}]
name = 'Plot Age'
```

We can update the field using:

```
p = Plot.objects.get(pk=4)
old_age = p.udf_scalar_values['Plot Age']

p.udf_scalar_values['Plot Age'] = 4
p.save_with_user(some_user)
```

Scalar UDFs interop directly with the audit and authorizable system. In
the above example the user (`some_user`) must have `WRITE_DIRECTLY` or
`WRITE_WITH_AUDIT` privileges on 'Plot.Plot Age'.

Since this uses postgres's hstore feature we need to update our build
tools to install it:

```
bash> sudo apt-get install postgresql-contrib
psql> CREATE EXTENSION hstore;
```
