### PR TITLE
Mohr UI test fixes

### DIFF
--- a/opentreemap/treemap/tests/ui/registration_views.py
+++ b/opentreemap/treemap/tests/ui/registration_views.py
@@ -48,7 +48,7 @@ class LoginLogoutTest(UITestCase):
 
         login_url = self.driver.current_url
 
-        self.click('#login')
+        self.click_when_visible('#login')
         self.process_login_form(self.user.username, 'password')
 
         # We should not be on the same page


### PR DESCRIPTION
- Catch and ignore `InterfaceError` when a connection we're trying to kill is already closed
- `test_valid_login` waits for login button to be visible
