### PR TITLE
Reload tiles when adding a tree

### DIFF
--- a/opentreemap/treemap/views.py
+++ b/opentreemap/treemap/views.py
@@ -413,6 +413,10 @@ def _request_to_update_map_feature(request, instance, feature):
         request_dict = json.loads(request.body)
         feature, tree = update_map_feature(request_dict, request.user, feature)
 
+        # We need to reload the instance here since a new georev
+        # may have been set
+        instance = Instance.objects.get(pk=instance.pk)
+
         return {
             'ok': True,
             'geoRevHash': instance.geo_rev_hash,


### PR DESCRIPTION
A regression occurred when adding map features. The main issues is that
the geo rev count is updated by a database trigger, thus invalidating
any existing objects. Since we want to return the update geo rev, we
need to requery the instance.

Fixes #1152
