### PR TITLE
Make tree tiles appear faster on load

### DIFF
--- a/opentreemap/treemap/js/src/mapManager.js
+++ b/opentreemap/treemap/js/src/mapManager.js
@@ -75,16 +75,19 @@ exports.init = function(options) {
                          reset);
     };
 
-    var setCenterWM = exports.setCenterWM = _.partial(setCenterAndZoomWM, exports.ZOOM_PLOT);
-    var setCenterLL = exports.setCenterLL = _.partial(setCenterAndZoomLL, exports.ZOOM_PLOT);
-
-    map.addLayer(boundsLayer);
-    map.addLayer(utfLayer);
-    map.addLayer(plotLayer);
+    exports.setCenterWM = _.partial(setCenterAndZoomWM, exports.ZOOM_PLOT);
+    exports.setCenterLL = _.partial(setCenterAndZoomLL, exports.ZOOM_PLOT);
 
     var center = options.center || config.instance.center,
         zoom = options.zoom || exports.ZOOM_DEFAULT;
     setCenterAndZoomWM(zoom, center);
+
+    map.addLayer(boundsLayer);
+    map.addLayer(plotLayer);
+
+    // Delay loading of UTF grid; otherwise UTF tiler requests precede
+    // visible tile requests, making the map appear to load more slowly.
+    _.defer(function () { map.addLayer(utfLayer); });
 };
 
 var createMap = exports.createMap = function(elmt, config, options) {


### PR DESCRIPTION
1) We were adding layers before setting the initial zoom level, causing Leaflet to request tiles at zoom level 2 which we weren't using. Solved by setting initial zoom level before adding layers.

2) Tiler requests for the UTF grid were all being made before tiler requests for visible tiles, delaying the appearance of visible tiles. Solved by delaying adding the UTF grid layer. On my 40,000-tree instance this doesn't appear to prevent clicking on a tree as soon as it appears. We'll see how it works with Edmonton's 250,000 trees.
