### PR TITLE
Remove color from grunt when run through the fabric file

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -110,7 +110,7 @@ def check():
 def bundle():
     """ Update npm and bundle javascript """
     local('npm install')
-    local('grunt')
+    local('grunt --no-color')
 
 def static():
     """ Collect static files and bundle javascript. """


### PR DESCRIPTION
Color in grunt's output is nice, but weird color codes in the build failure emails are not...
