### PR TITLE
Allow geocoder to work without an instance

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,19 +22,20 @@ module.exports = function(grunt) {
      * are the path to a file, relative to `opentreemap`
      */
     function getAliases() {
-        var aliases = ['treemap/js/src/map.js:map',
-                       'treemap/js/src/user.js:user',
-                       'treemap/js/src/mapManager.js:mapManager',
-                       'treemap/js/src/plot.js:plot',
-                       'treemap/js/src/searchBar.js:searchBar',
+        var aliases = ['treemap/js/src/alerts.js:alerts',
+                       'treemap/js/src/baconUtils.js:BaconUtils',
                        'treemap/js/src/buttonEnabler.js:buttonEnabler',
                        'treemap/js/src/csrf.js:csrf',
-                       'treemap/js/src/photoReview.js:photoReview',
-                       'treemap/js/src/baconUtils.js:BaconUtils',
-                       'treemap/js/src/inlineEditForm.js:inlineEditForm',
+                       'treemap/js/src/geocoder.js:geocoder',
+                       'treemap/js/src/geocoderUi.js:geocoderUi',
                        'treemap/js/src/imageUploadPanel.js:imageUploadPanel',
-                       'treemap/js/src/export.js:export',
-                       'treemap/js/src/alerts.js:alerts',
+                       'treemap/js/src/inlineEditForm.js:inlineEditForm',
+                       'treemap/js/src/map.js:map',
+                       'treemap/js/src/mapManager.js:mapManager',
+                       'treemap/js/src/photoReview.js:photoReview',
+                       'treemap/js/src/plot.js:plot',
+                       'treemap/js/src/searchBar.js:searchBar',
+                       'treemap/js/src/user.js:user',
                        'treemap/js/src/utility.js:utility'];
 
         var extras = require('./extra.json');

--- a/opentreemap/treemap/js/src/geocoder.js
+++ b/opentreemap/treemap/js/src/geocoder.js
@@ -127,7 +127,7 @@ exports = module.exports = function (config) {
         return response;
     };
 
-    var geocodeClient = function(address, box) {
+    var geocodeClient = function(address, filter) {
         var url = '//geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/find';
         var params = {
             'maxLocations': config.geocoder.maxLocations,
@@ -145,7 +145,7 @@ exports = module.exports = function (config) {
                 dataType: 'jsonp'
             }))
             .map(processGeocoderResponse)
-            .map(filterBbox, box);
+            .map(filter);
     };
 
     var reverseGeocodeClient = function(latLng, distance) {
@@ -171,7 +171,8 @@ exports = module.exports = function (config) {
     return {
         geocodeStream: function(addressStream) {
             return addressStream.flatMap(function (address) {
-                return geocodeClient(address, config.instance.extent);
+                var filter = config.instance ? _.partial(filterBbox, config.instance.extent) : _.identity;
+                return geocodeClient(address, filter);
             }).flatMap(function(response) {
                 if (response.candidates && response.candidates.length > 0) {
                     return Bacon.once(response);

--- a/opentreemap/treemap/js/src/mapManager.js
+++ b/opentreemap/treemap/js/src/mapManager.js
@@ -63,8 +63,7 @@ exports.init = function(options) {
             zoom = map.getMaxZoom();
         }
 
-        var ll = U.webMercatorToLatLng(location.x, location.y);
-        map.setView(new L.LatLng(ll.lat, ll.lng),
+        map.setView(U.webMercatorToLeafletLatLng(location.x, location.y),
                     Math.max(map.getZoom(), zoom),
                     {reset: !!reset});
     };

--- a/opentreemap/treemap/js/src/plotMarker.js
+++ b/opentreemap/treemap/js/src/plotMarker.js
@@ -70,8 +70,7 @@ exports = module.exports = {
         var latlng;
 
         if (location.x && location.y) {
-            latlng = U.webMercatorToLatLng(location.x, location.y);
-            latlng = L.latLng(latlng.lat, latlng.lng);
+            latlng = U.webMercatorToLeafletLatLng(location.x, location.y);
         } else {
             latlng = location;
         }

--- a/opentreemap/treemap/js/src/utility.js
+++ b/opentreemap/treemap/js/src/utility.js
@@ -3,6 +3,7 @@
 var url = require('url'),
     QS = require('querystring'),
     $ = require('jquery'),
+    L = require('leaflet'),
     console = require('console-browserify');
 
 exports.getUpdatedQueryString = function (k, v) {
@@ -127,6 +128,12 @@ exports.webMercatorToLatLng = function(x, y) {
     var lat = r2d * ((2.0 * Math.atan(Math.exp(d2r * y / originShift))) - Math.PI / 2.0);
     return {lat: lat, lng: x / originShift};
 
+};
+
+exports.webMercatorToLeafletLatLng = function(x, y) {
+    var latLng = exports.webMercatorToLatLng(x, y),
+        leafletLatLng = L.latLng(latLng.lat, latLng.lng);
+    return leafletLatLng;
 };
 
 exports.lonLatToWebMercator = function(lon, lat) {

--- a/opentreemap/treemap/templates/base.html
+++ b/opentreemap/treemap/templates/base.html
@@ -148,6 +148,16 @@
     {% block templates %}
     {% endblock templates %}
 
+    {% verbatim %}
+    <script id="geocode-results-template" type="text/x-mustache-template">
+      <ul class="unstyled">
+        {{#candidates}}
+        <li><a href="javascript:;" data-class="geocode-result" data-x="{{x}}" data-y="{{y}}" data-srid="{{srid}}" data-address"{{address}}">{{address}}</a></li>
+        {{/candidates}}
+      </ul>
+    </script>
+    {% endverbatim %}
+
     {% block scripts %}
     {% endblock scripts %}
 


### PR DESCRIPTION
- Don't assume there's a config.instance.extent to filter the results
- Move geocode-results-template from instance_base.html to base.html so it can be used without an instance

Also:
- Add and use utility webMercatorToLeafletLatLng()
- Alphabetize aliases in Gruntfile
