### PR TITLE
Add a setting switch for js18n

### DIFF
--- a/opentreemap/opentreemap/settings.py
+++ b/opentreemap/opentreemap/settings.py
@@ -46,6 +46,9 @@ SITE_ID = 1
 # to load the internationalization machinery.
 USE_I18N = True
 
+# Setting this to False will remove the jsi18n url configuration
+USE_JS_I18N = False
+
 # If you set this to False, Django will not format dates, numbers and
 # calendars according to the current locale.
 USE_L10N = True

--- a/opentreemap/opentreemap/urls.py
+++ b/opentreemap/opentreemap/urls.py
@@ -15,11 +15,6 @@ instance_pattern = r'^(?P<instance_url_name>' + URL_NAME_PATTERN + r')'
 from django.contrib import admin
 admin.autodiscover()
 
-js_i18n_info_dict = {
-    'domain': 'djangojs',
-    'packages': settings.I18N_APPS,
-}
-
 # Testing notes:
 # We want to test that every URL succeeds (200) or fails with bad data (404).
 # If you add/remove/modify a URL, please update the corresponding test(s).
@@ -49,13 +44,20 @@ urlpatterns = patterns(
     # Create a redirect view for setting the session language preference
     # https://docs.djangoproject.com/en/1.0/topics/i18n/#the-set-language-redirect-view  # NOQA
     url(r'^i18n/', include('django.conf.urls.i18n')),
-    url(r'^jsi18n/$', 'django.views.i18n.javascript_catalog',
-        js_i18n_info_dict),
     url(r'^not-available$', instance_not_available_view,
         name='instance_not_available'),
     url(r'^unsupported$', unsupported_view,
         name='unsupported'),
 )
+
+if settings.USE_JS_I18N:
+    js_i18n_info_dict = {
+        'domain': 'djangojs',
+        'packages': settings.I18N_APPS,
+    }
+
+    urlpatterns += patterns('', url(r'^jsi18n/$',
+        'django.views.i18n.javascript_catalog', js_i18n_info_dict))
 
 if settings.EXTRA_URLS:
     for (url_pattern, url_module) in settings.EXTRA_URLS:

--- a/opentreemap/treemap/templates/base.html
+++ b/opentreemap/treemap/templates/base.html
@@ -101,9 +101,9 @@
     {% endblock config_scripts %}
 
     {% block global_scripts %}
+      {% if settings.USE_JS_I18N %}
       <script type="text/javascript" src="{% url 'django.views.i18n.javascript_catalog' %}"></script>
-      <script>
-      </script>
+      {% endif %}
       {% if debug %}
       <script src="{{ STATIC_URL }}js/treemap.js"></script>
       {% else %}


### PR DESCRIPTION
We are getting 404 requests on the jsi18n url because the plumbing is
setup, but all of our translation is currently handled by server-side
code. This switch allows us to turn it off until needed.
