### PR TITLE
Change ecobenefit labels

### DIFF
--- a/opentreemap/treemap/ecobenefits.py
+++ b/opentreemap/treemap/ecobenefits.py
@@ -398,16 +398,16 @@ def within_itree_regions(request):
                                              float(y))).exists())
 
 benefit_labels = {
-    # Translators: 'Energy' is the name of an eco benefit
-    'energy':     trans('Energy'),
-    # Translators: 'Stormwater' is the name of an eco benefit
-    'stormwater': trans('Stormwater'),
-    # Translators: 'Carbon Dioxide' is the name of an eco benefit
-    'co2':        trans('Carbon Dioxide'),
-    # Translators: 'Carbon Dioxide Stored' is the name of an eco benefit
-    'co2storage': trans('Carbon Dioxide Stored'),
-    # Translators: 'Air Quality' is the name of an eco benefit
-    'airquality': trans('Air Quality')
+    # Translators: 'Energy conserved' is the name of an eco benefit
+    'energy':     trans('Energy conserved'),
+    # Translators: 'Stormwater filtered' is the name of an eco benefit
+    'stormwater': trans('Stormwater filtered'),
+    # Translators: 'Carbon dioxide removed' is the name of an eco benefit
+    'co2':        trans('Carbon dioxide removed'),
+    # Translators: 'Carbon dioxide stored' is the name of an eco benefit
+    'co2storage': trans('Carbon dioxide stored'),
+    # Translators: 'Air quality improved' is the name of an eco benefit
+    'airquality': trans('Air quality improved')
 }
 
 

--- a/opentreemap/treemap/templates/treemap/map-browse-trees.html
+++ b/opentreemap/treemap/templates/treemap/map-browse-trees.html
@@ -50,7 +50,7 @@
   {% if request.instance_supports_ecobenefits %}
   <div class="accordion-group">
     <div class="accordion-heading">
-      <a class="accordion-toggle" data-toggle="collapse" data-parent="#map-info" href="#yearlyEco">{% trans "Yearly Eco Benefits" %} <span class="arrow pull-right"><i class="icon-right-open"></i></span></a>
+      <a class="accordion-toggle" data-toggle="collapse" data-parent="#map-info" href="#yearlyEco">{% trans "Eco Benefits" %} <span class="arrow pull-right"><i class="icon-right-open"></i></span></a>
     </div>
     <div id="yearlyEco" class="accordion-body collapse in">
       <div class="accordion-inner benefit-values" id="benefit-values"></div>

--- a/opentreemap/treemap/templates/treemap/partials/benefit_value_row.html
+++ b/opentreemap/treemap/templates/treemap/partials/benefit_value_row.html
@@ -1,21 +1,14 @@
 {% load i18n %}
 {% load l10n %}
 
+{% if benefit.value %}
 <div class="benefit-value-row">
-  {% if benefit.label == 'Energy' %}
-  <div class="benefit-icon"><i class="icon-flash-1"></i></div>
-  {% elif benefit.label == 'Stormwater' %}
-  <div class="benefit-icon"><i class="icon-tint"></i></div>
-  {% elif benefit.label == 'Air Quality' %}
-  <div class="benefit-icon"><i class="icon-cloud"></i></div>
-  {% elif benefit.label.lower == 'reduced stormwater runoff' %}
-  <div class="benefit-icon"><i class="icon-tint"></i></div>
-  {% elif benefit.label.lower == 'water conserved' %}
-  <div class="benefit-icon"><i class="icon-tint"></i></div>
+  {% if icon %}
+  <div class="benefit-icon"><i class="icon-{{ icon }}"></i></div>
   {% else %}
   <div class="benefit-icon"><i class="icon-sun-filled"></i></div>
   {% endif %}
-  <h3 class="benefit-label">{{ benefit.label }} {% trans "Benefits" %}</h3>
+  <h3 class="benefit-label">{{ benefit.label }}</h3>
   <span class="benefit-content">
     {% if benefit.value %}
       {{ benefit.value }} {{ benefit.unit }}
@@ -31,3 +24,4 @@
     {% endif %}
   </span>
 </div>
+{% endif %}

--- a/opentreemap/treemap/templates/treemap/partials/eco_benefits.html
+++ b/opentreemap/treemap/templates/treemap/partials/eco_benefits.html
@@ -4,33 +4,23 @@
 {% if request.instance_supports_ecobenefits %}
 <div {% if not hidecounts %}id="benefit-values"{% endif %} class="benefit-values accordion-inner">
     {% with plot_benefits=benefits.plot %}
