### PR TITLE
Change the API return schema for instance eco

### DIFF
--- a/opentreemap/api/instance.py
+++ b/opentreemap/api/instance.py
@@ -176,14 +176,25 @@ def _instance_info_dict(instance):
 def _instance_eco_dict(instance):
     return {
         "supportsEcoBenefits": instance.has_itree_region(),
-        #  All instances have the same ecobenefits and
-        #  the mobile apps do not need any details to render
-        #  fields for displaying per-feature eco values.
+
+        # This is a list of eco benefit field sections. Currently, the
+        # mobile apps only support tree benefits. The values defined
+        # in this structure are used to pull benefit details from a
+        # map feature dictionary. The benefit label, formatted
+        # currency amount, etc. are all included with the map feature,
+        # so the instance only needs to define the ordering of the keys.
         "benefits": [
-            {"label": "Energy"},
-            {"label": "Stormwater"},
-            {"label": "Carbon Dioxide"},
-            {"label": "Carbon Dioxide Stored"},
-            {"label": "Air Quality"}
+            {
+                "label": "Tree Benefits",
+                # The tree benefits _are_ listed under "plot"
+                "model": "plot",
+                "keys": [
+                    "energy",
+                    "stormwater",
+                    "airquality",
+                    "co2",
+                    "co2storage"
+                ]
+            }
         ]
     }


### PR DESCRIPTION
Previously, eco benefits were returned with a plot as an array. Mobile applications only needed to know the number of eco fields that would be included. Now, the eco fields for a plot are returned as a dictionary, so the instance API must return the keys needed to read from the dictionary and the order in which those keys should be displayed. I copied the key ordering from the current web app UI.
