### PR TITLE
Link static pages (FAQ, About, Resources). Fixes #409.

### DIFF
--- a/opentreemap/treemap/templates/base.html
+++ b/opentreemap/treemap/templates/base.html
@@ -107,24 +107,10 @@
 
     </div>
 
-    {% block footer %}
     <footer>
-      <div class="footer-inner">
-        <ul class="inline pull-left">
-          {% with linkData=request.instance|instance_config:"linkData" %}
-          <li><a href="{% if linkData.treekey %}{{ linkData.treekey }}{% else %}http://www.arborday.org/trees/whatTree/{% endif %}">{% trans "Tree Key" %}</a></li>
-          <li><a href="javascript:;">{% trans "Resources" %}</a></li>
-          <li><a href="javascript:;">{% trans "FAQ" %}</a></li>
-          <li><a href="javascript:;">{% trans "About" %}</a></li>
-          {% if linkData.contact %}
-          <li><a href="mailto:{{ linkData.contact }}">{% trans "Contact" %}</a></li>
-          {% endif %}
-          {% endwith %}
-        </ul>
-        <a href="javascript:;" class="pull-right partners">Partners</a>
-      </div>
-    </footer>
+    {% block footer %}
     {% endblock footer %}
+    </footer>
 
     {% block config_scripts %}
       {% if request.instance %}

--- a/opentreemap/treemap/templates/instance_base.html
+++ b/opentreemap/treemap/templates/instance_base.html
@@ -99,6 +99,23 @@
 </script>
 {% endblock searchscripts %}
 
+{% block footer %}
+<div class="footer-inner">
+  <ul class="inline pull-left">
+    {% with linkData=request.instance|instance_config:"linkData" %}
+    <li><a href="{% if linkData.treekey %}{{ linkData.treekey }}{% else %}http://www.arborday.org/trees/whatTree/{% endif %}">{% trans "Tree Key" %}</a></li>
+    <li><a href="{% url 'static_page' instance_url_name=request.instance.url_name page='Resources' %}">{% trans "Resources" %}</a></li>
+    <li><a href="{% url 'static_page' instance_url_name=request.instance.url_name page='FAQ' %}">{% trans "FAQ" %}</a></li>
+    <li><a href="{% url 'static_page' instance_url_name=request.instance.url_name page='About' %}">{% trans "About" %}</a></li>
+    {% if linkData.contact %}
+    <li><a href="mailto:{{ linkData.contact }}">{% trans "Contact" %}</a></li>
+    {% endif %}
+    {% endwith %}
+  </ul>
+  <a href="javascript:;" class="pull-right partners">Partners</a>
+</div>
+{% endblock footer %}
+
 {% block templates %}
 {% verbatim %}
 <script id="species-element-template" type="text/x-mustache-template">

--- a/opentreemap/treemap/templates/treemap/staticpage.html
+++ b/opentreemap/treemap/templates/treemap/staticpage.html
@@ -1,0 +1,14 @@
+{% extends "instance_base.html" %}
+
+{% block page_title %} | {{ title }}{% endblock %}
+
+{% block content %}
+<div class="image-background"></div>
+<div class="container contained profile">
+    <div class="row">
+        <div class="span12">
+          {{ content|safe }}
+        </div>
+    </div>
+</div>
+{% endblock content %}

--- a/opentreemap/treemap/urls.py
+++ b/opentreemap/treemap/urls.py
@@ -16,7 +16,7 @@ from treemap.views import (boundary_to_geojson_view, index_view, map_view,
                            add_tree_photo_endpoint, photo_review_endpoint,
                            approve_or_reject_photo_view, next_photo_endpoint,
                            photo_review_partial_endpoint, get_plot_eco_view,
-                           edit_plot_detail_view)
+                           edit_plot_detail_view, static_page_view)
 
 # Testing notes:
 # We want to test that every URL succeeds (200) or fails with bad data (404).
@@ -26,6 +26,8 @@ from treemap.views import (boundary_to_geojson_view, index_view, map_view,
 urlpatterns = patterns(
     '',
     url(r'^$', index_view),
+    url(r'page/(?P<page>[a-zA-Z0-9]+)/$',
+        static_page_view, name='static_page'),
     url(r'^boundaries/(?P<boundary_id>\d+)/geojson/$',
         boundary_to_geojson_view),
     url(r'^boundaries/$', boundary_autocomplete_view),

--- a/opentreemap/treemap/views.py
+++ b/opentreemap/treemap/views.py
@@ -915,6 +915,19 @@ def approve_or_reject_photo(
     return resp
 
 
+def static_page(request, instance, page):
+    # TODO: Right now all pages simply return
+    #       the same string. In the future, they'll grab
+    #       from the instance config
+
+    allowed_pages = ['Resources', 'FAQ', 'About']
+
+    if page not in allowed_pages:
+        raise Http404()
+
+    return {'content': trans('There is no content for this page yet'),
+            'title': page}
+
 audits_view = instance_request(
     render_template('treemap/recent_edits.html', audits))
 
@@ -1000,3 +1013,6 @@ next_photo_endpoint = instance_request(
 
 approve_or_reject_photo_view = instance_request(
     approve_or_reject_photo)
+
+static_page_view = instance_request(
+    render_template("treemap/staticpage.html", static_page))


### PR DESCRIPTION
They all link to a blank screen right now. The goal is to provide
content by default for all of these and allow the users to be able to
customize it for each map.
