### PR TITLE
Add support for custom units

### DIFF
--- a/opentreemap/ecobenefits/util.py
+++ b/opentreemap/ecobenefits/util.py
@@ -1,0 +1,15 @@
+from django.utils.translation import ugettext as trans
+
+_benefit_labels = {
+    'energy':     trans('Energy'),
+    'stormwater': trans('Stormwater'),
+    'co2':        trans('Carbon Dioxide'),
+    'airquality': trans('Air Quality')
+}
+
+
+def get_label(benefit_name):
+    if benefit_name in _benefit_labels:
+        return _benefit_labels[benefit_name]
+    else:
+        raise Exception("Unexpected benefit name: " + benefit_name)

--- a/opentreemap/opentreemap/settings.py
+++ b/opentreemap/opentreemap/settings.py
@@ -246,3 +246,25 @@ MIDDLEWARE_CLASSES += EXTRA_MIDDLEWARE_CLASSES
 #       to a valid redis URL in local_settings.py
 import djcelery
 djcelery.setup_loader()
+
+#
+# Units and decimal digits for fields and eco values
+#
+
+DISPLAY_DEFAULTS = {
+    'plot': {
+        'width':  {'units': 'in', 'digits': 1},
+        'length': {'units': 'in', 'digits': 1},
+    },
+    'tree': {
+        'diameter':      {'units': 'in', 'digits': 1},
+        'height':        {'units': 'ft', 'digits': 1},
+        'canopy_height': {'units': 'ft', 'digits': 1}
+    },
+    'eco': {
+        'energy':     {'units': 'kwh', 'digits': 1},
+        'co2':        {'units': 'lbs', 'digits': 1},
+        'stormwater': {'units': 'gal', 'digits': 1},
+        'airquality': {'units': 'lbs', 'digits': 1}
+    }
+}

--- a/opentreemap/treemap/css/sass/partials/_admin.scss
+++ b/opentreemap/treemap/css/sass/partials/_admin.scss
@@ -139,3 +139,14 @@ $nav-width: 200px;
 .error-on-tab {
         border-bottom: 8px solid red;
 }
+
+/* Units tables ---------------------- */
+
+table.units th {
+  padding: 5px 15px 0 0;
+  text-align: left;
+}
+
+table.units td {
+  padding: 5px 15px 0 0;
+}

--- a/opentreemap/treemap/js/src/inlineEditForm.js
+++ b/opentreemap/treemap/js/src/inlineEditForm.js
@@ -132,6 +132,10 @@ exports.init = function(options) {
                             value = $input.val();
                         }
                         $(display).attr('data-value', value);
+                        if ($input.is('select')) {
+                            // Use dropdown text (not value) as display value
+                            value = $input.find('option:selected').text();
+                        }
                         $(display).html(value);
                     }
                 }

