### PR TITLE
Hide export on plot detail page. Fixes #637

### DIFF
--- a/opentreemap/treemap/templates/instance_base.html
+++ b/opentreemap/treemap/templates/instance_base.html
@@ -37,9 +37,11 @@
     <!-- This is what the counts will look like -->
     <!-- <span id="tree-count">4567</span> trees, <span id="planting-site-count">10,683</span> planting sites -->
   </div>
-  {% if request.instance|feature_enabled:'exports' %}
-  <a href="javascript:;" class="btn btn-primary btn-mini exportBtn" id="exportbutton"><i class="icon-export"></i> Export Search Results</a>
-  {% endif %}
+  {% block subhead_exports %}
+    {% if request.instance|feature_enabled:'exports' %}
+    <a href="javascript:;" class="btn btn-primary btn-mini exportBtn" id="exportbutton"><i class="icon-export"></i> Export Search Results</a>
+    {% endif %}
+  {% endblock subhead_exports %}
   <a class="btn btn-primary addBtn"
      data-class="add-tree"
      data-action='addtree'

--- a/opentreemap/treemap/templates/treemap/plot_detail.html
+++ b/opentreemap/treemap/templates/treemap/plot_detail.html
@@ -11,6 +11,9 @@
 {% block head_extra %}
 {% endblock head_extra %}
 
+{% block subhead_exports %}
+{# Exporting is not available from the plot detail page #}
+{% endblock subhead_exports %}
 
 {% block content %}
 {% include "treemap/partials/upload_image.html" with panel_id="add-photo-modal" title="Add a Photo" endpoint=upload_tree_photo_url %}


### PR DESCRIPTION
It is a little confusing to see export on the plot detail page. You might expect it to export just the single tree, which is not what happens.
