### PR TITLE
Really fix UI tests

### DIFF
--- a/opentreemap/opentreemap/test_settings.py
+++ b/opentreemap/opentreemap/test_settings.py
@@ -7,3 +7,8 @@ PASSWORD_HASHERS = (
 )
 
 STATIC_URL = 'http://localhost:/static/'
+
+# For session management use file backend instead of DB, to reduce extraneous
+# transactions which can cause deadlock when UI test tearDown() truncates all
+# tables.
+SESSION_ENGINE = "django.contrib.sessions.backends.file"

--- a/opentreemap/treemap/tests/ui/map.py
+++ b/opentreemap/treemap/tests/ui/map.py
@@ -168,7 +168,7 @@ class MapTest(TreemapUITestCase):
         # Click on the tree we added
         self.click_point_on_map(20, 20)
 
-        self.click('#quick-edit-button')
+        self.click_when_visible('#quick-edit-button')
         self.wait_until_visible('#save-details-button')
 
         diameter = self.driver.find_element_by_css_selector(
@@ -222,7 +222,7 @@ class ModeChangeTest(TreemapUITestCase):
         self.click_point_on_map(20, 20)
 
         # enter edit mode, which should lock
-        self.click('#quick-edit-button')
+        self.click_when_visible('#quick-edit-button')
 
         expected_alert_text = ("You have begun entering data. "
                                "Any unsaved changes will be lost. "

--- a/opentreemap/treemap/tests/ui/plot_detail.py
+++ b/opentreemap/treemap/tests/ui/plot_detail.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+from time import sleep
 from selenium.common.exceptions import ElementNotVisibleException
 from django.contrib.gis.geos import Point
 
@@ -15,20 +16,18 @@ from treemap.models import Plot, Tree
 
 class PlotEditTest(TreemapUITestCase):
 
-    def test_empty_plot_edit_url(self):
+    def test_edit_empty_plot(self):
 
         self.login_and_go_to_map_page()
         self.start_add_tree(20, 20)
 
-        self.add_tree_done()
+        self.add_tree_done('edit')
 
         self.assertEqual(1, self.nplots())
 
         plot = self.instance_plots().order_by('-id')[0]
 
         self.assertEqual(plot.width, None)
-
-        self.go_to_feature_detail(plot.pk, edit=True)
 
         plot_width_field = self.find('input[name="plot.width"]')
         plot_width_field.clear()
@@ -40,6 +39,8 @@ class PlotEditTest(TreemapUITestCase):
         plot = Plot.objects.get(pk=plot.pk)
 
         self.assertEqual(plot.width, 5)
+
+        sleep(1)  # prevent hang
 
     @skip("This test will pass when issue #943 is fixed "
           "https://github.com/azavea/OTM2/issues/943")

--- a/opentreemap/treemap/tests/ui/registration_views.py
+++ b/opentreemap/treemap/tests/ui/registration_views.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+from time import sleep
 from django.core.urlresolvers import reverse
 from django.core import mail
 
@@ -57,6 +58,8 @@ class LoginLogoutTest(UITestCase):
 
         value = email_element.get_attribute('data-value')
         self.assertEqual(self.user.email, value)
+
+        sleep(1)  # prevent hang
 
 
 class ForgotUsernameTest(UITestCase):


### PR DESCRIPTION
- For session management use file backend instead of DB, to reduce extraneous transactions
- Add `sleep(1)` to two tests which sometimes caused deadlock because there was still DB activity (reads, not writes) when the driver ended the test and truncated the tables. I can't explain how a read can cause deadlock, but it definitely does in this case.
