### PR TITLE
Try alternate mount syntax in vagrant provisioning

### DIFF
--- a/scripts/virtualbox.sh
+++ b/scripts/virtualbox.sh
@@ -3,4 +3,13 @@
 # vagrant mounts the share as the wrong user (vagrant)
 # umount and remount as otm.
 mountpoint -q /usr/local/otm/app/ && umount /usr/local/otm/app/
-mount -t vboxsf -o uid=`id -u otm`,gid=`id -g vagrant` '/usr/local/otm/app' /usr/local/otm/app/
+mkdir -p /usr/local/otm/app
+success_message="Remounted /usr/local/otm/app as otm"
+if mount -t vboxsf -o uid=`id -u otm`,gid=`id -g vagrant` '/usr/local/otm/app' /usr/local/otm/app/ ; then
+  echo $success_message
+else
+  echo "Remounting failed. Trying alternate syntax..."
+  if mount.vboxsf -o uid=`id -u otm`,gid=`id -g vagrant` usr_local_otm_app /usr/local/otm/app/ ; then
+    echo $success_message
+  fi
+fi


### PR DESCRIPTION
Laurence's linux box, my OS X machine, and Christopher's OS X machine all had problems with remounting the shared folder inside the vagrant box as the 'otm' user. Googling the issue turned up an alternate syntax that works for us, but fails on Steve's linux box. I assume this has something to due with versioning of either Vagrant or Virtual Box.

This change to the provisioning script tries the original mount method and falls back to the second on failure.
