### PR TITLE
Fix regex error breaking management page

### DIFF
--- a/opentreemap/treemap/templatetags/form_extras.py
+++ b/opentreemap/treemap/templatetags/form_extras.py
@@ -25,7 +25,7 @@ register = template.Library()
 # model.udf:field name, can't be done in the grammar as it can't be checked
 # until looked up in the context
 _identifier_regex = re.compile(
-    r"^[a-zA-Z_]+\.(?:udf\:[\w '\._-]+|[a-zA-Z_]+)$")
+    r"^[a-zA-Z_.\-]+(?:udf\:[\w '\._-]+|[a-zA-Z_\-]+)$")
 
 
 class Variable(Grammar):


### PR DESCRIPTION
Introduced in 5c7162509fc

The change prevented nested lookups:
instance.config.linkData

And dashes:
instance.scss-colop
