### PR TITLE
Add middleware to redirect old IE versions

### DIFF
--- a/opentreemap/opentreemap/middleware.py
+++ b/opentreemap/opentreemap/middleware.py
@@ -1,0 +1,49 @@
+import re
+from django.http import HttpResponseRedirect
+from django.conf import settings
+
+import logging
+logger = logging.getLogger(__name__)
+
+_ie_version_regex = re.compile(r'MSIE\s+([\d]+)')
+
+
+# Reference: http://djangosnippets.org/snippets/510/
+# Reference: http://djangosnippets.org/snippets/1147/
+class InternetExplorerRedirectMiddleware:
+    """
+    Sets `from_ie` and `ie_version` on the request. If the `ie_version` is
+    less than `settings.IE_VERSION_MINIMUM` the response redirects to
+    `settings.IE_VERSION_UNSUPPORTED_REDIRECT_PATH`
+    """
+
+    def _parse_major_ie_version_from_user_agent(self, user_agent):
+        search_result = _ie_version_regex.search(user_agent)
+        if search_result:
+            return int(search_result.groups()[0])
+        else:
+            return None
+
+    def process_request(self, request):
+        if not hasattr(settings, 'IE_VERSION_MINIMUM'):
+            logger.warning('InternetExplorerRedirectMiddleware is loaded '
+                           'but IE_VERSION_MINIMUM was not found in settings.')
+            return None
+
+        if not hasattr(settings, 'IE_VERSION_UNSUPPORTED_REDIRECT_PATH'):
+            logger.warning('InternetExplorerRedirectMiddleware is loaded '
+                           'but IE_VERSION_UNSUPPORTED_REDIRECT_PATH was '
+                           'not found in settings.')
+            return None
+
+        request.ie_version = self._parse_major_ie_version_from_user_agent(
+            request.META['HTTP_USER_AGENT'])
+        if request.ie_version is not None:
+            request.from_ie = True
+            if request.ie_version < settings.IE_VERSION_MINIMUM:
+                path = request.META['PATH_INFO']
+                redirect_path = settings.IE_VERSION_UNSUPPORTED_REDIRECT_PATH
+                if path != redirect_path:
+                    return HttpResponseRedirect(redirect_path)
+        else:
+            request.from_ie = False

--- a/opentreemap/opentreemap/settings.py
+++ b/opentreemap/opentreemap/settings.py
@@ -25,6 +25,10 @@ OMGEO_SETTINGS = [[
     'omgeo.services.EsriWGS', {}
 ]]
 
+IE_VERSION_MINIMUM = 9
+
+IE_VERSION_UNSUPPORTED_REDIRECT_PATH = '/unsupported'
+
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.
@@ -102,6 +106,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
+    'opentreemap.middleware.InternetExplorerRedirectMiddleware',
     # Uncomment the next line for simple clickjacking protection:
     # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )

--- a/opentreemap/opentreemap/urls.py
+++ b/opentreemap/opentreemap/urls.py
@@ -6,7 +6,8 @@ from opentreemap.util import route
 
 from treemap.views import (user_view, root_settings_js_view,
                            profile_to_user_view, user_audits_view,
-                           instance_not_available_view, update_user_view)
+                           instance_not_available_view, update_user_view,
+                           unsupported_view)
 
 from django.contrib import admin
 admin.autodiscover()
@@ -48,6 +49,8 @@ urlpatterns = patterns(
         js_i18n_info_dict),
     url(r'^not-available$', instance_not_available_view,
         name='instance_not_available'),
+    url(r'^unsupported$', unsupported_view,
+        name='unsupported'),
 )
 
 if settings.EXTRA_URLS:

--- a/opentreemap/treemap/templates/treemap/unsupported.html
+++ b/opentreemap/treemap/templates/treemap/unsupported.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block search %}
+{% comment %} Hide search options when the browser is unsupported {% endcomment %}
+{% endblock search %}
+
+{% block subhead %}
+{% comment %} Hide subhead when the browser is unsupported {% endcomment %}
+{% endblock subhead %}
+
+{% block content %}
+<h3>{% trans "Sorry. OpenTreeMap requires Internet Explorer 9 or above." %}</h3>
+
+<p>{% trans "If you cannot upgrade your version of Internet Explorer, try using one of these alternate web browsers." %}</p>
+
+<ul>
+    <li><a href="http://www.google.com/chrome">Chrome</a></li>
+    <li><a href="http://www.mozilla.org/firefox">Firefox</a></li>
+</ul>
+{% endblock content %}
+
+{% block scripts %}
+{% comment %} This page has no interactivity {% endcomment %}
+{% endblock scripts %}

