### PR TITLE
Fix regressions from audit display update

### DIFF
--- a/opentreemap/treemap/tests/views.py
+++ b/opentreemap/treemap/tests/views.py
@@ -845,9 +845,11 @@ class PlotViewTest(PlotViewTestCase):
 
         self.assertIn('recent_activity', details)
 
-        recent_activity = details['recent_activity']
+        audit_groups = details['recent_activity']
 
-        audit = recent_activity[0]
+        user, update, audits = audit_groups[0]
+        audit = audits[0]
+
         self.assertEqual(audit.model, 'Plot')
         self.assertEqual(audit.field, 'width')
 
@@ -867,9 +869,10 @@ class PlotViewTest(PlotViewTestCase):
 
         self.assertIn('recent_activity', details)
 
-        recent_activity = details['recent_activity']
-        readonly_audit = recent_activity[0]
-        insert_audit = recent_activity[1]
+        audit_groups = details['recent_activity']
+        user, updates, audits = audit_groups[0]
+        readonly_audit = audits[0]
+        insert_audit = audits[1]
 
         self.assertEqual(readonly_audit.model, 'Tree')
         self.assertEqual(readonly_audit.field, 'readonly')

--- a/opentreemap/treemap/views.py
+++ b/opentreemap/treemap/views.py
@@ -271,8 +271,6 @@ def plot_detail(request, instance, plot_id, edit=False, tree_id=None):
 
     audits = _plot_audits(request.user, instance, plot)
 
-    context['latest_update'] = audits[0]
-
     def _audits_are_in_different_groups(prev_audit, audit):
         if prev_audit is None:
             return True
@@ -298,6 +296,11 @@ def plot_detail(request, instance, plot_id, edit=False, tree_id=None):
     # Converting the audit groups to tuples makes the template code cleaner
     context['recent_activity'] = [
         (ag['user'], ag['updated'], ag['audits']) for ag in audit_groups]
+
+    if len(audits) > 0:
+        context['latest_update'] = audits[0]
+    else:
+        context['latest_update'] = None
 
     return context
 


### PR DESCRIPTION
I failed to update all the tests that assumed recent_activity in the view context was a list of Audit objects. It is now a list of tuples that group audit objects together by user and updated day.
