### PR TITLE
Larger OTM logo in header

### DIFF
--- a/opentreemap/treemap/css/sass/partials/_header.scss
+++ b/opentreemap/treemap/css/sass/partials/_header.scss
@@ -24,8 +24,8 @@
     position: relative;
 
     img {
-        max-width: 225px;
-        max-height: 65px;
+        max-width: 300px;
+        max-height: 78px;
     }
 }
 


### PR DESCRIPTION
Not much to see, just needed to make the logo image's max dimension's bigger.
