### PR TITLE
Fix production crash caused by a name longer than 30 chars

### DIFF
--- a/opentreemap/treemap/migrations/0066_copy_smushname_to_no_smush_name.py
+++ b/opentreemap/treemap/migrations/0066_copy_smushname_to_no_smush_name.py
@@ -24,7 +24,7 @@ class Migration(DataMigration):
                     if no_smush_val:
                         conflict_message = base_user_template % locals()
                         print(conflict_message)
-                    setattr(user, no_smush_field, smush_val)
+                    setattr(user, no_smush_field, smush_val[:30])
                     # for good measure
                     setattr(user, smush_field, '')
                     user.save()


### PR DESCRIPTION
Maybe trailing blanks?
