### PR TITLE
Disallow editing when no fields are editable

### DIFF
--- a/opentreemap/treemap/js/src/inlineEditForm.js
+++ b/opentreemap/treemap/js/src/inlineEditForm.js
@@ -18,17 +18,32 @@ exports.init = function(options) {
             updateUrl: options.updateUrl
         },
         form = options.form,
-        edit = options.edit,
-        save = options.save,
-        cancel = options.cancel,
+        $edit = $(options.edit),
+        $save = $(options.save),
+        $cancel = $(options.cancel),
         displayFields = options.displayFields,
         editFields = options.editFields,
         validationFields = options.validationFields,
-        onSaveBefore = options.onSaveBefore || _.identity,
+        onSaveBefore = options.onSaveBefore || _.identity;
 
-        editStream = $(edit).asEventStream('click').map('edit:start'),
-        saveStream = $(save).asEventStream('click').map('save:start'),
-        cancelStream = $(cancel).asEventStream('click').map('cancel'),
+    if ($(editFields).filter(':not(a)').length === 0) {
+        return $.extend(self, {
+            saveOkStream: Bacon.never(),
+            cancelStream: Bacon.never(),
+            inEditModeProperty: Bacon.never().toProperty(false)
+        });
+    }
+
+    // the initial styling of $edit is disabled with title text notifying
+    // the user that editing is disallowed. Since we haven't returned yet,
+    // we can assume at this point that editing is allowed and remove these
+    // styles.
+    $edit.attr('disabled', false);
+    $edit.attr('title', '');
+
+    var editStream = $edit.asEventStream('click').map('edit:start'),
+        saveStream = $save.asEventStream('click').map('save:start'),
+        cancelStream = $cancel.asEventStream('click').map('cancel'),
         actionStream = new Bacon.Bus(),
 
         displayValuesToTypeahead = function() {

--- a/opentreemap/treemap/templates/treemap/plot_detail.html
+++ b/opentreemap/treemap/templates/treemap/plot_detail.html
@@ -48,7 +48,9 @@
       <h3>{{ plot.address_full }}</h3>
       <form id="plot-form">
         <a href="javascript:;" id="edit-plot"
-           data-class="display" class="btn">{% trans "Edit" %}</a>
+           data-class="display" class="btn"
+           title="{% trans "Editing of the tree details is not available to all users" %}"
+           disabled="disabled">{% trans "Edit" %}</a>
         <a href="javascript:;" id="save-edit-plot"
            data-class="edit" class="btn" style="display: none;">{% trans "Save" %}</a>
         <a href="javascript:;" id="cancel-edit-plot"


### PR DESCRIPTION
fixes #376 on github

Default the 'Edit' button to be disabled with explanatory title text. on js initialization, search the DOM for edit fields, which are only present when fields are in fact editable, and if they exist, re-enable the 'Edit' button.
