### PR TITLE
Add default CartoCSS files

### DIFF
--- a/opentreemap/treemap/assets/carto/boundary.mms
+++ b/opentreemap/treemap/assets/carto/boundary.mms
@@ -1,0 +1,5 @@
+#treemap_boundary {
+   line-color: #C00;
+   line-width: 1;
+   line-opacity: 0.5;
+}

--- a/opentreemap/treemap/assets/carto/plot.mms
+++ b/opentreemap/treemap/assets/carto/plot.mms
@@ -1,0 +1,40 @@
+#treemap_plot {
+    marker-fill: #8BAA3D;
+    marker-allow-overlap: true;
+    marker-line-width: 1;
+
+    
+    [zoom >= 15] {
+        marker-line-color: #b6ce78;    
+    }
+    [zoom < 15] {
+        marker-line-color: #8BAA3D;
+    }
+
+
+    [zoom >= 18] {
+       marker-width: 10;
+    }
+    [zoom >= 17][zoom < 18] {
+       marker-width: 9;
+    }
+    [zoom >= 16][zoom < 17] {
+       marker-width: 8;
+    }
+    [zoom >= 15][zoom < 16] {
+       marker-width: 7;
+    }
+    [zoom >= 14][zoom < 15] {
+       marker-width: 6;
+    }
+    [zoom >= 13][zoom < 14] {
+       marker-width: 5;
+    }
+    [zoom >= 12][zoom < 13] {
+       marker-width: 4;
+    }
+    [zoom < 12] {
+       marker-width: 3;
+    }
+
+}


### PR DESCRIPTION
The default cartography for the tiler that matches the coloring of the
default site style.
