### PR TITLE
Show tree progress on plot detail page

### DIFF
--- a/opentreemap/treemap/templates/treemap/plot_detail.html
+++ b/opentreemap/treemap/templates/treemap/plot_detail.html
@@ -39,10 +39,15 @@
       <hr>
       <h3>{% trans "Latest Update" %}</h3>
       <p>{{ recent_activity.0.short_descr }}</p>
-      <h5>20% {% trans "Complete" %}</h5>
+      <h5>{{ progress_percent }}% {% trans "Complete" %}</h5>
       <div class="progress">
-        <div class="bar" style="width: 20%;"></div>
+        <div class="bar" style="width: {{ progress_percent }}%;"></div>
       </div>
+      <ul>
+        {% for message in progress_messages %}
+          <li>{{ message }}</li>
+        {% endfor %}
+      </ul>
       <hr>
       <h3>{% trans "Recent Edits" %}</h3>
       <ul>

--- a/opentreemap/treemap/views.py
+++ b/opentreemap/treemap/views.py
@@ -215,6 +215,7 @@ def plot_detail(request, instance, plot_id, edit=False, tree_id=None):
     has_tree_diameter = tree is not None and tree.diameter is not None
     has_tree_species_with_code = tree is not None \
         and tree.species is not None and tree.species.otm_code is not None
+    has_photo = tree is not None and tree.treephoto_set.all().count() > 0
 
     if has_tree_diameter and has_tree_species_with_code:
         try:
@@ -225,6 +226,29 @@ def plot_detail(request, instance, plot_id, edit=False, tree_id=None):
             context = _tree_benefits_helper([eco_tree], 1, 1, instance)
         except Exception:
             pass
+
+    total_progress_items = 4
+    completed_progress_items = 1  # there is always a plot
+
+    if has_tree_diameter:
+        completed_progress_items += 1
+    if has_tree_species_with_code:
+        completed_progress_items += 1
+    if has_photo:
+        completed_progress_items += 1
+
+    context['progress_percent'] = int(100 * (
+        completed_progress_items / total_progress_items))
+
+    context['progress_messages'] = []
+    if not tree:
+        context['progress_messages'].append(trans('Add a tree'))
+    if not has_tree_diameter:
+        context['progress_messages'].append(trans('Add the diameter'))
+    if not has_tree_species_with_code:
+        context['progress_messages'].append(trans('Add the species'))
+    if not has_photo:
+        context['progress_messages'].append(trans('Add a photo'))
 
     if tree:
         context['upload_tree_photo_url'] = \


### PR DESCRIPTION
The progress bar has been in the plot detail markup for a while but has
not been functional.

Fixes #283
