### PR TITLE
DRY up references to the add tree URL hash

### DIFF
--- a/opentreemap/opentreemap/settings.py
+++ b/opentreemap/opentreemap/settings.py
@@ -285,3 +285,5 @@ DISPLAY_DEFAULTS = {
         'airquality': {'units': 'lbs/year', 'digits': 1}
     }
 }
+
+ADD_TREE_URL_HASH = '#addTree'

--- a/opentreemap/treemap/js/src/addTreeMode.js
+++ b/opentreemap/treemap/js/src/addTreeMode.js
@@ -24,12 +24,12 @@ var config,
     $editFields,
     $editControls,
     $validationFields,
-    deactivateBus;
-
-var hash = "#addTree";
+    deactivateBus,
+    addTreeUrlHash;
 
 function init(options) {
     config = options.config;
+    addTreeUrlHash = config.addTreeUrlHash;
     mapManager = options.mapManager;
     plotMarker = options.plotMarker;
     onAddTree = options.onAddTree;
@@ -156,7 +156,7 @@ function init(options) {
 //     deactivate() -> Inactive
 
 function activate() {
-    window.location.hash = hash;
+    window.location.hash = addTreeUrlHash;
     // Let user start creating a tree (by clicking the map)
     plotMarker.hide();
     plotMarker.enablePlacing();
@@ -271,6 +271,5 @@ function deactivate() {
 module.exports = {
     init: init,
     activate: activate,
-    deactivate: deactivate,
-    hash: hash
+    deactivate: deactivate
 };

--- a/opentreemap/treemap/js/src/map.js
+++ b/opentreemap/treemap/js/src/map.js
@@ -96,7 +96,7 @@ module.exports = {
             selector: '#map'
         });
         modes.init(config, mapManager, triggerSearchFromSidebar);
-        if (window.location.hash === addTreeMode.hash) {
+        if (window.location.hash === config.addTreeUrlHash) {
             modes.activateAddTreeMode();
         } else {
             modes.activateBrowseTreesMode();

--- a/opentreemap/treemap/js/src/searchBar.js
+++ b/opentreemap/treemap/js/src/searchBar.js
@@ -74,7 +74,5 @@ module.exports = exports = {
         exports.searchEventStream()
            .map(Search.buildSearch, elems)
            .onValue(exports.redirectToSearchPage, config);
-
-        $('.addBtn').attr('href', config.instance.url + 'map/#addtree');
     }
 };

--- a/opentreemap/treemap/templates/base.html
+++ b/opentreemap/treemap/templates/base.html
@@ -42,7 +42,7 @@
               {% if last_instance %}
               <li class="{% block activeexplore %}active{% endblock %}"><a href="{% url 'map' instance_url_name=last_instance.url_name %}">{% trans "Explore Trees" %}</a></li>
               {% if request.user.is_authenticated %}
-              <li><a data-class='add-tree' href="{% url 'map' instance_url_name=last_instance.url_name %}#addtree">{% trans "Add a Tree" %}</a></li>
+              <li><a data-class='add-tree' href="{% url 'map' instance_url_name=last_instance.url_name %}{{ settings.ADD_TREE_URL_HASH }}">{% trans "Add a Tree" %}</a></li>
               {% else %}
               <li><a href="{% url 'django.contrib.auth.views.login' %}?next={{ request.get_full_path }}">{% trans "Add a Tree" %}</a></li>
               {% endif %}

--- a/opentreemap/treemap/templates/instance_base.html
+++ b/opentreemap/treemap/templates/instance_base.html
@@ -18,7 +18,7 @@
 {% block instancetopnav %}
 <li class="{% block activeexplore %}active{% endblock %}"><a href="{% url 'map' instance_url_name=request.instance.url_name %}">{% trans "Explore Trees" %}</a></li>
 {% if request.user.is_authenticated %}
-<li><a data-action="addtree" href="{% url 'map' instance_url_name=request.instance.url_name %}#addtree">{% trans "Add a Tree" %}</a></li>
+<li><a data-action="addtree" href="{% url 'map' instance_url_name=request.instance.url_name %}{{ settings.ADD_TREE_URL_HASH }}">{% trans "Add a Tree" %}</a></li>
 {% else %}
 <li><a href="{% url 'django.contrib.auth.views.login' %}?next={{ request.get_full_path }}">{% trans "Add a Tree" %}</a></li>
 {% endif %}
@@ -41,9 +41,9 @@
   <a href="javascript:;" class="btn btn-primary btn-mini exportBtn" id="exportbutton"><i class="icon-export"></i> Export Search Results</a>
   {% endif %}
   {% if request.user.is_authenticated %}
-  <a data-action="addtree" href="{% url 'map' instance_url_name=request.instance.url_name %}#addtree" class="btn btn-primary addBtn"><i class="icon-plus"></i> Add a Tree</a>
+  <a data-action="addtree" href="{% url 'map' instance_url_name=request.instance.url_name %}{{ settings.ADD_TREE_URL_HASH }}" class="btn btn-primary addBtn"><i class="icon-plus"></i> Add a Tree</a>
   {% else %}
-  <a href="{% url 'django.contrib.auth.views.login' %}?next={{ request.get_full_path }}" class="btn btn-primary addBtn"><i class="icon-plus"></i> {% trans "Add a Tree" %}</a>
+  <a href="{% url 'django.contrib.auth.views.login' %}?next={{ request.get_full_path }}{{ settings.ADD_TREE_URL_HASH|urlencode }}" class="btn btn-primary addBtn"><i class="icon-plus"></i> {% trans "Add a Tree" %}</a>
   {% endif %}
 </div>
 {% endblock subhead %}

--- a/opentreemap/treemap/templates/treemap/settings.js
+++ b/opentreemap/treemap/templates/treemap/settings.js
@@ -36,10 +36,14 @@ otm.settings.geocoder = {
     threshold: 80
 };
 
+otm.settings.addTreeUrlHash = '{{ settings.ADD_TREE_URL_HASH }}';
+
 {% if request.instance %}
     otm.settings.instance = {
         'id': '{{ request.instance.id }}',
         'url': '{{ SITE_ROOT }}{{ request.instance.url_name }}/',
+        'mapUrl': "{% url 'map' instance_url_name=last_instance.url_name %}",
+        'addTreeUrl': "{% url 'map' instance_url_name=last_instance.url_name %}{{ settings.ADD_TREE_URL_HASH }}",
         'name': '{{ request.instance.name }}',
         'rev': '{{ request.instance.geo_rev_hash }}',
         'center': {


### PR DESCRIPTION
We funnel users into adding trees from many places in an effort to maximize user contributions. As a result, construting the url to the add tree mode of the map page was scattered in a few different files. I unified this as best I could by moving the hash text out to `settings.py` and then forwarding it through to the templates and the client-side code, via the templated `settings.js`.

Fixes #635
