### PR TITLE
Performance enhancements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 django-extensions==1.2.5
 six==1.4.1
 django-debug-toolbar==1.2
+git+git://github.com/streeter/johnny-panel.git

--- a/opentreemap/opentreemap/settings.py
+++ b/opentreemap/opentreemap/settings.py
@@ -158,6 +158,8 @@ TEMPLATE_LOADERS = (
 )
 
 MIDDLEWARE_CLASSES = (
+    'johnny.middleware.LocalStoreClearMiddleware',
+    'johnny.middleware.QueryCacheMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,5 @@ django-contrib-comments==1.5
 django-threadedcomments==0.9.0
 django-apptemplates==0.0.1
 django-queryset-csv>=0.2.7
+django-redis-cache==0.13.0
+git+https://github.com/jmoiron/johnny-cache.git@262525216f0d0ae


### PR DESCRIPTION
After some investigation, it seems like the biggest culprit for slowness on the plot detail page is  `form_extras.py`.

Specifically, it makes a set of requests for every field on the page for:
- The instance user
- The instance user's role
- The field permissions for the instance user

It seems like these could be easily stored in a thread local cache, as there isn't a scenario where these will be changed during the course of handling the request that we would _want_ to capture.

This PR brings in [Johnny Cache](https://github.com/jmoiron/johnny-cache), which provides a generic QuerySet caching, using Redis as the backend.  Just using johnny-cache gives a x4 speed improvement when the cache is warmed up.
It also provides a thread local storage cache, which is invalidated at the end of every request, which we can use for further manual caching.
