### PR TITLE
Propagate eco service failure error string

### DIFF
--- a/opentreemap/treemap/ecobenefits.py
+++ b/opentreemap/treemap/ecobenefits.py
@@ -191,6 +191,7 @@ class TreeBenefitsCalculator(BenefitCalculator):
 
                 if err:
                     rslt = {'error': err}
+                    error = err
                 else:
                     benefits = self._compute_currency_and_transform_units(
                         instance, rawb['Benefits'])


### PR DESCRIPTION
Eco benefit formatting was throwing an exception because a failing call to the eco service was not returning the error string.
