### PR TITLE
Fix regression introduced in cf745d87a. Fixes #504.

### DIFF
--- a/opentreemap/treemap/templates/treemap/map-add-tree.html
+++ b/opentreemap/treemap/templates/treemap/map-add-tree.html
@@ -8,8 +8,8 @@
     <small>{% trans "Search by address or use your current location, then drag the marker to the correct location. Or click the map." %}</small>
     <form class="form-search">
         <input type="text" class="search-query" id="add-tree-address" placeholder="{% trans "340 N 12th St, Philadelphia" %}">
-        <button class="btn geocode">{% trans "Search" %}</button>
     </form>
+    <button class="btn geocode">{% trans "Search" %}</button>
     <button class="geolocate"><i class="icon-direction"></i> Use Current Location</a>
     <div class="alert alert-error text-error geocode-error" style="display: none;">{% trans "Unable to locate address in this region" %}</div>
     <div class="alert alert-error text-error geolocate-error" style="display: none;">{% trans "Unable to determine current location" %}</div>

--- a/opentreemap/treemap/templates/treemap/plot_detail.html
+++ b/opentreemap/treemap/templates/treemap/plot_detail.html
@@ -54,12 +54,13 @@
       <h1>{{ tree.species.common_name }}</h1>
       <h2>{{ tree.species.scientific_name }}</h2>
       <h3>{{ plot.address_full }}</h3>
-      <form id="plot-form">
-        <button id="edit-plot" data-class="display" class="btn"
-           title="{% trans "Editing of the tree details is not available to all users" %}"
+      <button id="edit-plot" data-class="display" class="btn"
+              title="{% trans "Editing of the tree details is not available to all users" %}"
            disabled="disabled">{% trans "Edit" %}</button>
         <button id="save-edit-plot" data-class="edit" class="btn" style="display: none;">{% trans "Save" %}</button>
         <button id="cancel-edit-plot" data-class="edit" class="btn" style="display: none;">{% trans "Cancel" %}</button>
+      <form id="plot-form">
+
 
         <!-- General Tree Information -->
         <table class="table table-striped">

--- a/opentreemap/treemap/templates/treemap/user.html
+++ b/opentreemap/treemap/templates/treemap/user.html
@@ -42,7 +42,7 @@
                     {% endfor %}
                     <ul class="chunk" data-class="display">
                         <li class="chunk-label">{% trans "Password" %}</li>
-                        <li class="chunk-content"><button>{% trans "Reset" %}</button></li>
+                        <li class="chunk-content"><a href="javascript:;">{% trans "Reset" %}</a></li>
                     </ul>
                     <ul class="chunk">
                         <li class="chunk-label">{% trans "Emails" %}</li>
@@ -93,12 +93,12 @@
             cancel: '#cancel-edit',
             displayFields: '[data-class="display"]',
             editFields: '[data-class="edit"]',
-            validationFields: '[data-class="error"]'    
+            validationFields: '[data-class="error"]'
         },
         recentEdits: {
             recentEditsContainer: '#recent-user-edits-container',
             prevLink: '#recent-user-edits-prev',
-            nextLink: '#recent-user-edits-next',    
+            nextLink: '#recent-user-edits-next',
         }
     });
 })(require);


### PR DESCRIPTION
Buttons that had previously been anchors were changed to button
tags. That caused them to trigger the form actions, resulting is page
reloads.

Since forms are mostly stylistic, we've moved the buttons outside of
them.
