### PR TITLE
Fix template typo: isntance -> instance

### DIFF
--- a/opentreemap/treemap/templates/treemap/plot_detail.html
+++ b/opentreemap/treemap/templates/treemap/plot_detail.html
@@ -141,7 +141,7 @@
     <div class="span3">
       <button
          disabled="disabled"
-         data-always-enable="{{ last_effective_isntance_user|plot_field_is_writable:"geom" }}"
+         data-always-enable="{{ last_effective_instance_user|plot_field_is_writable:"geom" }}"
          data-disabled-title="{% trans "Editing a plot's location is not available to all users" %}"
          data-href="{{ request.get_full_path }}"
          style="display:none"


### PR DESCRIPTION
fixes #775 on github.

The 'Move Tree' button data-always-enable attribute was always being set to "False" because of this typo, causing the button to remain disabled by the buttonEnabler.
