### PR TITLE
Support for static page creation

### DIFF
--- a/opentreemap/treemap/css/sass/partials/_admin.scss
+++ b/opentreemap/treemap/css/sass/partials/_admin.scss
@@ -76,6 +76,11 @@
         width: 80%;
     }
 
+    textarea {
+        width: 80%;
+        height: 20em;
+    }
+
     .messages,
     .text-error {
         &:empty {

--- a/opentreemap/treemap/js/src/inlineEditForm.js
+++ b/opentreemap/treemap/js/src/inlineEditForm.js
@@ -184,7 +184,7 @@ exports.init = function(options) {
                                 displayValue = value + ' ' + units;
                             }
                         }
-                        $(display).html(displayValue);
+                        $(display).text(displayValue);
                     }
                 }
             });

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -13,6 +13,7 @@ from django.core import validators
 from django.contrib.gis.db import models
 from django.contrib.gis.measure import D
 from django.db import IntegrityError
+from django.http import Http404
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as trans
 
@@ -82,6 +83,24 @@ class StaticPage(models.Model):
     name = models.CharField(max_length=100)
     title = models.CharField(max_length=100)
     content = models.TextField()
+
+    @staticmethod
+    def page_names():
+        return ['Resources', 'FAQ', 'About']
+
+    @staticmethod
+    def get_or_new_or_404(instance, page_name):
+        allowed_pages = [name.lower() for name in StaticPage.page_names()]
+        if page_name.lower() not in allowed_pages:
+            raise Http404()
+        try:
+            static_page = StaticPage.objects.get(name__iexact=page_name,
+                                                 instance=instance)
+        except StaticPage.DoesNotExist:
+            static_page = StaticPage(
+                instance=instance, name=page_name.lower(), title=page_name,
+                content=trans('There is no content for this page yet.'))
+        return static_page
 
 
 class BenefitCurrencyConversion(Dictable, models.Model):

--- a/opentreemap/treemap/templates/treemap/field/inputs.html
+++ b/opentreemap/treemap/templates/treemap/field/inputs.html
@@ -32,6 +32,11 @@
            data-date-format="{{ settings.SHORT_DATE_FORMAT|datepicker_format }}"
            {% endif %}
            {{ extra|default:"" }} />
+{% elif field.data_type == 'long_string' %}
+    <textarea name="{{ field.identifier }}"
+           class="{{ class|default_if_none:"" }}"
+           value="{{ field.value|default_if_none:""|unlocalize }}"
+           {{ extra|default:"" }} ></textarea>
 {% else %}
   {% if field.units %}
   <div class="input-append">

--- a/opentreemap/treemap/templatetags/form_extras.py
+++ b/opentreemap/treemap/templatetags/form_extras.py
@@ -31,7 +31,7 @@ FIELD_MAPPINGS = {
     'ForeignKey': 'int',
     'AutoField': 'int',
     'FloatField': 'float',
-    'TextField': 'string',
+    'TextField': 'long_string',
     'CharField': 'string',
     'DateTimeField': 'datetime',
     'DateField': 'date',

--- a/opentreemap/treemap/views.py
+++ b/opentreemap/treemap/views.py
@@ -1216,23 +1216,10 @@ def static_page(request, instance, page):
     #
     #       In the future we will want to add a full
     #       UI and perhaps auto-create these pages
-    try:
-        staticpage = StaticPage.objects.get(name__iexact=page,
-                                            instance=instance)
+    static_page = StaticPage.get_or_new_or_404(instance, page)
 
-        content = staticpage.content
-        title = staticpage.title
-    except StaticPage.DoesNotExist:
-        allowed_pages = ['resources', 'faq', 'about']
-
-        if page.lower() not in allowed_pages:
-            raise Http404()
-
-        content = trans('There is no content for this page yet')
-        title = page
-
-    return {'content': content,
-            'title': title}
+    return {'content': static_page.content,
+            'title': static_page.title}
 
 
 def index(request, instance):


### PR DESCRIPTION
- Add helpers to StaticPage model and use them in existing view
- "field" template tag uses new data_type "long_string" for "TextField" fields; templates render it as &lt;textarea&gt;
- When inlineEditForm.js moves a field value to a display value, use text() instead of html() so HTML characters will be escaped
