### PR TITLE
Change instance info API schema

### DIFF
--- a/opentreemap/api/instance.py
+++ b/opentreemap/api/instance.py
@@ -98,7 +98,6 @@ def instance_info(request, instance):
             else:
                 model_inst = safe_get_model_class(fp.model_name)(
                     instance=instance)
-                print(fp.field_name)
                 data_type, _, choices = field_type_label_choices(
                     model_inst, fp.field_name, fp.display_field_name)
 

--- a/opentreemap/treemap/templatetags/form_extras.py
+++ b/opentreemap/treemap/templatetags/form_extras.py
@@ -38,7 +38,8 @@ FIELD_MAPPINGS = {
     'BooleanField': 'bool',
     'NullBooleanField': 'bool',
     'FileField': 'string',
-    'PointField': 'point'
+    'PointField': 'point',
+    'MultiPolygonField': 'multipolygon'
 }
 
 VALID_FIELD_KEYS = ','.join([k for k, v in FIELD_MAPPINGS.iteritems()])


### PR DESCRIPTION
This changes accomplishes two goals
- Supports explicitly defining the order in which fields appear in mobile apps
- Makes the instance API more useful beyond our mobile needs. All readable fields are now returned with the instance, not just the ones used by the mobile application.

This is the new, expected schema of the the mobile_api_fields value in the instance config

``` python
[
  {
    'header': 'Tree Information',
    'field_keys': ['tree.species', 'tree.diameter', 'tree.height']
  },
  {
    'header': 'Plot Information',
    'field_keys': ['plot.width', 'plot.length']
  }
]
```
