### PR TITLE
Return geoRevHash with plot API response

### DIFF
--- a/opentreemap/api/instance.py
+++ b/opentreemap/api/instance.py
@@ -157,7 +157,7 @@ def _instance_info_dict(instance):
     center = instance.center
     center.transform(4326)
 
-    info = {'geoRev': instance.geo_rev_hash,
+    info = {'geoRevHash': instance.geo_rev_hash,
             'id': instance.pk,
             'url': instance.url_name,
             'name': instance.name,

--- a/opentreemap/api/plots.py
+++ b/opentreemap/api/plots.py
@@ -13,7 +13,7 @@ from django.contrib.gis.measure import D
 from treemap.exceptions import HttpBadRequestException
 
 from treemap.views import context_dict_for_plot, update_map_feature
-from treemap.models import Plot
+from treemap.models import Plot, Instance
 
 
 def plots_closest_to_point(request, instance, lat, lng):
@@ -96,8 +96,15 @@ def update_or_create_plot(request, instance, plot_id=None):
 
     plot, _ = update_map_feature(data, request.user, plot)
 
-    return context_dict_for_plot(
+    context_dict = context_dict_for_plot(
         request.instance,
         plot,
         user=request.user,
         supports_eco=request.instance_supports_ecobenefits)
+
+    # Fetch the latest instance version to get an updated geo rev hash
+    # so that clients will know if a tile refresh is required
+    instance = Instance.objects.get(pk=instance.pk)
+    context_dict["geoRevHash"] = instance.geo_rev_hash
+
+    return context_dict


### PR DESCRIPTION
This was implemented previously, but it looks like it may have gotten lost in a refactor. I have also taken the opportunity to standardize the dictionary key name. The geo rev is always referred to as "geoRevHash"
