### PR TITLE
Add and configure celery (with redis)

### DIFF
--- a/opentreemap/opentreemap/settings.py
+++ b/opentreemap/opentreemap/settings.py
@@ -189,6 +189,7 @@ UNMANAGED_APPS = (
     'django.contrib.staticfiles',
     'django.contrib.admin',
     'django.contrib.gis',
+    'djcelery',
     'south',
 )
 
@@ -221,3 +222,10 @@ from opentreemap.local_settings import *  # NOQA
 
 MANAGED_APPS += EXTRA_INSTALLED_APPS
 INSTALLED_APPS = MANAGED_APPS + UNMANAGED_APPS
+
+# CELERY
+# NOTE: BROKER_URL and CELERY_RESULT_BACKEND must be set
+#       to a valid redis URL in local_settings.py
+import djcelery
+djcelery.setup_loader()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ flake8==2.0
 python-omgeo==1.5
 git+git://github.com/azavea/django-registration.git
 modgrammar-py2==0.9.1
+django-celery-with-redis==3.0


### PR DESCRIPTION
celery connects to the default redis port and to a (non-standard, arbitarily chosen) database. Redis prefers flat heirarchies with namespaced keys, so there's little risk of collision anyway, but using a database other than '0' further mitigates this risk.
