### PR TITLE
Use more permissive url pattern (allow @.+=) for user profile.

### DIFF
--- a/opentreemap/opentreemap/urls.py
+++ b/opentreemap/opentreemap/urls.py
@@ -10,6 +10,8 @@ from treemap.views import (user_view, root_settings_js_view,
                            unsupported_view, landing_view, scss_view)
 
 from treemap.instance import URL_NAME_PATTERN
+from treemap.urls import USERNAME_PATTERN
+
 instance_pattern = r'^(?P<instance_url_name>' + URL_NAME_PATTERN + r')'
 
 from django.contrib import admin
@@ -30,10 +32,10 @@ urlpatterns = patterns(
     url(r'^', include('geocode.urls')),
     url(r'^$', landing_view),
     url(r'^config/settings.js$', root_settings_js_view),
-    url(r'^users/(?P<username>\w+)/$',
+    url(r'^users/%s/$' % USERNAME_PATTERN,
         route(GET=user_view, PUT=update_user_view), name='user'),
-    url(r'^users/(?P<username>\w+)/edits/$', user_audits_view,
-        name='user_audits'),
+    url(r'^users/%s/edits/$' % USERNAME_PATTERN,
+        user_audits_view, name='user_audits'),
     url(r'^api/v2/', include('api.urls')),
     # The profile view is handled specially by redirecting to
     # the page of the currently logged in user

--- a/opentreemap/treemap/tests/urls.py
+++ b/opentreemap/treemap/tests/urls.py
@@ -73,6 +73,11 @@ class RootUrlTests(UrlTestCase):
         user = make_commander_user(self.instance)
         self.assert_template('/users/%s/' % user.username, 'treemap/user.html')
 
+    def test_user_with_weird_characters(self):
+        self.instance = make_instance()
+        user = make_commander_user(self.instance, username='dot.name-site.com')
+        self.assert_template('/users/%s/' % user.username, 'treemap/user.html')
+
     def test_user_invalid(self):
         self.assert_404('/users/nobody/')
 

--- a/opentreemap/treemap/urls.py
+++ b/opentreemap/treemap/urls.py
@@ -24,7 +24,7 @@ from treemap.views import (boundary_to_geojson_view, index_view, map_view,
 # If you add/remove/modify a URL, please update the corresponding test(s)
 # in treemap/tests/urls.py
 
-username_pattern = r'(?P<username>[\w.@+-]+)'
+USERNAME_PATTERN = r'(?P<username>[\w.@+-]+)'
 
 urlpatterns = patterns(
     '',
@@ -69,6 +69,6 @@ urlpatterns = patterns(
     url(r'^config/settings.js$',
         instance_settings_js_view, name='settings'),
     url(r'^benefit/search$', search_tree_benefits_view),
-    url(r'^users/%s/$' % username_pattern, instance_user_view),
-    url(r'^users/%s/edits/$' % username_pattern, instance_user_audits),
+    url(r'^users/%s/$' % USERNAME_PATTERN, instance_user_view),
+    url(r'^users/%s/edits/$' % USERNAME_PATTERN, instance_user_audits),
 )


### PR DESCRIPTION
PR #774 addressed this for the instance-level urls which redirect to the
site-wide user profile, but missed the urls for the site-wide user profile.
