### PR TITLE
Hide/show messages during "Add Tree" session per @dboyer (fixes #741)

### DIFF
--- a/opentreemap/treemap/templates/treemap/map-add-tree.html
+++ b/opentreemap/treemap/templates/treemap/map-add-tree.html
@@ -6,7 +6,7 @@
     <h3>{% trans "Add a Tree" %}</h3>
     <div class="add-step">
         <h4>1. {% trans "Set the tree’s location" %}</h4>
-        <small>{% trans "Search by address or use your current location, then drag the marker to the correct location. Or click the map." %}</small>
+        <div class="alert alert-info place-marker-message">{% trans "Choose a point on the map, or search by address, or use current location." %}</div>
         {# Making onsubmit return false prevents the form from being submitted. We want to run JS code instead #}
         <form class="form-search" onsubmit="return false;">
             <input type="text" class="search-query" id="add-tree-address" placeholder="{% trans 'Address, City, State' %}">
@@ -15,7 +15,7 @@
         <a class="geolocate"><i class="icon-direction"></i> Use Current Location</a>
         <div class="alert alert-error text-error geocode-error" style="display: none;">{% trans "Unable to locate this address" %}</div>
         <div class="alert alert-error text-error geolocate-error" style="display: none;">{% trans "Unable to determine current location" %}</div>
-        <div class="alert alert-info move-tree-message" style="display: none;">{% trans "Please move the plot marker to continue" %}</div>
+        <div class="alert alert-info move-marker-message" style="display: none;">{% trans "Please move marker to exact location of tree." %}</div>
     </div>
     <div class="add-step">
         <h4>2. {% trans "Additional information" %}</h4>


### PR DESCRIPTION
- Show "place" message when entering "Add Tree" mode.
- Hide "place" message when marker is placed by click, geolocate, or address search
- Show "move" message when marker is placed by geolocate or address search, or when user adds another tree
- Hide "move" message when user moves marker
