### PR TITLE
Move bounds layer to the bottom of the layer stack

### DIFF
--- a/opentreemap/treemap/js/src/mapManager.js
+++ b/opentreemap/treemap/js/src/mapManager.js
@@ -69,9 +69,9 @@ exports.init = function(options) {
                     {reset: !!reset});
     };
 
+    map.addLayer(boundsLayer);
     map.addLayer(utfLayer);
     map.addLayer(plotLayer);
-    map.addLayer(boundsLayer);
 
     var center = options.center || config.instance.center,
         zoom = options.zoom || exports.ZOOM_DEFAULT;


### PR DESCRIPTION
The updated styling of the boundaries in a4119d52 ended up obscuring the tree markers so I moved it to the bottom of the stack.
