### PR TITLE
Put leaflet controls behind the typeaheads

### DIFF
--- a/opentreemap/treemap/css/sass/modules/_mappaths.scss
+++ b/opentreemap/treemap/css/sass/modules/_mappaths.scss
@@ -4,3 +4,15 @@
 .leaflet-retina .leaflet-control-layers-toggle {
         background-image: url(/static/img/leaflet/layers-2x.png) !important;
         }
+
+/**
+ * We can't control typeahead using 100 so we have to move
+ * leaflet down
+ */
+.leaflet-bottom {
+        z-index: 99 !important;
+}
+
+.leaflet-top {
+        z-index: 99 !important;
+}


### PR DESCRIPTION
Unfortunately, the typeahead library uses a fixed z-index of 100 that we
can't really change. Instead, we can force leaflet to use a lower z-index.

Fixes #619.
