### PR TITLE
Show map list on user profile page

### DIFF
--- a/opentreemap/treemap/templates/treemap/user.html
+++ b/opentreemap/treemap/templates/treemap/user.html
@@ -74,21 +74,35 @@ active
         <div class="span9">
             <div class="profile-tabs">
                 <ul class="nav nav-tabs">
-                    <li class="hidden"><a href="#edits" data-toggle="tab"><span class="number">{{ total_count }}</span> Edits</a></li>
-                    <li class="hidden"><a href="#maps" data-toggle="tab"><span class="number">3</span> Tree Maps</a></li>
+                    <li class="active">
+                      <a href="#maps" data-toggle="tab">
+                        <span class="number">{{ instances|length }}</span>
+                        {% blocktrans count n=instances|length %}Tree Map{% plural %}Tree Maps{% endblocktrans %}
+                      </a>
+                    </li>
+                    <li>
+                      <a href="#edits" data-toggle="tab">
+                        <span class="number">{{ total_edits }}</span>
+                        {% blocktrans count n=total_edits %}Edit{% plural %}Edits{% endblocktrans %}
+                      </a>
+                    </li>
                     <li class="hidden"><a href="#faves" data-toggle="tab"><span class="number">86</span> Favorites</a></li>
                 </ul>
             </div>
             <div class="tab-content">
-                <div class="tab-pane active" id="edits">
+                <div class="tab-pane active" id="maps">
+                    <h3>Tree Maps</h3>
+                    {% for instance in instances %}
+                      <div>
+                        <a href="{% url 'map' instance_url_name=instance.url_name %}">{{ instance.name }}</a>
+                      </div>
+                    {% endfor %}
+                </div>
+                <div class="tab-pane" id="edits">
                     <h3>{% trans "Recent Edits" %}</h3>
                     <div id="recent-user-edits-container">
                         {% include 'treemap/recent_user_edits.html' %}
                     </div>
-                </div>
-                <div class="tab-pane" id="maps">
-                    <h3>Tree Maps</h3>
-                    <!-- INSERT LIST OF OTHER TREE MAPS HERE -->
                 </div>
                 <div class="tab-pane" id="faves">
                     <h3>Favorites</h3>

--- a/opentreemap/treemap/tests/__init__.py
+++ b/opentreemap/treemap/tests/__init__.py
@@ -207,6 +207,11 @@ def make_plain_user(username, password='password'):
     return user
 
 
+def make_instance_user(instance, user):
+    iu = InstanceUser(instance=instance, user=user, role=instance.default_role)
+    iu.save_with_user(User._system_user)
+
+
 def login(client, username):
     client.post('/accounts/login/', {'username': username,
                                      'password': 'password'})


### PR DESCRIPTION
Show banner counts/tabs on User Details page
- Categories are "Tree Maps" and "Edits"
- Use singular form ("Tree Map" or "Edit") if there's only one

"Tree Maps" list includes:
- maps the user has joined (via invite) or edited, which current user has permission to view
- the map most recently visited in the current session (if user is looking at their own list)
