### PR TITLE
Fix tree photo review

### DIFF
--- a/opentreemap/treemap/views.py
+++ b/opentreemap/treemap/views.py
@@ -995,7 +995,7 @@ def photo_review(request, instance):
     if next_page > total_pages:
         next_page = None
 
-    pages = xrange(1, total_pages+1)
+    pages = range(1, total_pages+1)
     if len(pages) > 10:
         pages = pages[0:8] + [pages[-1]]
 


### PR DESCRIPTION
Fixes issue #686 on the internal tracker.

We should only review photos that haven't already been deleted.

Also fixes a separate undiscovered bug in the same function, where there was an uncaught exception for more than 10 pages of results.
