### PR TITLE
Plot detail: UI to support resolving alerts

### DIFF
--- a/opentreemap/treemap/js/src/inlineEditForm.js
+++ b/opentreemap/treemap/js/src/inlineEditForm.js
@@ -204,6 +204,7 @@ exports.init = function(options) {
                         .map(function() {
                             return $(this).html();
                         });
+                headers = _.compact(headers);
 
                 data[name] =
                     _.map($table.find('tr[data-value-id]').toArray(), function(row) {

--- a/opentreemap/treemap/js/src/plot.js
+++ b/opentreemap/treemap/js/src/plot.js
@@ -97,9 +97,24 @@ exports.init = function(options) {
     form.inEditModeProperty.onValue(function (inEditMode) {
         if (inEditMode) {
             showAddTree();
+            addResolveAlertButtons();
         } else {
             hideAddTree();
         }
     });
+
+    function addResolveAlertButtons() {
+        var $tables = $('table[data-udf-name$="Alerts"]'),
+            $buttons = $tables.find('.resolveBtn'),
+            $unresolved = $tables.find('tr[data-value-id] td:contains("Unresolved")');
+        $buttons.remove();
+        $unresolved.next().append(
+            '<a href="javascript:;" class="btn btn-mini resolveBtn" data-class="edit">Resolve</a>');
+        $tables.find('.resolveBtn').click(function () {
+            $(this).closest('tr')
+                .find('td:contains("Unresolved")')
+                .text('Resolved');
+        });
+    }
 
 };

--- a/opentreemap/treemap/templates/treemap/partials/collection_udf_row.html
+++ b/opentreemap/treemap/templates/treemap/partials/collection_udf_row.html
@@ -8,4 +8,5 @@
   {% for field in udf.datatype_dict %}
   <td>{{ value.data|get:field.name }}</td>
   {% endfor %}
+  <td></td>
 </tr>

--- a/opentreemap/treemap/templates/treemap/partials/collectionudf.html
+++ b/opentreemap/treemap/templates/treemap/partials/collectionudf.html
@@ -19,14 +19,19 @@
       {% for field in udf.datatype_dict %}
       <th>{{ field.name }}</th>
       {% endfor %}
+      <th></th>
     </tr>
     {% if perm_level == "write" %}
     <tr class="editrow" style="display: none">
       {% for field in udf.datatype_dict %}
       <td>
         {% include 'treemap/partials/udf_edit_field.html' with field=field %}
-        {% if forloop.last %}<a data-udf-id="{{ udf.pk|unlocalize }}" class="btn">+</a>{% endif %}
       </td>
+      {% if forloop.last %}
+      <td>
+        <a data-udf-id="{{ udf.pk|unlocalize }}" class="btn">+</a>
+      </td>
+      {% endif %}
       {% endfor %}
     </tr>
     {% endif %}


### PR DESCRIPTION
- Collection UDF tables get an extra final column for buttons (e.g. "+" and "Resolve")
- When entering "Edit" mode, add "Resolve" buttons on unresolved "Alerts" rows
