### PR TITLE
Template tag "partial.py" renders template with sub-dict of context

### DIFF
--- a/opentreemap/treemap/templatetags/partial.py
+++ b/opentreemap/treemap/templatetags/partial.py
@@ -1,0 +1,36 @@
+# Modified from https://djangosnippets.org/snippets/1302/
+
+from django.template import Library, Node, Variable, loader
+from django.template.context import Context
+
+register = Library()
+
+
+class PartialNode(Node):
+    def __init__(self, template, context_item):
+        self.template = template
+        self.context_item = Variable(context_item)
+
+    def render(self, context):
+        item = self.context_item.resolve(context)
+        template_context = Context(item)
+        return self.template.render(template_context)
+
+
+@register.tag
+def partial(parser, token):
+    """
+    Renders a template using a sub-dict of the current context.
+    For example, if the context is:
+       {'car': {'mileage': 9000, 'doors': 4},
+        'house': {'sqft': 1800, 'baths': 2}}
+    and the template "myApp/partials/house.html" contains:
+        <div>Area: {{ sqft }} sq. ft.</div>
+        <div>Bathrooms: {{ baths }}</div>
+    you could render it like this:
+        {% load partial %}
+        {% partial myApp/partials/house.html house %}
+    """
+    tag, template_name, context_item = token.split_contents()
+    template = loader.get_template(template_name)
+    return PartialNode(template, context_item)

--- a/opentreemap/treemap/tests/templatetags.py
+++ b/opentreemap/treemap/tests/templatetags.py
@@ -15,6 +15,7 @@ from shutil import rmtree
 
 from treemap.audit import FieldPermission, Role
 from treemap.json_field import set_attr_on_json_field
+from treemap.templatetags.partial import PartialNode
 from treemap.udf import UserDefinedFieldDefinition
 from treemap.models import Plot, InstanceUser
 from treemap.tests import (make_instance, make_observer_user,
@@ -624,3 +625,21 @@ class DiameterTagsTest(TestCase):
         """
         rt = self.template.render(Context({'value': None}))
         self.assertEqual(rt, '')
+
+
+class PartialTagTest(TestCase):
+    def _assert_renders_as(self, template_text, subdict_name, expected):
+        context = Context({
+            'mine': {'val': 'yes'},
+            'yours': {'val': 'no'}
+        })
+        template = Template(template_text)
+        partialNode = PartialNode(template, subdict_name)
+        text = partialNode.render(context)
+        self.assertEqual(text, expected)
+
+    def test_template_can_reference_subdict_value(self):
+        self._assert_renders_as("{{ val }}", 'mine', 'yes')
+
+    def test_template_cannot_reference_dict_value(self):
+        self._assert_renders_as("{{ yours }}", 'mine', '')


### PR DESCRIPTION
When rendering a complex page using many partial templates, it's simpler to give the partials a subdict of the context rather than the entire context.

For example, if the context is:

``` python
{'car': {'mileage': 9000, 'doors': 4},
 'house': {'sqft': 1800, 'baths': 2}}
```

and the template "myApp/partials/house.html" contains:

``` html
<div>Area: {{ sqft }} sq. ft.</div>
<div>Bathrooms: {{ baths }}</div>
```

you could render it like this:

``` html
{% load partial %}
{% partial myApp/partials/house.html house %}
```
