### PR TITLE
Remove empty values from clickedIdStream

### DIFF
--- a/opentreemap/treemap/js/src/mapFeature.js
+++ b/opentreemap/treemap/js/src/mapFeature.js
@@ -144,7 +144,8 @@ exports.init = function(options) {
 
     var detailUrlPrefix = U.removeLastUrlSegment(detailUrl),
         clickedIdStream = mapManager.map.utfEvents
-        .map('.data.' + options.config.utfGrid.mapfeatureIdKey);
+            .map('.data.' + options.config.utfGrid.mapfeatureIdKey)
+            .filter(BU.isDefinedNonEmpty);
 
     clickedIdStream
         .filter(BU.not, options.featureId)


### PR DESCRIPTION
fixes #1098 on github

clickedIdStream represents the id of other features clicked from the mapFeature page map, allowing you to jump to that other feature's page. However, all clicks to the map were producing values in the stream, even ones that were not tied to an actual feature.

This fixes #1098 on github because the clicking of another feature tries to jump to a different page, which is blocked/prompted by the statePrompter during edit mode.
