### PR TITLE
Show map list on user profile page

### DIFF
--- a/opentreemap/treemap/templates/treemap/user.html
+++ b/opentreemap/treemap/templates/treemap/user.html
@@ -74,21 +74,35 @@ active
         <div class="span9">
             <div class="profile-tabs">
                 <ul class="nav nav-tabs">
-                    <li class="hidden"><a href="#edits" data-toggle="tab"><span class="number">{{ total_count }}</span> Edits</a></li>
-                    <li class="hidden"><a href="#maps" data-toggle="tab"><span class="number">3</span> Tree Maps</a></li>
+                    <li class="active">
+                      <a href="#maps" data-toggle="tab">
+                        <span class="number">{{ instances|length }}</span>
+                        {% blocktrans count n=instances|length %}Tree Map{% plural %}Tree Maps{% endblocktrans %}
+                      </a>
+                    </li>
+                    <li>
+                      <a href="#edits" data-toggle="tab">
+                        <span class="number">{{ total_edits }}</span>
+                        {% blocktrans count n=total_edits %}Edit{% plural %}Edits{% endblocktrans %}
+                      </a>
+                    </li>
                     <li class="hidden"><a href="#faves" data-toggle="tab"><span class="number">86</span> Favorites</a></li>
                 </ul>
             </div>
             <div class="tab-content">
-                <div class="tab-pane active" id="edits">
+                <div class="tab-pane active" id="maps">
+                    <h3>Tree Maps</h3>
+                    {% for instance in instances %}
+                      <div>
+                        <a href="{% url 'map' instance_url_name=instance.url_name %}">{{ instance.name }}</a>
+                      </div>
+                    {% endfor %}
+                </div>
+                <div class="tab-pane" id="edits">
                     <h3>{% trans "Recent Edits" %}</h3>
                     <div id="recent-user-edits-container">
                         {% include 'treemap/recent_user_edits.html' %}
                     </div>
-                </div>
-                <div class="tab-pane" id="maps">
-                    <h3>Tree Maps</h3>
-                    <!-- INSERT LIST OF OTHER TREE MAPS HERE -->
                 </div>
                 <div class="tab-pane" id="faves">
                     <h3>Favorites</h3>

--- a/opentreemap/treemap/tests/__init__.py
+++ b/opentreemap/treemap/tests/__init__.py
@@ -207,6 +207,11 @@ def make_plain_user(username, password='password'):
     return user
 
 
+def make_instance_user(instance, user):
+    iu = InstanceUser(instance=instance, user=user, role=instance.default_role)
+    iu.save_with_user(User._system_user)
+
+
 def login(client, username):
     client.post('/accounts/login/', {'username': username,
                                      'password': 'password'})

--- a/opentreemap/treemap/views.py
+++ b/opentreemap/treemap/views.py
@@ -42,7 +42,7 @@ from treemap.search import Filter
 from treemap.audit import (Audit, approve_or_reject_existing_edit,
                            approve_or_reject_audits_and_apply)
 from treemap.models import (Plot, Tree, User, Species, Instance,
-                            TreePhoto, StaticPage, MapFeature)
+                            TreePhoto, StaticPage, MapFeature, InstanceUser)
 from treemap.units import get_units, get_display_value, Convertible
 from treemap.ecobackend import BAD_CODE_PAIR
 from treemap.util import leaf_subclasses
@@ -583,6 +583,17 @@ def update_map_feature(request_dict, user, feature):
     return feature, tree
 
 
+def _user_accessible_instance_filter(logged_in_user):
+    public = Q(is_public=True)
+    if logged_in_user is not None and not logged_in_user.is_anonymous():
+        private_with_access = Q(instanceuser__user=logged_in_user)
+
+        instance_filter = public | private_with_access
+    else:
+        instance_filter = public
+    return instance_filter
+
+
 def _get_audits(logged_in_user, instance, query_vars, user, models,
                 model_id, page=0, page_size=20, exclude_pending=True,
                 should_count=False):
@@ -608,14 +619,7 @@ def _get_audits(logged_in_user, instance, query_vars, user, models,
     # If we didn't specify an instance we only want to
     # show audits where the user has permission
     else:
-        public = Q(is_public=True)
-
-        if logged_in_user is not None and not logged_in_user.is_anonymous():
-            private_with_access = Q(instanceuser__user=logged_in_user)
-
-            instance_filter = public | private_with_access
-        else:
-            instance_filter = public
+        instance_filter = _user_accessible_instance_filter(logged_in_user)
 
     instances = Instance.objects.filter(instance_filter)
 
@@ -982,6 +986,25 @@ def _format_benefits(instance, benefits, basis):
     return rslt
 
 
+def _user_instances(logged_in_user, user, current_instance=None):
+    # Which instances can the user being inspected see?
+    user_instances = {iu.instance
+                      for iu in InstanceUser.objects.filter(user=user)}
+
+    # Which instances can the logged-in user see?
+    accessible_filter = _user_accessible_instance_filter(logged_in_user)
+    accessible_instances = set(Instance.objects.filter(accessible_filter))
+
+    instances = user_instances.intersection(accessible_instances)
+
+    # The logged-in user should see the current instance in their own list
+    if current_instance and logged_in_user == user:
+        instances = instances.union({current_instance})
+
+    instances = sorted(instances, cmp=lambda x, y: cmp(x.name, y.name))
+    return instances
+
+
 def user(request, username):
     user = get_object_or_404(User, username=username)
     instance_id = request.GET.get('instance_id', None)
@@ -1011,7 +1034,8 @@ def user(request, username):
     return {'user': user,
             'reputation': reputation,
             'instance_id': instance_id,
-            'total_count': audit_dict['total_count'],
+            'instances': _user_instances(request.user, user, instance),
+            'total_edits': audit_dict['total_count'],
             'audits': audit_dict['audits'],
             'next_page': audit_dict['next_page'],
             'public_fields': public_fields,


### PR DESCRIPTION
Show banner counts/tabs on User Details page
- Categories are "Tree Maps" and "Edits"
- Use singular form ("Tree Map" or "Edit") if there's only one

"Tree Maps" list includes:
- maps the user has joined (via invite) or edited, which current user has permission to view
- the map most recently visited in the current session (if user is looking at their own list)
