### PR TITLE
Send id fields when serializing collection UDFs

### DIFF
--- a/opentreemap/treemap/js/src/inlineEditForm.js
+++ b/opentreemap/treemap/js/src/inlineEditForm.js
@@ -208,11 +208,18 @@ exports.init = function(options) {
 
                 data[name] =
                     _.map($table.find('tr[data-value-id]').toArray(), function(row) {
-                        return _.object(headers, $(row)
-                                        .find('td')
+                        var $row = $(row),
+                            $tds = $row.find('td'),
+                            id = $row.attr('data-value-id'),
+
+                            rowData = _.object(headers, $tds
                                         .map(function() {
                                             return $.trim($(this).html());
                                         }));
+                        if (! _.isEmpty(id)) {
+                            rowData.id = id;
+                        }
+                        return rowData;
                     });
             });
 


### PR DESCRIPTION
This allows the backend to determine if a row is new or already present,
and prevents it from generating spurious audit logs for unchanged rows
which are already present.

Fixes #1327
