### PR TITLE
Include eco benefit detail in API responses

### DIFF
--- a/opentreemap/api/instance.py
+++ b/opentreemap/api/instance.py
@@ -136,9 +136,26 @@ def _instance_info_dict(instance):
             'name': instance.name,
             'center': {'lat': center.y,
                        'lng': center.x},
+            'eco': _instance_eco_dict(instance)
             }
 
     if hasattr(instance, 'distance'):
         info['distance'] = instance.distance.km
 
     return info
+
+
+def _instance_eco_dict(instance):
+    return {
+        "supportsEcoBenefits": instance.has_itree_region(),
+        #  All instances have the same ecobenefits and
+        #  the mobile apps do not need any details to render
+        #  fields for displaying per-feature eco values.
+        "benefits": [
+            {"label": "Energy"},
+            {"label": "Stormwater"},
+            {"label": "Carbon Dioxide"},
+            {"label": "Carbon Dioxide Stored"},
+            {"label": "Air Quality"}
+        ]
+    }

--- a/opentreemap/treemap/templates/treemap/partials/eco_benefits.html
+++ b/opentreemap/treemap/templates/treemap/partials/eco_benefits.html
@@ -19,7 +19,7 @@
         <dt>{{ benefit.value }}</dt>
         <dd>{{ benefit.unit }}</dd>
         {% if benefit.currency_saved %}
-          <dt>{{ currency_symbol }}{{ benefit.currency_saved }}</dt>
+          <dt>{{ benefit.currency_saved }}</dt>
           <dd>
             {% comment %}Translators: Money saved{% endcomment %}
             {% trans "saved" %}

--- a/opentreemap/treemap/templates/treemap/partials/plot_eco.html
+++ b/opentreemap/treemap/templates/treemap/partials/plot_eco.html
@@ -14,7 +14,7 @@
     <tr>
       <td>{{ benefit.label }}</td>
       <td>{{ benefit.value }} {{ benefit.unit}}</td>
-      <td>{{ currency_symbol }}{{ benefit.currency_saved }}</td>
+      <td>{{ benefit.currency_saved }}</td>
     </tr>
     {% endfor %}
   </tbody>

--- a/opentreemap/treemap/views.py
+++ b/opentreemap/treemap/views.py
@@ -892,11 +892,15 @@ def _tree_benefits_helper(trees, total_plots, total_trees, instance):
 def _format_benefits(instance, benefits, num_calculated_trees,
                      total_trees=1, total_plots=1):
 
-    def displayize_benefit(key):
+    def displayize_benefit(key, currency_symbol=None):
         benefit = benefits[key]
 
         if benefit['currency'] is not None:
-            benefit['currency_saved'] = number_format(
+            if not currency_symbol:
+                #  Ensure that None is converted into an empty string
+                currency_symbol = ""
+            # TODO: Use i18n/l10n to format currency
+            benefit['currency_saved'] = currency_symbol + number_format(
                 benefit['currency'], decimal_pos=0)
 
         _, value = get_display_value(instance, 'eco', key, benefit['value'])
@@ -917,13 +921,9 @@ def _format_benefits(instance, benefits, num_calculated_trees,
     if instance.eco_benefits_conversion:
         currency = instance.eco_benefits_conversion.currency_symbol
 
-    benefits_for_display = [
-        displayize_benefit('energy'),
-        displayize_benefit('stormwater'),
-        displayize_benefit('co2'),
-        displayize_benefit('co2storage'),
-        displayize_benefit('airquality')
-    ]
+    benefit_keys = ['energy', 'stormwater', 'co2', 'co2storage', 'airquality']
+    benefits_for_display = [displayize_benefit(key, currency)
+                            for key in benefit_keys]
 
     rslt = {'benefits': benefits_for_display,
             'currency_symbol': currency,


### PR DESCRIPTION
I needed two additional pieces of information to allow the iOS
application to correctly display eco benefits on a plot detail view.
1. The instance details need to declare the eco fields that can be
   displayed.
2. The plot details need to include the configured currency symbol in
   the formatted amount saved field. This keeps all the currency
   formatting on the server side.
