### PR TITLE
Update search to work on all pages that extend base

### DIFF
--- a/opentreemap/treemap/js/src/search.js
+++ b/opentreemap/treemap/js/src/search.js
@@ -19,7 +19,28 @@ var config,
               { 'key': 'tree.diameter',
                 'pred': 'MAX' }};
 
-function buildSearch(stream) {
+function executeSearch(search_query) {
+    var search = $.ajax({
+        url: '/' + config.instance.id + '/benefit/search',
+        data: {'q': search_query && Object.keys(search_query).length > 0 ?
+                JSON.stringify(search_query) :
+                ''},
+        type: 'GET',
+        dataType: 'html'
+    });
+
+    return Bacon.fromPromise(search);
+}
+
+function updateSearchResults(newMarkup) {
+    var $new = $(newMarkup),
+        countsMarkup = $new.filter('#tree-and-planting-site-counts').html(),
+        benefitsMarkup = $new.filter('#benefit-values').html();
+    $('#tree-and-planting-site-counts').html(countsMarkup);
+    $('#benefit-values').html(benefitsMarkup);
+}
+
+exports.buildSearch = function (stream) {
     return _.reduce(elems, function(preds, key_and_pred, id) {
         var val = $(id).val(),
             pred = {};
@@ -38,28 +59,7 @@ function buildSearch(stream) {
 
         return preds;
     }, {});
-}
-
-function executeSearch(search_query) {
-    var search = $.ajax({
-        url: '/' + config.instance.id + '/benefit/search',
-        data: {'q': search_query && Object.keys(search_query).length > 0 ? 
-                JSON.stringify(search_query) :
-                ''},
-        type: 'GET',
-        dataType: 'html'
-    });
-
-    return Bacon.fromPromise(search);
-}
-
-function updateSearchResults(newMarkup) {
-    var $new = $(newMarkup),
-        countsMarkup = $new.filter('#tree-and-planting-site-counts').html(),
-        benefitsMarkup = $new.filter('#benefit-values').html();
-    $('#tree-and-planting-site-counts').html(countsMarkup);
-    $('#benefit-values').html(benefitsMarkup);
-}
+};
 
 // Arguments
 //
@@ -72,7 +72,7 @@ function updateSearchResults(newMarkup) {
 // applyFilter: Function to call when filter changes.
 exports.init = function(triggerEventStream, otmConfig, applyFilter) {
     config = otmConfig;
-    var searchStream = triggerEventStream.map(buildSearch);
+    var searchStream = triggerEventStream.map(exports.buildSearch);
 
     searchStream.onValue(applyFilter);
 

--- a/opentreemap/treemap/templates/base.html
+++ b/opentreemap/treemap/templates/base.html
@@ -141,7 +141,28 @@
     {% endblock global_scripts %}
 
     {% block scripts %}
+    <script type="text/javascript">
+      (function(require) {
+        var $ = require("jquery"),
+        app = require("app");
+
+        $(function(){
+          app.init(otm.settings);
+        })
+      })(require);
+    </script>
     {% endblock scripts %}
+
+    {% verbatim %}
+    <script id="species-element-template" type="text/x-mustache-template">
+      <p>{{common_name}}</p>
+      <p>{{scientific_name}}</p>
+    </script>
+    <script id="boundary-element-template" type="text/x-mustache-template">
+      <p>{{name}}</p>
+      <p>{{category}}</p>
+    </script>
+    {% endverbatim %}
 
     {% block templates %}
     {% endblock templates %}

--- a/opentreemap/treemap/templates/treemap/map.html
+++ b/opentreemap/treemap/templates/treemap/map.html
@@ -14,7 +14,7 @@
         app = require("app");
 
     $(function(){
-        app.init(otm.settings);
+        app.initMapPage(otm.settings);
     })
 })(require);
 </script>
@@ -68,14 +68,4 @@
 
 
 {% block templates %}
-{% verbatim %}
-<script id="species-element-template" type="text/x-mustache-template">
-  <p>{{common_name}}</p>
-  <p>{{scientific_name}}</p>
-</script>
-<script id="boundary-element-template" type="text/x-mustache-template">
-  <p>{{name}}</p>
-  <p>{{category}}</p>
-</script>
-{% endverbatim %}
 {% endblock templates %}


### PR DESCRIPTION
In particular, pages that call init will get the dropdowns initialized
and any searching will redirect to the search page.

The map page overrides that javascript init functions to provide custom
mapping and searching.
