### PR TITLE
Support for external MapFeature subclasses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ opentreemap/.idea
 node_modules/
 opentreemap/beta
 opentreemap/cloud_management
+opentreemap/map_features
 opentreemap/super_admin
 opentreemap/treemap/static/js/
 opentreemap/treemap/static/css/
@@ -26,3 +27,4 @@ prototype/css/.sass-cache
 local/
 
 opentreemap/treemap/management/commands/extracollect.py
+

--- a/opentreemap/treemap/util.py
+++ b/opentreemap/treemap/util.py
@@ -199,3 +199,14 @@ def save_uploaded_image(image_data, name_prefix, thumb_size=None):
         return image_file, thumb_file
     except:
         raise ValidationError(trans('Image upload issue'))
+
+
+def leaf_subclasses(cls):
+    """Return all leaf subclasses of given class"""
+    def get(c):
+        subclasses = c.__subclasses__()
+        return subclasses + sum([get(s) for s in subclasses], [])
+
+    all = get(cls)
+    leaves = [s for s in all if not s.__subclasses__()]
+    return leaves


### PR DESCRIPTION
Use Python's **subclasses**() to identify subclasses
- of MapFeature, when creating permissions for testing
- of Auditable and Authorizable, for finding model classes based on class name
