### PR TITLE
Save address fields when plots are moved

### DIFF
--- a/opentreemap/treemap/js/src/addTreeMode.js
+++ b/opentreemap/treemap/js/src/addTreeMode.js
@@ -6,6 +6,8 @@ var $ = require('jquery'),
     U = require('treemap/utility'),
     Bacon = require('baconjs'),
     otmTypeahead = require('treemap/otmTypeahead'),
+    reverseGeocodeStreamAndUpdateAddressesOnForm =
+        require('treemap/reverseGeocodeStreamAndUpdateAddressesOnForm'),
     geocoder = require('treemap/geocoder'),
     geocoderUi = require('treemap/geocoderUi'),
     enterOrClickEventStream = require('treemap/baconUtils').enterOrClickEventStream,
@@ -132,7 +134,10 @@ function init(options) {
     });
 
     var markerMoveStream = plotMarker.moveStream.filter(options.inMyMode);
-    var reverseGeocodeStream = gcoder.reverseGeocodeStream(markerMoveStream);
+    var reverseGeocodeStream =
+            reverseGeocodeStreamAndUpdateAddressesOnForm(
+                config, markerMoveStream, formSelector);
+
     reverseGeocodeStream.map(reverseGeocodeResponseToAddressString)
                         .onValue($address, 'val');
     reverseGeocodeStream.onError($address, 'val', '');

--- a/opentreemap/treemap/js/src/editTreeDetailsMode.js
+++ b/opentreemap/treemap/js/src/editTreeDetailsMode.js
@@ -4,10 +4,13 @@ var $ = require('jquery'),
     _ = require('underscore'),
     otmTypeahead = require('treemap/otmTypeahead'),
     plotMover = require('treemap/plotMover'),
-    diameterCalculator = require('treemap/diameterCalculator');
+    diameterCalculator = require('treemap/diameterCalculator'),
+    reverseGeocodeStreamAndUpdateAddressesOnForm =
+        require('treemap/reverseGeocodeStreamAndUpdateAddressesOnForm');
 
 
-var mapManager,
+var formSelector = '#details-form',
+    mapManager,
     inlineEditForm,
     typeaheads,
     plotMarker,
@@ -18,6 +21,10 @@ function init(options) {
     inlineEditForm = options.inlineEditForm;
     typeaheads = options.typeaheads;
     plotMarker = options.plotMarker;
+
+    var markerMoveStream = plotMarker.moveStream.filter(options.inMyMode);
+    reverseGeocodeStreamAndUpdateAddressesOnForm(
+        options.config, markerMoveStream, formSelector);
 }
 
 function activate() {
@@ -35,7 +42,7 @@ function activate() {
     });
 
     calculator = diameterCalculator({
-        formSelector: '#details-form',
+        formSelector: formSelector,
         cancelStream: inlineEditForm.cancelStream,
         saveOkStream: inlineEditForm.saveOkStream
     });
@@ -58,4 +65,3 @@ module.exports = {
     deactivate: deactivate,
     onSaveBefore: onSaveBefore
 };
-

--- a/opentreemap/treemap/js/src/modeManagerForMapPage.js
+++ b/opentreemap/treemap/js/src/modeManagerForMapPage.js
@@ -41,6 +41,7 @@ function activateEditTreeDetailsMode() { activateMode(editTreeDetailsMode, $side
 
 function inBrowseTreesMode() { return currentMode === browseTreesMode; }
 function inAddTreeMode()     { return currentMode === addTreeMode; }
+function inEditTreeMode()    { return currentMode === editTreeDetailsMode; }
 
 function init(config, mapManager, triggerSearchBus) {
     // browseTreesMode and editTreeDetailsMode share an inlineEditForm,
@@ -91,9 +92,11 @@ function init(config, mapManager, triggerSearchBus) {
     });
 
     editTreeDetailsMode.init({
+        config: config,
         mapManager: mapManager,
         inlineEditForm: form,
         plotMarker: plotMarker,
+        inMyMode: inEditTreeMode,
         typeaheads: [getSpeciesTypeaheadOptions(config, "edit-tree-species")]
     });
 }

--- a/opentreemap/treemap/js/src/plot.js
+++ b/opentreemap/treemap/js/src/plot.js
@@ -13,6 +13,8 @@ var $ = require('jquery'),
     plotMarker = require('treemap/plotMarker'),
     csrf = require('treemap/csrf'),
     imageUploadPanel = require('treemap/imageUploadPanel'),
+    reverseGeocodeStreamAndUpdateAddressesOnForm =
+        require('treemap/reverseGeocodeStreamAndUpdateAddressesOnForm'),
     streetView = require('treemap/streetView'),
     diameterCalculator = require('treemap/diameterCalculator'),
     History = require('history');
@@ -102,6 +104,9 @@ exports.init = function(options) {
     });
 
     plotMarker.init(options.config, mapManager.map);
+
+    reverseGeocodeStreamAndUpdateAddressesOnForm(
+        options.config, plotMarker.moveStream, '#plot-form');
 
     plotMover.init({
         mapManager: mapManager,

--- a/opentreemap/treemap/js/src/reverseGeocodeStreamAndUpdateAddressesOnForm.js
+++ b/opentreemap/treemap/js/src/reverseGeocodeStreamAndUpdateAddressesOnForm.js
@@ -1,0 +1,24 @@
+"use strict";
+
+var geocoder = require('treemap/geocoder'),
+    _ = require('underscore'),
+    $ = require('jquery');
+
+module.exports = function(config, triggerStream, formSelector) {
+    var gcoder = geocoder(config);
+    var reverseGeocodeStream = gcoder.reverseGeocodeStream(triggerStream);
+    reverseGeocodeStream.onValue(function(geocode) {
+        // Grab the applicaable values
+        var updates = {'plot.address_street': geocode.address.Address,
+                       'plot.address_city': geocode.address.City,
+                       'plot.address_zip': geocode.address.Postal};
+
+        // Apply the updates to the form
+        var $form = $(formSelector);
+        _.each(updates, function(value, key) {
+            $form.find("input[name='" + key + "']").val(value);
+        });
+    });
+
+    return reverseGeocodeStream;
+};

--- a/opentreemap/treemap/templates/treemap/map-add-tree.html
+++ b/opentreemap/treemap/templates/treemap/map-add-tree.html
@@ -28,6 +28,11 @@
           {% for label, identifier in fields_for_add_tree %}
               {% create label from identifier in request.instance withtemplate "treemap/field/div.html" %}
           {% endfor %}
+
+          <input type="hidden" name="plot.address_street">
+          <input type="hidden" name="plot.address_city">
+          <input type="hidden" name="plot.address_zip">
+
         </form>
     </div>
     <div class="add-step">

--- a/opentreemap/treemap/templates/treemap/plot_accordion.html
+++ b/opentreemap/treemap/templates/treemap/plot_accordion.html
@@ -15,4 +15,8 @@
     {% field height from "tree.height" for request.user withtemplate "treemap/field/div.html" %}
     {% endif %}
 
+    <input type="hidden" name="plot.address_street" value="{{ plot.address_street}}">
+    <input type="hidden" name="plot.address_city" value="{{ plot.address_city}}">
+    <input type="hidden" name="plot.address_zip" value="{{ plot.address_zip}}">
+
 </form>


### PR DESCRIPTION
Includes the following places:
- Create a new tree on map page
- "Quick edit" on map page
- Edit details page

This introduces a transitive dependency where editing will fail if the
user has permissions on plot.geom but not on plot.address_*.

Fixes #341
