### PR TITLE
Limit photo selection to images. Fixes #296.

### DIFF
--- a/opentreemap/treemap/templates/treemap/partials/upload_image.html
+++ b/opentreemap/treemap/templates/treemap/partials/upload_image.html
@@ -4,7 +4,7 @@
     <h2>{{ title }}</h2>
   </div>
   <div class="modal-body">
-    <input class="fileChooser" type="file" name="file" data-url="{{ endpoint }}">
+    <input class="fileChooser" type="file" name="file" data-url="{{ endpoint }}" accept="image/*">
     <div class="progress">
       <div class="bar-info" style="width: 0%; height: 100%"></div>
     </div>


### PR DESCRIPTION
This generally makes the file picker only accept image types. The
backend does additional checks since this cannot be relied upon.
