### PR TITLE
Pull time off datetime before lexico comp to date

### DIFF
--- a/opentreemap/treemap/search.py
+++ b/opentreemap/treemap/search.py
@@ -249,7 +249,8 @@ def _parse_min_max_value_fn(operator):
 
         if field:  # implies hstore
             if isinstance(value, datetime):
-                inner_value = {field: raw_value}
+                date_value = value.date().isoformat()
+                inner_value = {field: date_value}
             else:
                 raise ParseException("Cannot perform min/max comparisons on "
                                      "non-date hstore fields at this time.")

--- a/opentreemap/treemap/tests/search.py
+++ b/opentreemap/treemap/tests/search.py
@@ -916,3 +916,12 @@ class SearchTests(TestCase):
             self._execute_and_process_filter(
                 {'udf:plot:%s.action' % self.plotstew.pk: {'IS': 'prune'},
                  'udf:plot:%s.date' % self.plotstew.pk: {'MAX': 2}})
+
+    def test_cudf_date_min_bound_succeeds(self):
+        p1, _, _ = self._setup_collection_udfs()
+        self.assertIn(p1,
+                      self._execute_and_process_filter(
+                          {'udf:plot:%s.action' % self.plotstew.pk:
+                           {'IS': 'prune'},
+                           'udf:plot:%s.date' % self.plotstew.pk:
+                           {'MIN': '2013-09-15 00:00:00'}}))


### PR DESCRIPTION
fixes #1337 on github

For hstore queries, we compare isoformatted date strings lexicographically. This does not work when comparing isoformatted datetimes to dates. For example, If you set the minimum bound on a search to "2014-03-24 00:00:00", you'll never capture dates in the database stored as "2014-03-24" using this method.

This fix forces datetimes to be represented as date strings.
