### PR TITLE
hide diam calc total field when only one trunk

### DIFF
--- a/opentreemap/treemap/js/src/diameterCalculator.js
+++ b/opentreemap/treemap/js/src/diameterCalculator.js
@@ -8,6 +8,8 @@ var $ = require('jquery'),
     _addRowBtnSelector = '#add-trunk-row',
     _tbodySelector = '#diameter-worksheet',
     _trunkRowSelector = '#trunk-row',
+    _totalRowSelector = '#diameter-calculator-total-row',
+    _totalReferenceSelector = '#diameter-calculator-total-reference',
     _totalFieldSelector = 'input[name="tree.diameter"]';
 
 function eventToText(e) {
@@ -80,11 +82,13 @@ function updateTotalDiameter ($parentForm) {
     // to the db with the values from the worksheet
     var $diameterFields = $parentForm.find(_diameterSelector),
         $totalField = $parentForm.find(_totalFieldSelector),
+        $totalReference = $parentForm.find(_totalReferenceSelector),
         diameterValues = _.map($diameterFields,
                                _.compose(textToFloat, elementToText)),
         validValues = _.reject(diameterValues, isNaN),
         totalDiameter = calculateDiameterFromMultiple(validValues);
 
+    $totalReference.html(totalDiameter);
     $totalField.val(totalDiameter);
 }
 
@@ -103,11 +107,16 @@ function createWorksheetRow ($parentForm) {
         html = $templateTr.html(),
         $newEl = $('<tr>').append(html),
         $circEl = $newEl.find(_circumferenceSelector),
-        $diamEl = $newEl.find(_diameterSelector);
+        $diamEl = $newEl.find(_diameterSelector),
+        $totalRow = $(_totalRowSelector);
 
     $diamEl.val('');
     $circEl.val('');
     $tbody.append($newEl);
+
+    // when a row is added, make the total row visible.
+    // it will remain visible thereafter.
+    $totalRow.css('visibility', 'visible');
 }
 
 function updateCorrespondingRowValue ($parentForm, event) {

--- a/opentreemap/treemap/templates/treemap/field/diameter_div.html
+++ b/opentreemap/treemap/templates/treemap/field/diameter_div.html
@@ -4,6 +4,6 @@
 {% block label %}{% trans "Total Trunk Diameter" %}{% endblock %}
 
 {% block inputs %}
-  {% include "treemap/field/inputs.html" with extra='readonly=readonly' %}
+  {% include "treemap/field/inputs.html" with extra='style="display:none"' unit_extra='style="display:none"' %}
   {% include "treemap/partials/diameter_calculator.html" %}
 {% endblock inputs %}

--- a/opentreemap/treemap/templates/treemap/field/diameter_tr.html
+++ b/opentreemap/treemap/templates/treemap/field/diameter_tr.html
@@ -9,9 +9,7 @@
     {% if field.is_editable %}
       <td style="display: none;"
           {% include "treemap/field/attrs.html" with class="edit" %}>
-          {% with 'readonly=readonly' as extras %}
-            {% include "treemap/field/inputs.html" with extra=extras %}
-          {% endwith %}
+          {% include "treemap/field/inputs.html" with extra='style="display:none"' unit_extra='style="display:none"' %}
       {% include "treemap/partials/diameter_calculator.html" %}
       </td>
     <td style="display:none;"

--- a/opentreemap/treemap/templates/treemap/field/inputs.html
+++ b/opentreemap/treemap/templates/treemap/field/inputs.html
@@ -40,7 +40,7 @@
            class="{{ class|default_if_none:"" }}"
            value="{{ field.value|default_if_none:""|unlocalize }}"
            {{ extra|default:"" }} />
-    <span class="add-on">{{ field.units }}</span>
+    <span class="add-on" {{ unit_extra|default:"" }}>{{ field.units }}</span>
   </div>
   {% else %}
     <input name="{{ field.identifier }}"

--- a/opentreemap/treemap/templates/treemap/partials/diameter_calculator.html
+++ b/opentreemap/treemap/templates/treemap/partials/diameter_calculator.html
@@ -36,5 +36,6 @@
   </tbody>
 </table>
 {% if not hide_multiple_trunks %}
+<p id="diameter-calculator-total-row" style="visibility: hidden;">Total Diameter: <span id="diameter-calculator-total-reference">{{ field.value|default_if_none:""|unlocalize }}</span>{% if field.units %} {{ field.units }}{% endif %}</p>
 <a href="http://player.vimeo.com/video/11119129" target="_blank"><i class="icon-videocam"></i> Measuring multiple trunks?</a>
 {% endif %}


### PR DESCRIPTION
fixes #655 on github.

Instead of having a readonly input field, the input field used for the inlineEditForm is now totally hidden. In addition, there is a input field underneath the worksheet that will show the total when multiple trunks are added.
