### PR TITLE
Set default map popup size and missing species text

### DIFF
--- a/opentreemap/treemap/js/src/browseTreesMode.js
+++ b/opentreemap/treemap/js/src/browseTreesMode.js
@@ -127,6 +127,7 @@ function getPlotPopupContent(id) {
 
 function makePopup(latLon, html, size) {
     if (latLon && html) {
+        size = size || new OL.Size(320, 130);
         var popup = new OL.Popup("plot-popup", latLon, size, html, true);
         popup.panMapIfOutOfView = true;
         return popup;

--- a/opentreemap/treemap/templates/treemap/plot_popup.html
+++ b/opentreemap/treemap/templates/treemap/plot_popup.html
@@ -1,16 +1,17 @@
 {% load i18n %}
 <div>
-	<h4>{{ plot.current_tree.species }}</h4>
-	<dl class="dl-horizontal">
-		<dt>{% trans "ID:" %}</dt>
-		<dd>{{ plot.pk }}</dd>
-	</dl>
-	<address>
-		<strong>{% trans "Nearby Address:" %}</strong>
-		{{ plot.address_full }}
-	</address>
+    {% if plot.current_tree and plot.current_tree.species %}
+        <h4>{{ plot.current_tree.species }}</h4>
+    {% else %}
+        <h4>{% trans "Missing Species" %}</h4>
+    {% endif %}
+
+    <address>
+        <strong>{% trans "Nearby Address:" %}</strong>
+        {{ plot.address_full }}
+    </address>
 </div>
 <div>
-	<a href="{% url 'plot_detail' instance_url_name=request.instance.url_name plot_id=plot.pk %}" class="btn btn-small btn-secondary">{% trans "View all details" %}</a>
-	<a href="{% url 'plot_detail' instance_url_name=request.instance.url_name plot_id=plot.pk %}#edit" class="btn btn-small btn-info">{% trans "Edit details" %}</a>
+    <a href="{% url 'plot_detail' instance_url_name=request.instance.url_name plot_id=plot.pk %}" class="btn btn-small btn-secondary">{% trans "View all details" %}</a>
+    <a href="{% url 'plot_detail' instance_url_name=request.instance.url_name plot_id=plot.pk %}#edit" class="btn btn-small btn-info">{% trans "Edit details" %}</a>
 </div>


### PR DESCRIPTION
I removed the ID from the popup because space is at a premium in a popup and it is not helpful to the user.
