### PR TITLE
Add fabric support for code coverage

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 PyVirtualDisplay==0.1.2
 selenium==2.37.0
+coverage==3.7


### PR DESCRIPTION
When running either UI or regular tests specify:

```
coverage=True
```

And a text coverage report will be printed to stdout and a tar called
"coverage.tar.gz" will be downloaded that contains html report.
