### PR TITLE
Show subheader on static pages.

### DIFF
--- a/opentreemap/treemap/css/sass/partials/_layout.scss
+++ b/opentreemap/treemap/css/sass/partials/_layout.scss
@@ -76,7 +76,7 @@ body {
     }
 
     > div {
-        z-index: 99;
+        z-index: 10;
         position: relative;
     }
 }

--- a/opentreemap/treemap/templates/treemap/staticpage.html
+++ b/opentreemap/treemap/templates/treemap/staticpage.html
@@ -2,10 +2,6 @@
 
 {% block page_title %} | {{ title }}{% endblock %}
 
-{% block subhead %}
-{% comment %} Hide subhead when the map is not available {% endcomment %}
-{% endblock subhead %}
-
 {% block activeexplore %}
 {% endblock %}
 


### PR DESCRIPTION
Fixes #1209 Advanced search options don't work on static pages or management pages
