### PR TITLE
Add more information to instance info endpoint

### DIFF
--- a/opentreemap/treemap/templates/treemap/map-add-tree.html
+++ b/opentreemap/treemap/templates/treemap/map-add-tree.html
@@ -21,7 +21,7 @@
         <h4>2. {% trans "Additional information" %}</h4>
         <form id="add-tree-form" onsubmit="return false;">
           {# The "add-tree-species" label is used as an id prefix in "species_ul.html" #}
-          {% create "add-tree-species" from "tree.species" withtemplate "treemap/field/species_div.html" %}
+          {% create "add-tree-species" from "tree.species" in request.instance withtemplate "treemap/field/species_div.html" %}
           {% create "add-tree-diameter" from "tree.diameter" in request.instance withtemplate "treemap/field/diameter_div.html" %}
 
           {% for label, identifier in fields_for_add_tree %}

--- a/opentreemap/treemap/tests/udfs.py
+++ b/opentreemap/treemap/tests/udfs.py
@@ -522,7 +522,7 @@ class ScalarUDFDefTest(TestCase):
         with self.assertRaises(ValidationError):
             self._create_and_save_with_datatype(
                 {'type': 'choice',
-                'choices': [0, 1, 3, 4, 5]})
+                 'choices': [0, 1, 3, 4, 5]})
 
     def test_can_create_subfields(self):
         self._create_and_save_with_datatype(

--- a/opentreemap/treemap/units.py
+++ b/opentreemap/treemap/units.py
@@ -75,6 +75,20 @@ def get_value_display_attr(instance, category_name, value_name, key):
     return identifier, value
 
 
+def get_units_if_convertible(instance, category_name, value_name):
+    if is_convertible(category_name, value_name):
+        return get_units(instance, category_name, value_name)
+    else:
+        return ''
+
+
+def get_digits_if_formattable(instance, category_name, value_name):
+    if is_formattable(category_name, value_name):
+        return get_digits(instance, category_name, value_name)
+    else:
+        return ''
+
+
 def get_units(instance, category_name, value_name):
     _, units = get_value_display_attr(
         instance, category_name, value_name, 'units')


### PR DESCRIPTION
Most of what we want is similar to the "form_extras" tags that we use in
our templates so part of this commit refactors for edits to share code
directly with the API.

This also fixes an bug where a model without an instance but with unit
data would crash the template tags.
