### PR TITLE
Allow address search after polygon search

### DIFF
--- a/opentreemap/treemap/js/src/otmTypeahead.js
+++ b/opentreemap/treemap/js/src/otmTypeahead.js
@@ -38,16 +38,11 @@ function setTypeaheadAfterDataLoaded($typeahead, key, query) {
 
 function eventToTargetValue(e) { return $(e.target).val(); }
 
-function inputProperty($input) {
+function inputStream($input) {
     return $input.asEventStream('input')
-                 .map(eventToTargetValue)
-                 .toProperty();
+                 .map(eventToTargetValue);
 }
 
-
-function firstIfSecondIsEmptyElseEmpty (first, second) {
-    return second === "" ? first : "";
-}
 
 exports.getDatum = function($typeahead) {
     return $typeahead.data('datum');
@@ -98,9 +93,8 @@ var create = exports.create = function(options) {
     // Set data-unmatched to the input value if the value was not
     // matched to a typeahead datum. Allows for external code to take
     // alternate action if there is no typeahead match.
-    inputProperty($input)
-        .combine(idStream.toProperty("").skipDuplicates(),
-                 firstIfSecondIsEmptyElseEmpty)
+    inputStream($input)
+        .merge(idStream.map(""))
         .onValue($input, 'attr', 'data-unmatched');
 
     if (options.hidden) {


### PR DESCRIPTION
We support arbitrary address search by detecting when a typeahead did
not match a valid choice. In such a case a 'data-unmatched' attribute
was set on the typeahead.

The code looked something like:

``` js
inputStream($input)
  .combine(idStream.toProperty("").skipDuplicates(),
    firstIfSecondIsEmptyElseEmpty)
  .onValue($input, 'attr', 'data-unmatched');
```

However, the idStream sticks on the last value which is what led to this
bug. For instance, if idStream was set to '2900' because of a successful
match the combinator would never trigger the `onValue` with a proper
values.

The solution is to `merge` the streams. Whenever a selection is made the
`data-unmatched` attribute is cleared and whenever a change is made to
the input it is put back.

Fixes #1062
