### PR TITLE
Include config and logo url in instance API response

### DIFF
--- a/opentreemap/api/instance.py
+++ b/opentreemap/api/instance.py
@@ -141,6 +141,15 @@ def instance_info(request, instance):
     info['fields'] = perms
     info['search'] = instance.mobile_search_fields
 
+    public_config_keys = ['scss_variables']
+
+    info['config'] = {x: instance.config[x]
+                      for x in instance.config
+                      if x in public_config_keys}
+
+    if instance.logo:
+        info['logoUrl'] = instance.logo.url
+
     return info
 
 


### PR DESCRIPTION
The mobile apps need access to the custom color and logo settings for the instance so I have added them to the instance info API endpoint. I decided to include the entire config dictionary, rather than pull out just the color settings, because it may prove useful in the future.
