### PR TITLE
Fix search issues

### DIFF
--- a/opentreemap/treemap/js/src/mapManager.js
+++ b/opentreemap/treemap/js/src/mapManager.js
@@ -142,7 +142,7 @@ function getBasemapLayers(config) {
 function createPlotTileLayer(config) {
     var url = getPlotLayerURL(config, 'png'),
         layer = L.tileLayer(url, { maxZoom: 20 });
-    makeLayerFilterable(layer, url, config.urls.filterQueryArgumentName, config.urls.displayQueryArgumentName);
+    makeLayerFilterable(layer, url, config);
     return layer;
 }
 

--- a/opentreemap/treemap/js/src/search.js
+++ b/opentreemap/treemap/js/src/search.js
@@ -5,7 +5,8 @@ var $ = require('jquery'),
     _ = require('lodash'),
     moment = require("moment"),
     isTypeaheadHiddenField = require('treemap/fieldHelpers'),
-    FH = require('treemap/fieldHelpers');
+    FH = require('treemap/fieldHelpers'),
+    querystring = require('querystring');
 
 var DATETIME_FORMAT = FH.DATETIME_FORMAT;
 var TREE_MODELS = ['Tree', 'EmptyPlot'];
@@ -20,6 +21,25 @@ var textToBool = function(text) {
 
 var boolToText = function(bool) {
     return bool ? "true" : "false";
+};
+
+var filterObjectIsEmpty = exports.filterObjectIsEmpty = function(filterObj) {
+    return filterObj ? _.keys(filterObj).length === 0 : true;
+};
+
+var displayListIsEmpty = exports.displayListIsEmpty = function(displayList) {
+    return _.isUndefined(displayList) || _.isNull(displayList);
+};
+
+var makeQueryStringFromFilters = exports.makeQueryStringFromFilters = function(config, filters) {
+    var query = {};
+    if ( ! filterObjectIsEmpty(filters.filter)) {
+        query[config.urls.filterQueryArgumentName] = JSON.stringify(filters.filter);
+    }
+    if ( ! displayListIsEmpty(filters.display)) {
+        query[config.urls.displayQueryArgumentName] = JSON.stringify(filters.display);
+    }
+    return querystring.stringify(query);
 };
 
 exports.buildElems = function (inputSelector) {
@@ -37,19 +57,11 @@ exports.buildElems = function (inputSelector) {
 };
 
 function executeSearch(config, filters) {
-    var searchQuery = filters.filter,
-        displayQuery = filters.display;
+    var query = makeQueryStringFromFilters(config, filters);
 
-    // An empty filter object is serialized as an empty string
-    searchQuery = searchQuery && Object.keys(searchQuery).length > 0 ?
-            JSON.stringify(searchQuery) :
-            '';
-    displayQuery = displayQuery && displayQuery.length > 0 ?
-            JSON.stringify(displayQuery) :
-            '';
     var search = $.ajax({
         url: config.instance.url + 'benefit/search',
-        data: {'q': searchQuery, 'show': displayQuery},
+        data: query,
         type: 'GET',
         dataType: 'html'
     });

--- a/opentreemap/treemap/js/src/searchBar.js
+++ b/opentreemap/treemap/js/src/searchBar.js
@@ -47,14 +47,11 @@ function redirectToSearchPage(config, filters, wmCoords) {
             var ll = U.webMercatorToLatLng(wmCoords.x, wmCoords.y);
             return '&z='+ mapManager.ZOOM_PLOT + '/' + ll.lat + '/' + ll.lng;
         },
-        filterObj = filters.filter,
-        displayList = filters.display,
-        filterPortion = U.getUpdatedQueryString(config.urls.filterQueryArgumentName, JSON.stringify(filterObj)),
-        displayPortion = U.getUpdatedQueryString(config.urls.displayQueryArgumentName, JSON.stringify(displayList)),
-        zPortion = wmCoords ? getZPortion(wmCoords) : '',
-        url = config.instance.url + 'map/?' + filterPortion + displayPortion + zPortion;
+        query = Search.makeQueryStringFromFilters(config, filters);
 
-    window.location.href = url;
+    query += wmCoords ? getZPortion(wmCoords) : '';
+
+    window.location.href = config.instance.url + 'map/?' + query;
 }
 
 function initSearchUi(config, searchStream) {


### PR DESCRIPTION
Fixes a few issues:
- "Show Trees" and "Show Plots" were not being rechecked properly on redirects to the map page
- The display filters are not added to the URL when they are all checked
- Cleans up adding the filters into the query string for both ecobenefits and tile requests
