### PR TITLE
Re-privatize user profile edit buttons

### DIFF
--- a/opentreemap/treemap/templates/treemap/user.html
+++ b/opentreemap/treemap/templates/treemap/user.html
@@ -51,11 +51,11 @@ active
             </div>
             {% usercontent for user %}
             <div id="upload-photo-error" class="text-error" style="display: none"></div>
-            {% endusercontent %}
             <button id="edit-user" data-class="display" class="btn btn-small btn-info">{% trans "Edit Profile" %}</button>
             <button id="save-edit" data-class="edit" class="btn btn-small btn-primary" style="display: none;">{% trans "Save" %}</button>
             <button id="cancel-edit" data-class="edit" class="btn btn-small" style="display: none;">{% trans "Cancel" %}</button>
             <a class="btn btn-small" href="{% url 'django.contrib.auth.views.password_reset' %}">{% trans "Reset Password" %}</a>
+            {% endusercontent %}
             <form id="user-form">
                 {% for label, identifier, template in public_fields %}
                   {% field label from identifier withtemplate template %}


### PR DESCRIPTION
The user profile edit buttons were mistakenly un-privatized (11/5/2013). Other users could see the buttons, but server checks prevented any changes. Now the buttons are once again visible only to the owning user.
