### PR TITLE
Drop "recent" from "recent edits"

### DIFF
--- a/opentreemap/api/tests.py
+++ b/opentreemap/api/tests.py
@@ -313,7 +313,7 @@ class PlotListing(TestCase):
         teardownTreemapEnv()
         User.objects.filter(username__in=['peon', 'duke', 'leroi']).delete()
 
-    def test_recent_edits(self):
+    def test_edits(self):
         #TODO: Test recent edits
         return None
         user = self.u

--- a/opentreemap/api/urls.py
+++ b/opentreemap/api/urls.py
@@ -8,7 +8,7 @@ from views import (get_plot_list, create_plot_optional_tree, status,
                    approve_pending_edit, reject_pending_edit, species_list,
                    geocode_address, reset_password, verify_auth,
                    register, add_profile_photo, update_password,
-                   recent_edits)
+                   edits)
 
 from treemap.instance import URL_NAME_PATTERN
 instance_pattern = r'^(?P<instance_url_name>' + URL_NAME_PATTERN + r')'
@@ -48,5 +48,5 @@ urlpatterns = patterns(
     (r'^user/$', route(POST=register)),
     (r'^user/(?P<user_id>\d+)/photo/(?P<title>.+)$', add_profile_photo),
     (r'^user/(?P<user_id>\d+)/password$', update_password),
-    (r'^user/(?P<user_id>\d+)/edits$', recent_edits),
+    (r'^user/(?P<user_id>\d+)/edits$', edits),
 )

--- a/opentreemap/api/views.py
+++ b/opentreemap/api/views.py
@@ -296,7 +296,7 @@ def extract_plot_from_audit(audit):
 @api_call()
 @instance_request
 @login_required
-def recent_edits(request, instance, user_id):
+def edits(request, instance, user_id):
     if (int(user_id) != request.user.pk):
         return create_401unauthorized()
 

--- a/opentreemap/treemap/templates/instance_base.html
+++ b/opentreemap/treemap/templates/instance_base.html
@@ -32,7 +32,7 @@
 </li>
 {% endif %}
 <li class="{% block activerecentedits %}{% endblock %}">
-  <a href="{% url 'recent_edits' instance_url_name=request.instance.url_name %}">{% trans "Recent Edits" %}</a>
+  <a href="{% url 'edits' instance_url_name=request.instance.url_name %}">{% trans "Edits" %}</a>
 </li>
 {% endblock instancetopnav %}
 

--- a/opentreemap/treemap/templates/treemap/edits.html
+++ b/opentreemap/treemap/templates/treemap/edits.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load image %}
 
-{% block page_title %} | {% trans "Recent Edits" %} {{plot.pk}}{% endblock %}
+{% block page_title %} | {% trans "Edits" %} {{plot.pk}}{% endblock %}
 
 {% block activeexplore %}
 {% endblock %}
@@ -29,8 +29,8 @@ active
   <div class="row-fluid">
     <div class="span12">
       <h1>
-        {% trans "Recent Edits" %}
-        <a class="btn pull-right" href="{% url 'recent_edits' instance_url_name=request.instance.url_name %}">{% trans "Reset" %}</a>
+        {% trans "Edits" %}
+        <a class="btn pull-right" href="{% url 'edits' instance_url_name=request.instance.url_name %}">{% trans "Reset" %}</a>
       </h1>
 
       <table class="table table-striped">

--- a/opentreemap/treemap/templates/treemap/photo_review.html
+++ b/opentreemap/treemap/templates/treemap/photo_review.html
@@ -1,7 +1,7 @@
 {% extends "instance_base.html" %}
 {% load i18n %}
 
-{% block page_title %} | {% trans "Recent Edits" %} {{plot.pk}}{% endblock %}
+{% block page_title %} | {% trans "Edits" %} {{plot.pk}}{% endblock %}
 
 {% block content %}
 

--- a/opentreemap/treemap/tests/urls.py
+++ b/opentreemap/treemap/tests/urls.py
@@ -144,9 +144,9 @@ class TreemapUrlTests(UrlTestCase):
         self.make_boundary()
         self.assert_200(self.prefix + 'boundaries/')
 
-    def test_recent_edits(self):
+    def test_edits(self):
         self.assert_template(
-            self.prefix + 'edits/', 'treemap/recent_edits.html')
+            self.prefix + 'edits/', 'treemap/edits.html')
 
     def test_species_list(self):
         self.assert_200(self.prefix + 'species/')

--- a/opentreemap/treemap/tests/views.py
+++ b/opentreemap/treemap/tests/views.py
@@ -31,7 +31,7 @@ from treemap.models import (Instance, Species, User, Plot, Tree, TreePhoto,
                             InstanceUser, BenefitCurrencyConversion)
 
 from treemap.views import (species_list, boundary_to_geojson, plot_detail,
-                           boundary_autocomplete, audits, user_audits,
+                           boundary_autocomplete, edits, user_audits,
                            search_tree_benefits, user, instance_user_view,
                            update_plot_and_tree, update_user, add_tree_photo,
                            root_settings_js_view, instance_settings_js_view,
@@ -1090,7 +1090,7 @@ class RecentEditsViewTest(ViewTestCase):
         req.user = AnonymousUser()
         resulting_audits = [audit.dict()
                             for audit
-                            in audits(req, self.instance)['audits']]
+                            in edits(req, self.instance)['audits']]
 
         self._assert_dicts_equal(dicts, resulting_audits)
 

--- a/opentreemap/treemap/urls.py
+++ b/opentreemap/treemap/urls.py
@@ -8,7 +8,7 @@ from opentreemap.util import route
 
 from treemap.views import (boundary_to_geojson_view, index_view, map_view,
                            get_plot_detail_view, update_plot_detail_view,
-                           instance_settings_js_view, audits_view,
+                           instance_settings_js_view, edits_view,
                            search_tree_benefits_view, species_list_view,
                            boundary_autocomplete_view, instance_user_view,
                            plot_popup_view, instance_user_audits,
@@ -34,7 +34,7 @@ urlpatterns = patterns(
     url(r'^boundaries/(?P<boundary_id>\d+)/geojson/$',
         boundary_to_geojson_view),
     url(r'^boundaries/$', boundary_autocomplete_view),
-    url(r'^edits/$', audits_view, name='recent_edits'),
+    url(r'^edits/$', edits_view, name='edits'),
     url(r'^photo_review/$', photo_review_endpoint),
     url(r'^photo_review/next$', next_photo_endpoint),
     url(r'^photo_review/partial$', photo_review_partial_endpoint),

--- a/opentreemap/treemap/views.py
+++ b/opentreemap/treemap/views.py
@@ -513,7 +513,7 @@ def _get_audits_params(request):
     return (page, page_size, models, model_id, exclude_pending)
 
 
-def audits(request, instance):
+def edits(request, instance):
     """
     Request a variety of different audit types.
     Params:
@@ -985,9 +985,9 @@ def index(request, instance):
         'instance_url_name': instance.url_name}))
 
 
-audits_view = instance_request(
+edits_view = instance_request(
     requires_feature('recent_edits_report')(
-        render_template('treemap/recent_edits.html', audits)))
+        render_template('treemap/edits.html', edits)))
 
 index_view = instance_request(index)
 


### PR DESCRIPTION
The edits view is intended to be paged through, sorted and filtered so including the word recent is a little misleading.

I changed the name of the view function and the template name for consistency.

I did not rename the recent_edits_report feature string since it is an arbitrary name and would require a more complicated multi-repo change.

I did not rename "recent edits" on the plot detail page because it is truly a list of the 5 most recent edits.

Fixes #793
