### PR TITLE
Style the not-available page

### DIFF
--- a/opentreemap/treemap/templates/treemap/instance_not_available.html
+++ b/opentreemap/treemap/templates/treemap/instance_not_available.html
@@ -10,7 +10,11 @@
 {% endblock subhead %}
 
 {% block content %}
-<h3>{% trans "This map is not available." %}</h3>
+<div class="content">
+  <div class="well error-panel">
+    <h3>{% trans "The map you requested is not available all users." %}</h3>
+  </div>
+</div>
 {% endblock content %}
 
 {% block scripts %}


### PR DESCRIPTION
This page may show up a lot in our beta period if people share links to their beta maps, which can not be made public.

Before:
![2013_10_18_111113_1075x436](https://f.cloud.github.com/assets/17363/1361452/21c60ba6-3808-11e3-93df-72440fdea21f.png)

After:
![2013_10_18_111312_1072x377](https://f.cloud.github.com/assets/17363/1361456/27f2d28e-3808-11e3-8949-7b130de17d77.png)
