### PR TITLE
Add exit prompt when leaving unsaved changes

### DIFF
--- a/opentreemap/treemap/js/src/addTreeMode.js
+++ b/opentreemap/treemap/js/src/addTreeMode.js
@@ -343,5 +343,6 @@ module.exports = {
     name: 'addTree',
     init: init,
     activate: activate,
-    deactivate: deactivate
+    deactivate: deactivate,
+    lockOnActivate: true
 };

--- a/opentreemap/treemap/js/src/editTreeDetailsMode.js
+++ b/opentreemap/treemap/js/src/editTreeDetailsMode.js
@@ -64,5 +64,6 @@ module.exports = {
     init: init,
     activate: activate,
     deactivate: deactivate,
-    onSaveBefore: onSaveBefore
+    onSaveBefore: onSaveBefore,
+    lockOnActivate: true
 };

--- a/opentreemap/treemap/js/src/plot.js
+++ b/opentreemap/treemap/js/src/plot.js
@@ -12,6 +12,7 @@ var $ = require('jquery'),
     plotMover = require('treemap/plotMover'),
     plotDelete = require('treemap/plotDelete'),
     plotMarker = require('treemap/plotMarker'),
+    statePrompter = require('treemap/statePrompter'),
     csrf = require('treemap/csrf'),
     imageUploadPanel = require('treemap/imageUploadPanel'),
     reverseGeocodeStreamAndUpdateAddressesOnForm =
@@ -32,6 +33,11 @@ exports.init = function(options) {
     $.ajaxSetup(csrf.jqueryAjaxSetupOptions);
 
     otmTypeahead.bulkCreate(options.typeaheads);
+
+    var prompter = statePrompter.init({
+        warning: options.config.exitWarning,
+        question: options.config.exitQuestion
+    });
 
     // Add threaded comments "reply" links
     var commentFormTempl = $("#template-comment").html();
@@ -114,10 +120,16 @@ exports.init = function(options) {
     form.inEditModeProperty.onValue(function(inEditMode) {
         var hrefHasEdit = U.getLastUrlSegment() === 'edit';
 
-        if (inEditMode && !hrefHasEdit) {
-            History.replaceState(null, '', U.appendSegmentToUrl('edit'));
-        } else if (!inEditMode && hrefHasEdit) {
-            History.replaceState(null, '', U.removeLastUrlSegment());
+        if (inEditMode) {
+            prompter.lock();
+            if (!hrefHasEdit) {
+                History.replaceState(null, '', U.appendSegmentToUrl('edit'));
+            }
+        } else {
+            prompter.unlock();
+            if (hrefHasEdit) {
+                History.replaceState(null, '', U.removeLastUrlSegment());
+            }
         }
     });
 

--- a/opentreemap/treemap/js/src/statePrompter.js
+++ b/opentreemap/treemap/js/src/statePrompter.js
@@ -1,0 +1,47 @@
+"use strict";
+
+var _locked,
+    _warning,
+    _question,
+    _externalBeforeUnload;
+
+function lock () {
+    if (_locked === false) {
+        _locked = true;
+        // don't clobber onbeforeunload in case it's used elsewhere
+        _externalBeforeUnload = window.onbeforeunload || null;
+        window.onbeforeunload = function () { return _warning; };
+    }
+}
+
+function unlock () {
+    if (_locked === true) {
+        _locked = false;
+        window.onbeforeunload = _externalBeforeUnload || null;
+    }
+}
+
+function canProceed() {
+    // if a runmode in the app has turned on the lock, prompt before continuing
+    // this function can be used inside any function that will change runmodes
+    // and it resembles the behavior of window.onbeforeunload
+    return _locked === true ?
+        window.confirm(_warning + ' ' + _question) : true;
+}
+
+exports.init = function (options) {
+
+    if (_warning || _question) {
+        throw ("Cannot initialize module multiple times.");
+    }
+
+    _locked = false;
+    _warning = options.warning;
+    _question = options.question;
+
+    return {
+        canProceed: canProceed,
+        unlock: unlock,
+        lock: lock
+    };
+};

--- a/opentreemap/treemap/templates/treemap/settings.js
+++ b/opentreemap/treemap/templates/treemap/settings.js
@@ -50,6 +50,10 @@ otm.settings.errorMessages.default = otm.settings.errorMessages['500'];
 
 otm.settings.doubleClickInterval = '{{ settings.DOUBLE_CLICK_INTERVAL }}';
 
+{# this has to be broken into two sections because window.onbeforeunload has a default but confirm() does not #}
+otm.settings.exitWarning = '{% trans "You have begun entering data. Any unsaved changes will be lost." %}';
+otm.settings.exitQuestion = '{% trans "Are you sure you want to continue?" %}';
+
 {% if request.instance %}
     otm.settings.instance = {
         'id': '{{ request.instance.id }}',

--- a/opentreemap/treemap/tests/ui/__init__.py
+++ b/opentreemap/treemap/tests/ui/__init__.py
@@ -116,7 +116,7 @@ class TreemapUITestCase(UITestCase):
         actions.click()
         actions.perform()
 
-    def _start_add_tree_and_click_point(self, x, y):
+    def _start_add_tree(self):
         # Enter add tree mode
 
         add_tree = self.driver.find_elements_by_css_selector(
@@ -124,6 +124,8 @@ class TreemapUITestCase(UITestCase):
 
         add_tree.click()
 
+    def _start_add_tree_and_click_point(self, x, y):
+        self._start_add_tree()
         self._click_point_on_map(x, y)
 
     def instance_trees(self):


### PR DESCRIPTION
When leaving certain data entry modes, including but not limited to 'Add Tree' and 'Edit Tree', you can now lock the page so that the user will be prompted before leaving the page, or before leaving that particular edit mode.
