### PR TITLE
Add uitest option to use a real browser

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -153,7 +153,7 @@ def test(test_filter=""):
 
     _manage('test --settings=opentreemap.test_settings %s' % test_filter)
 
-def uitest(skip_debug_check=None):
+def uitest(skip_debug_check=None, use_x=None):
     """ Run selenium UI tests """
     require('site_path')
     require('venv_path')
@@ -163,7 +163,12 @@ def uitest(skip_debug_check=None):
     else:
         skip_debug_check = ''
 
-    _manage('uitest %s' % skip_debug_check)
+    if use_x:
+        use_x = '--use-x'
+    else:
+        use_x = ''
+            
+    _manage('uitest %s %s' % (skip_debug_check, use_x))
 
 def restart_app():
     """ Restart the gunicorns running the app """

--- a/opentreemap/treemap/management/commands/uitest.py
+++ b/opentreemap/treemap/management/commands/uitest.py
@@ -23,7 +23,12 @@ class Command(BaseCommand):
         make_option('-s', '--skip-debug-check',
                     action='store_true',
                     dest='skip_debug',
-                    help='skip the debug'), )
+                    help='skip the debug'),
+        make_option('-x', '--use-x',
+                    action='store_true',
+                    dest='use_x',
+                    help='use X windows rather '
+                         'than a virtual distplay'), )
 
     def handle(self, *args, **options):
         if settings.DEBUG is False and not options['skip_debug']:
@@ -33,8 +38,9 @@ class Command(BaseCommand):
                             'leave extra data behind (such as users) or '
                             'delete data that already exists.')
 
-        disp = Display(visible=0, size=(800, 600))
-        disp.start()
+        if not options['use_x']:
+            disp = Display(visible=0, size=(800, 600))
+            disp.start()
 
         errors = False
         for module in settings.UITESTS:
@@ -49,7 +55,8 @@ class Command(BaseCommand):
             finally:
                 if hasattr(uitests, 'tearDownModule'):
                     uitests.tearDownModule()
-                disp.stop()
+                if not options['use_x']:
+                    disp.stop()
 
             if not rslt.wasSuccessful():
                 errors = True


### PR DESCRIPTION
When debugging ui tests it is helpful to watch the browser as the test progresses.
