### PR TITLE
Add in client-side geocoder. Fixes #543.

### DIFF
--- a/opentreemap/treemap/js/src/geocoder.js
+++ b/opentreemap/treemap/js/src/geocoder.js
@@ -1,26 +1,124 @@
 "use strict";
 
 var $ = require('jquery'),
+    U = require('utility'),
     _ = require('underscore'),
     Bacon = require('baconjs');
 
 exports = module.exports = function (config) {
 
-    var geocode = function (address, bbox, success, error) {
-        return $.ajax({
-            url: '/geocode',
-            type: 'GET',
-            data: _.extend({address: address}, bbox),
-            dataType: 'json',
-            success: success,
-            error: error
+    var geocodeServer = function (address, bbox, success, error) {
+        return Bacon.fromPromise(
+            $.ajax({
+                url: '/geocode',
+                type: 'GET',
+                data: _.extend({address: address}, bbox),
+                dataType: 'json',
+                success: success,
+                error: error
+            }));
+    };
+
+    // This uses filters similar to:
+    // https://github.com/azavea/python-omgeo/blob/master/omgeo/services/__init__.py
+    var processGeocoderResponse = function(geocoderResponse) {
+        function groupByAndExtractMaxScore(chained, param) {
+            return chained.groupBy(param)
+                .values()
+                .map(function(candidateGroup) {
+                    return _.max(candidateGroup, function(candidate) {
+                        return candidate.score;
+                    });
+                });
+        }
+
+        // Extract geom (x,y), score, name, and type
+        var candidates = _.chain(geocoderResponse.locations)
+            .map(function(candidate) {
+                var xy = U.lonLatToWebMercator(
+                    candidate.feature.geometry.x,
+                    candidate.feature.geometry.y);
+
+                return {
+                    x: xy.x,
+                    y: xy.y,
+                    loc: 'x:' + xy.x + ',y:' + xy.y,
+                    srid: '3857',
+                    score: candidate.feature.attributes.Score,
+                    type: candidate.feature.attributes.Addr_Type,
+                    address: candidate.name
+                };
+            });
+
+        // Remove duplicates based on location and name
+        candidates = groupByAndExtractMaxScore(candidates, 'loc');
+        candidates = groupByAndExtractMaxScore(candidates, 'address');
+
+        // Remove scores less than 'threshold'
+        candidates = candidates.filter(function(candidate) {
+            return candidate.score >= config.geocoder.threshold;
         });
+
+        // Only accept 'PointAddress' and 'StreetAddress' types
+        var types = candidates
+                .groupBy('type')
+                .value();
+
+        var pointAddresses = _.sortBy(types.PointAddress, 'score');
+        var streetAddresses = _.sortBy(types.StreetAddress, 'score');
+
+        // Prefer point addresses first
+        var filteredCandidates = pointAddresses.concat(streetAddresses);
+
+        return { candidates: filteredCandidates };
+    };
+
+    var filterBbox = function(bbox, response) {
+        if (response.candidates) {
+            response.candidates = _.filter(
+                response.candidates, function(candidate) {
+                    return candidate.x >= bbox.xmin &&
+                        candidate.x <= bbox.xmax &&
+                        candidate.y >= bbox.ymin &&
+                        candidate.y <= bbox.ymax;
+                });
+        }
+
+        return response;
+    };
+
+    var geocodeClient = function(address, box) {
+        var url = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/find';
+        var params = {
+            'maxLocations': config.geocoder.maxLocations,
+            'outFields': 'Loc_name,Score,Addr_Type,DisplayX,DisplayY',
+            'f': 'json',
+            text: address
+        };
+
+        return Bacon.fromPromise(
+            $.ajax({
+                url: url,
+                type: 'GET',
+                data: params,
+                crossDomain: true,
+                dataType: 'jsonp'
+            }))
+            .map(processGeocoderResponse)
+            .map(filterBbox, box);
     };
 
     return {
         geocodeStream: function(addressStream) {
             return addressStream.flatMap(function (address) {
-                return Bacon.fromPromise(geocode(address, config.instance.extent));
+                return geocodeClient(address, config.instance.extent);
+            }).flatMap(function(response) {
+                if (response.candidates && response.candidates.length > 0) {
+                    return Bacon.once(response);
+                } else {
+                    return Bacon.once(
+                        new Bacon.Error(config.geocoder.errorString));
+                }
             });
         }
     };

--- a/opentreemap/treemap/js/src/map.js
+++ b/opentreemap/treemap/js/src/map.js
@@ -23,7 +23,13 @@ var unmatchedBoundarySearchValue = function() {
 };
 
 var showGeocodeError = function (e) {
-    if (e.status && e.status === 404) {
+    // Bacon just returns an error string
+    if (_.isString(e)) {
+        // TODO: Toast
+        window.alert(e);
+    // If there was an error from the server the error
+    // object contains standard http info
+    } else if (e.status && e.status === 404) {
         // TODO: Toast
         window.alert('There were no results matching your search.');
     } else {
@@ -75,6 +81,7 @@ module.exports = {
         });
 
         // Let the user know if there was a problem geocoding
+        geocodeResponseStream.log();
         geocodeResponseStream.onError(showGeocodeError);
 
         // Set up cross-site forgery protection

--- a/opentreemap/treemap/templates/treemap/settings.js
+++ b/opentreemap/treemap/templates/treemap/settings.js
@@ -1,4 +1,5 @@
 {% load instance_config %}
+{% load i18n %}
 
 // Data structures pulled from django
 var otm = otm || {};
@@ -25,6 +26,12 @@ otm.settings.urls = {
 otm.settings.loginUrl = "{% url 'django.contrib.auth.views.login' %}?next=";
 
 otm.settings.staticUrl = '{{ STATIC_URL }}';
+
+otm.settings.geocoder = {
+    maxLocations: 20,
+    errorString: '{% trans "That address was not found near this map" %}',
+    threshold: 80
+};
 
 {% if request.instance %}
     otm.settings.instance = {


### PR DESCRIPTION
Provide both a client-side and server-side geocoder. Right now the
default is to use the client.
