### PR TITLE
Revert only showing elements with content in them, Fixes #757

### DIFF
--- a/opentreemap/treemap/js/src/inlineEditForm.js
+++ b/opentreemap/treemap/js/src/inlineEditForm.js
@@ -195,6 +195,9 @@ exports.init = function(options) {
         },
 
         showValidationErrorsInline = function (errors) {
+            $(validationFields).each(function() {
+                $(this).html('');
+            });
             _.each(errors, function (errorList, fieldName) {
                 FH.getField($(validationFields), fieldName)
                     .html(errorList.join(','));
@@ -234,12 +237,7 @@ exports.init = function(options) {
 
         hideAndShowElements = function (fields, actions, action) {
             if (_.contains(actions, action)) {
-                $(fields).each(function() {
-                    var $field = $(this);
-                    if ($field.html().trim() !== "") {
-                        $field.show();
-                    }
-                });
+                $(fields).show();
             } else {
                 if (action === 'edit:start') {
                     // always hide the applicable runmode buttons

--- a/opentreemap/treemap/templates/treemap/field/diameter_tr.html
+++ b/opentreemap/treemap/templates/treemap/field/diameter_tr.html
@@ -15,8 +15,7 @@
       {% include "treemap/partials/diameter_calculator.html" %}
       </td>
     <td style="display:none;"
-        {% include "treemap/field/attrs.html" with class="error" %}>
-    </td>
+        {% include "treemap/field/attrs.html" with class="error" %}></td>
   {% endif %}
   </tr>
 {% endif %}

--- a/opentreemap/treemap/templates/treemap/field/div.html
+++ b/opentreemap/treemap/templates/treemap/field/div.html
@@ -14,7 +14,6 @@
         </div>
         <div class="alert alert-error text-error"
             style="display: none;"
-            {% include "treemap/field/attrs.html" with class="error" %}>
-        </div>
+            {% include "treemap/field/attrs.html" with class="error" %}></div>
     {% endif %}
 {% endif %}

--- a/opentreemap/treemap/templates/treemap/field/hidden.html
+++ b/opentreemap/treemap/templates/treemap/field/hidden.html
@@ -8,8 +8,7 @@
     <div {% include "treemap/field/attrs.html" with class="edit" %}>
       {% include "treemap/field/inputs.html" %}
     </div>
-    <div {% include "treemap/field/attrs.html" with class="error" %}>
-    </div>
+    <div {% include "treemap/field/attrs.html" with class="error" %}></div>
   {% endif %}
 </div>
 {% endif %}

--- a/opentreemap/treemap/templates/treemap/field/species_div.html
+++ b/opentreemap/treemap/templates/treemap/field/species_div.html
@@ -16,8 +16,7 @@
     </div>
     <div class="alert alert-error text-error"
         style="display: none;"
-        {% include "treemap/field/attrs.html" with class="error"%}>
-    </div>
+        {% include "treemap/field/attrs.html" with class="error"%}></div>
   </div>
   {% endif %}
 {% endif %}

--- a/opentreemap/treemap/templates/treemap/field/species_tr.html
+++ b/opentreemap/treemap/templates/treemap/field/species_tr.html
@@ -22,8 +22,7 @@
     </td>
     <td class="text-error"
         style="display: none;"
-        {% include "treemap/field/attrs.html" with class="error"%}>
-    </td>
+        {% include "treemap/field/attrs.html" with class="error"%}></td>
   </tr>
   {% endif %}
 {% endif %}

--- a/opentreemap/treemap/templates/treemap/field/tr.html
+++ b/opentreemap/treemap/templates/treemap/field/tr.html
@@ -11,8 +11,7 @@
         {% include "treemap/field/inputs.html" %}
       </td>
       <td style="display:none;"
-          {% include "treemap/field/attrs.html" with class="error" %}>
-      </td>
+          {% include "treemap/field/attrs.html" with class="error" %}></td>
     {% endif %}
   </tr>
 {% endif %}


### PR DESCRIPTION
43c12d237e attempted to only show elements when there was content in them,
which broke the UI in several other interesting ways.

Instead we will handle this in CSS with :empty, which is why all error
elements have carefully had spaces removed from them.
