### PR TITLE
Tweak details of "Add another" tree / resource

### DIFF
--- a/opentreemap/treemap/js/src/addMapFeature.js
+++ b/opentreemap/treemap/js/src/addMapFeature.js
@@ -190,6 +190,7 @@ function init(options) {
         stepControls.showStep(0);
         stepControls.enableNext(indexOfSetLocationStep, false);
         $placeMarkerMessage.show();
+        $moveMarkerMessage.hide();
     }
 
     function setAddFeatureUrl(url) {
@@ -288,12 +289,10 @@ function init(options) {
 
         switch (option) {
         case 'copy':
-            requireMarkerDrag();
             stepControls.showStep(0);
             break;
         case 'new':
             clearEditControls();
-            requireMarkerDrag();
             stepControls.showStep(0);
             break;
         case 'edit':
@@ -347,6 +346,7 @@ function init(options) {
         setAddFeatureUrl: setAddFeatureUrl,
         focusOnAddressInput: focusOnAddressInput,
         getFormData: getFormData,
+        requireMarkerDrag: requireMarkerDrag,
         stepControls: stepControls,
         addFeatureStream: addFeatureStream,
         deactivateStream: deactivateBus.map(_.identity)

--- a/opentreemap/treemap/js/src/addResourceMode.js
+++ b/opentreemap/treemap/js/src/addResourceMode.js
@@ -104,6 +104,7 @@ function init(options) {
     function initSteps() {
         $resourceType.prop('checked', false);
         manager.stepControls.enableNext(STEP_CHOOSE_TYPE, false);
+        plotMarker.hide();
         removeAreaPolygon();
         hideSubquestions();
     }

--- a/opentreemap/treemap/js/src/addTreeMode.js
+++ b/opentreemap/treemap/js/src/addTreeMode.js
@@ -63,6 +63,9 @@ function init(options) {
         });
     }
 
+    // In case we're adding another tree, make user move the marker
+    manager.addFeatureStream.onValue(manager.requireMarkerDrag);
+
     _.defer(function () {
         manager.focusOnAddressInput();
     });

--- a/opentreemap/treemap/js/src/plotMarker.js
+++ b/opentreemap/treemap/js/src/plotMarker.js
@@ -103,7 +103,7 @@ exports = module.exports = {
     enableMoving: enableMoving,
     disableMoving: disableMoving,
 
-    // Hide/deactivate/clear everything (but keep feature so its location can still be retrieved)
+    // Hide/deactivate/clear everything
     hide: function () {
         if (marker) {
             lastMarkerLocation = marker.getLatLng();
@@ -169,7 +169,9 @@ function disableMoving() {
     if (markerDraggingContext) {
         markerDraggingContext.disable();
     }
-    showViewMarker();
+    if (map.hasLayer(marker)) {
+        showViewMarker();
+    }
 }
 
 var showViewMarker = _.partial(showMarker, false, '');


### PR DESCRIPTION
For speedy tree entry, "add another" allows you to just move the marker to a new location. But we don't want that behavior when adding resources. So:
- Call `requireMarkerDrag()` from `addTreeMode.js` rather than from the shared `addMapFeature.js`
- `addResourceMode.js` hides the marker in `initSteps()`