--- a/opentreemap/treemap/templates/treemap/field/inputs.html
+++ b/opentreemap/treemap/templates/treemap/field/inputs.html
@@ -1,13 +1,11 @@
 {# vim: set filetype=htmldjango : #}
 {% load dateformat %}
 {% if field.data_type == 'choice' %}
-    <select name="{{ field.identifier }}"
-            {% if extra %}{{ extra }}{% endif %} />
-            <option value=""></option>
+    <select name="{{ field.identifier }}" {{ extra|default:"" }} />
         {% for option in field.choices %}
-            <option value="{{ option }}"
-              {% ifequal option field.value %}selected="selected"{% endifequal %}>
-                {{option}}
+            <option value="{{ option.value }}"
+              {% ifequal option.value field.value %}selected="selected"{% endifequal %}>
+                {{option.display_value}}
             </option>
         {% endfor %}
     </select>
@@ -18,7 +16,7 @@
           {% endif %}
            type="checkbox"
            value="{{ field.value }}"
-           {% if extra %}{{ extra }}{% endif %} />
+           {{ extra|default:"" }} />
 {% elif field.data_type == 'date' %}
     <input name="{{ field.identifier }}"
            type="text"
@@ -29,10 +27,10 @@
            value="{{ field.value|date:"SHORT_DATE_FORMAT" }}"
            data-date-format="{{ settings.SHORT_DATE_FORMAT|datepicker_format }}"
            {% endif %}
-           {% if extra %}{{ extra }}{% endif %} />
+           {{ extra|default:"" }} />
 {% else %}
     <input name="{{ field.identifier }}"
            type="text"
            value="{{ field.value|default_if_none:"" }}"
-           {% if extra %}{{ extra }}{% endif %} />
+           {{ extra|default:"" }} />
 {% endif %}

--- a/opentreemap/treemap/templates/treemap/field/td.html
+++ b/opentreemap/treemap/templates/treemap/field/td.html
@@ -1,0 +1,10 @@
+<td>
+  <div {% include "treemap/field/attrs.html" with class="display" %}>
+    {{ field.display_value|default_if_none:"" }}
+  </div>
+  <div {% include "treemap/field/attrs.html" with class="edit" %} style="display: none;">
+    {% include "treemap/field/inputs.html" %}
+  </div>
+  <div class="text-error" style="display: none;"
+          {% include "treemap/field/attrs.html" with class="error" %}></div>
+</td>

--- a/opentreemap/treemap/templatetags/form_extras.py
+++ b/opentreemap/treemap/templatetags/form_extras.py
@@ -281,7 +281,9 @@ class AbstractNode(template.Node):
             elif model_has_udfs and field_is_udf:
                 val = model.udfs[udf_field_name]
                 try:
-                    choices = _udf_dict(model, udf_field_name)['choices']
+                    values = [''] + _udf_dict(model, udf_field_name)['choices']
+                    choices = [{'value': value, 'display_value': value}
+                               for value in values]
                 except KeyError:
                     choices = None
             else:

--- a/opentreemap/treemap/tests/templatetags.py
+++ b/opentreemap/treemap/tests/templatetags.py
@@ -510,8 +510,9 @@ class InlineFieldTagTests(TestCase):
 
     def test_sets_choices_for_udf_field(self):
         user = make_observer_user(self.instance)
-        template_string = """{% for c in field.choices %}{{c}}{% endfor %}"""
-        self.assert_plot_udf_template(user, template_string, 'abc')
+        template_string = """
+            {% for c in field.choices %}{{c.value}}-{% endfor %}"""
+        self.assert_plot_udf_template(user, template_string, '-a-b-c-')
 
     def test_sets_choices_to_none_for_normal_field(self):
         user = make_observer_user(self.instance)

--- a/opentreemap/treemap/units.py
+++ b/opentreemap/treemap/units.py
@@ -1,0 +1,35 @@
+from django.utils.translation import ugettext as trans
+
+_unit_names = {
+    "in":  trans("inches"),
+    "ft":  trans("feet"),
+    "cm":  trans("centimeters"),
+    "m":   trans("meters"),
+    "lbs": trans("pounds"),
+    "kg":  trans("kilograms"),
+    "kwh": trans("kilowatt-hours"),
+    "gal": trans("gallons"),
+    "L":   trans("liters")
+}
+
+_unit_conversions = {
+    "in": {"in": 1, "ft": .083333333, "cm": 2.54, "m": .0254},
+    "ft": {"in": 12, "ft": 1, "cm": 2.54, "m": 30.48},
+    "lbs": {"lbs": 1, "kg": 0.453592},
+    "gal": {"gal": 1, "L": 3.785},
+    "kwh": {"kwh": 1}
+}
+
+
+def get_unit_name(abbrev):
+    if abbrev in _unit_names:
+        return _unit_names[abbrev]
+    else:
+        raise Exception("Unexpected unit abbrev: " + abbrev)
+
+
+def get_convertible_units(abbrev):
+    if abbrev in _unit_conversions:
+        return _unit_conversions[abbrev].keys()
+    else:
+        raise Exception("Unexpected unit abbrev: " + abbrev)

--- a/opentreemap/treemap/util.py
+++ b/opentreemap/treemap/util.py
@@ -235,8 +235,9 @@ def package_validation_errors(model_name, validation_error):
     {fieldname1: [messages], fieldname2: [messages]}.
     Return a version keyed by "modelname.fieldname" instead of "fieldname".
     """
-    return {'%s.%s' % (model_name.lower(), field): msgs
+    dict = {'%s.%s' % (model_name.lower(), field): msgs
             for (field, msgs) in validation_error.message_dict.iteritems()}
+    return dict
 
 
 # https://docs.djangoproject.com/en/dev/topics/serialization/#id2


### PR DESCRIPTION
- Add settings for units and decimal digits to settings.py
- Add units.py with unit conversions and unit name/abbrev table
- "inputs.html" template doesn't assume a blank choice -- "choice" UDF adds its own blank choice
- A "Choice" field option's value can differ from its display_value

Fixes #457
