### PR TITLE
Fix pluralization. Closes #257.

### DIFF
--- a/opentreemap/treemap/templates/treemap/eco_benefits.html
+++ b/opentreemap/treemap/templates/treemap/eco_benefits.html
@@ -1,4 +1,6 @@
 {% load i18n %}
+{% load l10n %}
+
 <div id="benefit-values">
     {% for benefit in benefits %}
       <span class="benefit-label">{{ benefit.label }}</span>
@@ -15,16 +17,12 @@
     {% endfor %}
     <div>
       {% blocktrans with used=basis.n_trees_used %}
-        Based on {{ used }} out of
-      {% endblocktrans %}
-      {% blocktrans count basis.n_trees_total as tree_count %}
-        {{ tree_count }} total tree.
-      {% plural %}
-        {{ tree_count }} total trees.
+        Based on {{ used }} out of {{ basis.n_trees_total }} total trees
       {% endblocktrans %}
     </div>
 </div>
 <div id="tree-and-planting-site-counts">
+  {% localize on %}
   <span id="tree-count">
   {% blocktrans count basis.n_trees_total as tree_count %}
     {{ tree_count }}</span> tree,
@@ -38,4 +36,5 @@
   {% plural %}
     {{ plot_count }}</span> planting sites
   {% endblocktrans %}
+  {% endlocalize %}
 </div>

--- a/opentreemap/treemap/views.py
+++ b/opentreemap/treemap/views.py
@@ -617,16 +617,11 @@ def _tree_benefits_helper(trees_for_eco, total_plots, total_trees, instance):
             trans('Air Quality'), '%.1f')
     ]
 
-    locale.setlocale(locale.LC_ALL, '')
-    n_trees_used = locale.format("%d", num_calculated_trees, grouping=True)
-    n_trees_total = locale.format("%d", total_trees, grouping=True)
-    n_plots = locale.format("%d", total_plots, grouping=True)
-
     rslt = {'benefits': benefits_for_display,
             'currency_symbol': conversion.currency_symbol,
-            'basis': {'n_trees_used': n_trees_used,
-                      'n_trees_total': n_trees_total,
-                      'n_plots': n_plots,
+            'basis': {'n_trees_used': num_calculated_trees,
+                      'n_trees_total': total_trees,
+                      'n_plots': total_plots,
                       'percent': percent}}
 
     return rslt


### PR DESCRIPTION
There are two updates. The first, I think that the X out of Y should
always be plural:

```
Based on 0 out of 1 trees
```

The second, we were doing localization in the views, which made our
numbers into strings and tricked the template pluralizer.

Since templates can do their own localization, we moved it there- fixing
the issue.
