### PR TITLE
Include contents of static file version.txt as page header comment

### DIFF
--- a/opentreemap/opentreemap/context_processors.py
+++ b/opentreemap/opentreemap/context_processors.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.contrib.staticfiles import finders
 
 from treemap.util import get_last_visited_instance
 
@@ -15,10 +16,18 @@ def global_settings(request):
     else:
         logo_url = settings.STATIC_URL + "img/logo-beta.png"
 
+    try:
+        comment_file_path = finders.find('version.txt')
+        with open(comment_file_path, 'r') as f:
+            header_comment = f.read()
+    except:
+        header_comment = "Version information not available\n"
+
     ctx = {'SITE_ROOT': settings.SITE_ROOT,
            'settings': settings,
            'last_instance': last_instance,
            'last_effective_instance_user': last_effective_instance_user,
-           'logo_url': logo_url}
+           'logo_url': logo_url,
+           'header_comment': header_comment}
 
     return ctx

--- a/opentreemap/treemap/static/version.txt
+++ b/opentreemap/treemap/static/version.txt
@@ -1,0 +1,1 @@
+OpenTreeMap

--- a/opentreemap/treemap/templates/base.html
+++ b/opentreemap/treemap/templates/base.html
@@ -2,6 +2,8 @@
 {% load instance_config %}
 
 <!DOCTYPE html>
+<!--
+{{ header_comment }}-->
 <html>
   <head>
     <meta charset="utf-8">


### PR DESCRIPTION
- File treemap/static/version.txt has a default header comment
- Build systems can overwrite this file with specific info about the build
- base.html template inlines it as a header comment
- The file can also be referenced from a browser as http://<site>/version.txt