--- a/opentreemap/treemap/tests/__init__.py
+++ b/opentreemap/treemap/tests/__init__.py
@@ -321,4 +321,5 @@ from models import *        # NOQA
 from search import *        # NOQA
 from urls import *          # NOQA
 from views import *         # NOQA
-from util import *         # NOQA
+from util import *          # NOQA
+from middleware import *    # NOQA

--- a/opentreemap/treemap/tests/middleware.py
+++ b/opentreemap/treemap/tests/middleware.py
@@ -1,0 +1,76 @@
+from django.test import TestCase
+from django.conf import settings
+from django.http import HttpResponseRedirect
+from opentreemap.middleware import InternetExplorerRedirectMiddleware
+
+
+class USER_AGENT_STRINGS:
+    IE_6 = 'Mozilla/5.0 (compatible; MSIE 6.0; Windows NT 5.1)'
+    IE_7 = 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)'
+    IE_8 = 'Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 6.0)'
+    IE_9 = 'Mozilla/5.0 (Windows; U; MSIE 9.0; Windows NT 9.0)'
+    FIREFOX_22 = 'Mozilla/5.0 (Windows NT 6.1; Win64; x64; ' +\
+                 'rv:22.0) Gecko/20130328 Firefox/22.0'
+
+
+class MockRequest():
+    def __init__(self, http_user_agent=None, path_info='/'):
+        self.META = {
+            'HTTP_USER_AGENT': http_user_agent,
+            'PATH_INFO': path_info
+        }
+
+
+class InternetExplorerRedirectMiddlewareTests(TestCase):
+
+    def _request_with_agent(self, http_user_agent):
+        req = MockRequest(http_user_agent)
+        res = InternetExplorerRedirectMiddleware().process_request(req)
+        return req, res
+
+    def _assert_redirects(self, response, expected_url):
+        self.assertTrue(isinstance(response, HttpResponseRedirect))
+        self.assertEquals(expected_url, response["Location"])
+
+    def test_detects_ie(self):
+        req, _ = self._request_with_agent(USER_AGENT_STRINGS.IE_7)
+        self.assertTrue(req.from_ie,
+                        'Expected the middleware to set "from_ie" '
+                        'to True for an IE connection string')
+
+    def test_does_not_detect_ie(self):
+        req, _ = self._request_with_agent(USER_AGENT_STRINGS.FIREFOX_22)
+        self.assertFalse(req.from_ie,
+                         'Expected the middleware to set "from_ie" '
+                         'to False for a Firefox user agent string')
+        self.assertIsNone(req.ie_version,
+                          'Expected the middleware to set "ie_version" '
+                          'to None')
+
+    def test_sets_version_and_does_not_redirect_for_ie_9(self):
+        req, res = self._request_with_agent(USER_AGENT_STRINGS.IE_9)
+        self.assertIsNone(res, 'Expected the middleware to return a None '
+                          'response (no redirect) for IE 9')
+        self.assertEquals(9, req.ie_version, 'Expected the middleware to '
+                          'set "ie_version" to 9')
+
+    def test_sets_version_and_redirects_ie_8(self):
+        req, res = self._request_with_agent(USER_AGENT_STRINGS.IE_8)
+        self._assert_redirects(res,
+                               settings.IE_VERSION_UNSUPPORTED_REDIRECT_PATH)
+        self.assertEquals(8, req.ie_version, 'Expected the middleware to set '
+                          '"ie_version" to 8')
+
+    def test_sets_version_and_redirects_ie_7(self):
+        req, res = self._request_with_agent(USER_AGENT_STRINGS.IE_7)
+        self._assert_redirects(res,
+                               settings.IE_VERSION_UNSUPPORTED_REDIRECT_PATH)
+        self.assertEquals(7, req.ie_version, 'Expected the middleware to set '
+                          '"ie_version" to 7')
+
+    def test_sets_version_and_redirects_ie_6(self):
+        req, res = self._request_with_agent(USER_AGENT_STRINGS.IE_6)
+        self._assert_redirects(res,
+                               settings.IE_VERSION_UNSUPPORTED_REDIRECT_PATH)
+        self.assertEquals(6, req.ie_version, 'Expected the middleware to set '
+                          '"ie_version" to 6')

--- a/opentreemap/treemap/views.py
+++ b/opentreemap/treemap/views.py
@@ -674,3 +674,5 @@ user_audits_view = render_template("treemap/recent_user_edits.html",
 
 instance_not_available_view = render_template(
     "treemap/instance_not_available.html")
+
+unsupported_view = render_template("treemap/unsupported.html")


### PR DESCRIPTION
We decided that IE 9 was our cutoff. I implemented this as a piece of middleware that checks the user agent string and compares it to a minimum version in settings.py.
