### PR TITLE
Add tests for last instance session. Fixes #214.

### DIFF
--- a/opentreemap/treemap/tests/__init__.py
+++ b/opentreemap/treemap/tests/__init__.py
@@ -9,6 +9,10 @@ from django.conf import settings
 from django.contrib.gis.geos import Point, Polygon
 from django.contrib.auth.models import AnonymousUser
 
+from django.template import Template, RequestContext
+from django.http import HttpResponse
+from django.conf.urls import patterns
+
 from treemap.models import User, InstanceUser
 
 
@@ -237,6 +241,27 @@ class ViewTestCase(TestCase):
         setattr(req, 'user', user)
 
         return req
+
+    def _add_global_url(self, url, view_fn):
+        """
+        Insert a new url into treemap for Client resolution
+        """
+        from opentreemap import urls
+        urls.urlpatterns += patterns(
+            '', (url, view_fn))
+
+    def _mock_request_with_template_string(self, template):
+        """
+        Create a new request that renders the given template
+        with a normal request context
+        """
+        def mock_request(request):
+            r = RequestContext(request)
+            tpl = Template(template)
+
+            return HttpResponse(tpl.render(r))
+
+        return mock_request
 
     def setUp(self):
         self.factory = RequestFactory()


### PR DESCRIPTION
Commits f69ff5f and 832382f didn't add end-to-end test coverage for this
feature. This commit simulates a user experience via the django testing
client.

It also provides a couple of helpers methods for synthesizing urls while
testing.
