### PR TITLE
Return a 404, not a 500 on a verb mismatch

### DIFF
--- a/opentreemap/opentreemap/util.py
+++ b/opentreemap/opentreemap/util.py
@@ -1,13 +1,24 @@
-from django.views.decorators.csrf import csrf_exempt
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
 import json
+
+from django.views.decorators.csrf import csrf_exempt
+from django.http import HttpResponse, HttpResponseRedirect, Http404
 
 
 def route(**kwargs):
     @csrf_exempt
     def routed(request, *args2, **kwargs2):
         method = request.method
-        req_method = kwargs[method]
-        return req_method(request, *args2, **kwargs2)
+
+        if method not in kwargs:
+            raise Http404()
+        else:
+            req_method = kwargs[method]
+            return req_method(request, *args2, **kwargs2)
     return routed
 
 


### PR DESCRIPTION
Fixes #1101