-    {% if not hide_summary and plot_benefits %}
-    <div class="benefit-value-title">{% trans "General Eco Benefits"%}</div>
-    {% endif %}
-
-    {# Show value-less benefits first, so money only ones #}
-    {# Float to the top #}
-    {% for benefit in plot_benefits %}
-    {% if not benefit.value %}
-    {% include "treemap/partials/benefit_value_row.html" %}
-    {% endif %}
-    {% endfor %}
-
-    {% for benefit in plot_benefits %}
-    {% if benefit.value %}
-    {% include "treemap/partials/benefit_value_row.html" %}
-    {% endif %}
-    {% endfor %}
+      {% include "treemap/partials/benefit_value_row.html" with benefit=plot_benefits.totals %}
+      {% if not hide_summary and plot_benefits %}
+        <div class="benefit-value-title">{% trans "Tree Benefits"%}</div>
+      {% endif %}
+      {% include "treemap/partials/benefit_value_row.html" with benefit=plot_benefits.energy icon='flash-1' %}
+      {% include "treemap/partials/benefit_value_row.html" with benefit=plot_benefits.stormwater icon='tint' %}
+      {% include "treemap/partials/benefit_value_row.html" with benefit=plot_benefits.airquality icon='cloud' %}
+      {% include "treemap/partials/benefit_value_row.html" with benefit=plot_benefits.co2 %}
+      {% include "treemap/partials/benefit_value_row.html" with benefit=plot_benefits.co2storage %}
     {% endwith %}
 
     {% with resource_benefits=benefits.resource %}
-    {% if not hide_summary and request.instance.supports_resources and resource_benefits %}
-    <div class="benefit-value-title">{{ term.Resource }} {% trans "Benefits" %}</div>
-    {% endif %}
-
-    {% for benefit in resource_benefits %}
-    {% include "treemap/partials/benefit_value_row.html" %}
-    {% endfor %}
+      {% if not hide_summary and request.instance.supports_resources and resource_benefits %}
+        <div class="benefit-value-title">{{ term.Resource }} {% trans "Benefits" %}</div>
+      {% endif %}
+      {% include "treemap/partials/benefit_value_row.html" with benefit=resource_benefits.runoff_reduced icon='tint' %}
+      {% include "treemap/partials/benefit_value_row.html" with benefit=resource_benefits.usage_reduced icon='tint' %}
     {% endwith %}
 
     {% if not hide_summary and not hidecounts %}

--- a/opentreemap/treemap/templates/treemap/partials/plot_eco.html
+++ b/opentreemap/treemap/templates/treemap/partials/plot_eco.html
@@ -10,7 +10,7 @@
 {% elif benefits.plot %}
 <table class="table table-hover">
   <tbody>
-    {% for benefit in benefits.plot %}
+    {% for key, benefit in benefits.plot.items %}
     <tr>
       <td>{{ benefit.label }}</td>
       <td>{{ benefit.value }} {{ benefit.unit}}</td>

--- a/opentreemap/treemap/templates/treemap/resource_detail.html
+++ b/opentreemap/treemap/templates/treemap/resource_detail.html
@@ -34,7 +34,7 @@
 {% if stormbenefits %}
 <table class="table table-hover">
   <tbody>
-    {% for benefit in stormbenefits %}
+    {% for key, benefit in stormbenefits.items %}
     <tr>
       <td>{{ benefit.label }}</td>
       <td>{{ benefit.value }} {{ benefit.unit}}</td>

--- a/opentreemap/treemap/views.py
+++ b/opentreemap/treemap/views.py
@@ -932,7 +932,7 @@ def search_tree_benefits(request, instance):
     benefits.get('plot', {})['totals'] = {
         'value': None,
         'currency': total_currency_saved,
-        'label': trans('Total')
+        'label': trans('Total annual benefits')
     }
 
     formatted = _format_benefits(instance, benefits, basis)
@@ -967,11 +967,12 @@ def _format_benefits(instance, benefits, basis):
                 _, value = get_display_value(
                     instance, unit_key, key, benefit['value'])
 
+                benefit['name'] = key
                 benefit['value'] = value
                 benefit['unit'] = get_units(instance, unit_key, key)
 
     # Add total and percent to basis
-    rslt = {'benefits': {k: v.values() for (k, v) in benefits.iteritems()},
+    rslt = {'benefits': benefits,
             'currency_symbol': currency_symbol,
             'basis': basis}
 


### PR DESCRIPTION
- Change title in header from "Yearly Eco Benefits" to "Eco Benefits"
- "Total Benefits" should be renamed "Total Annual Benefits." Move it above the General Eco Benefits Header. This number is all the annual benefits generated by both trees and watershed solutions. It's everything but carbon dioxide stored to date.
- Rename "General Eco Benefits" to "Tree Benefits."
- Get rid of the word "Benefits" that's used for each individual benefit header. Change to desired wording and order.
