### PR TITLE
Fixes a few typeahead issues.

### DIFF
--- a/opentreemap/treemap/js/src/modeManagerForMapPage.js
+++ b/opentreemap/treemap/js/src/modeManagerForMapPage.js
@@ -98,8 +98,8 @@ function init(config, mapManager, triggerSearchBus) {
 
 function getSpeciesTypeaheadOptions(config, idPrefix) {
     return {
-        name: "species",
-        url: "/" + config.instance.url + "species",
+        name: "species-edit",
+        url: config.instance.url + "species/",
         input: "#" + idPrefix + "-typeahead",
         template: "#species-element-template",
         hidden: "#" + idPrefix + "-hidden",

--- a/opentreemap/treemap/js/src/searchBar.js
+++ b/opentreemap/treemap/js/src/searchBar.js
@@ -21,7 +21,7 @@ module.exports = exports = {
             $advancedPane = $("#advanced-search-pane");
         otmTypeahead.create({
             name: "species",
-            url: config.instance.url + "species",
+            url: config.instance.url + "species/",
             input: "#species-typeahead",
             template: "#species-element-template",
             hidden: "#search-species",
@@ -31,7 +31,7 @@ module.exports = exports = {
         });
         otmTypeahead.create({
             name: "boundaries",
-            url: config.instance.url + "boundaries",
+            url: config.instance.url + "boundaries/",
             input: "#boundary-typeahead",
             template: "#boundary-element-template",
             hidden: "#boundary",

--- a/opentreemap/treemap/templates/treemap/plot_detail.html
+++ b/opentreemap/treemap/templates/treemap/plot_detail.html
@@ -211,8 +211,8 @@
           addTreeSection: '#add-tree-section',
           treeSection: '#tree-details',
           typeaheads: [{
-              name: "species",
-              url: config.instance.url + "species",
+              name: "species-edit",
+              url: config.instance.url + "species/",
               input: "#plot-species-typeahead",
               template: "#species-element-template",
               hidden: "#plot-species-hidden",


### PR DESCRIPTION
typeahead.js caches it's Datasets by name, so typeaheads sharing names
forced them to share dataset options, which made add a tree continue to
show the list on focus.

We also were missing the trailing '/' on URLs, which was causing two
requests, one for a 301 redirect.
