### PR TITLE
Add tooltip to Additional Trunk '+' button

### DIFF
--- a/opentreemap/treemap/templates/treemap/partials/diameter_calculator.html
+++ b/opentreemap/treemap/templates/treemap/partials/diameter_calculator.html
@@ -1,3 +1,4 @@
+{% load i18n %}
 {% load l10n %}
 {% load diameter %}
 
@@ -9,6 +10,7 @@
         {% if not hide_multiple_trunks %}
           <th>
             <a id="add-trunk-row"
+               title="{% trans "Additional Trunk" %}"
                class="btn btn-mini" href="javascript:;"><i class="icon-plus"></i></a>
           </th>
         {% endif %}


### PR DESCRIPTION
addresses #691 on github.

may or may not be a complete fix.
