### PR TITLE
Fix ecobenefits search for "missing photos" search

### DIFF
--- a/opentreemap/treemap/search.py
+++ b/opentreemap/treemap/search.py
@@ -27,12 +27,14 @@ DEFAULT_MAPPING = {'plot': '',
                    'tree': 'tree__',
                    'species': 'tree__species__',
                    'treePhoto': 'tree__treephoto__',
+                   'mapFeaturePhoto': 'mapfeaturephoto__',
                    'mapFeature': ''}
 
 TREE_MAPPING = {'plot': 'plot__',
                 'tree': '',
                 'species': 'species__',
                 'treePhoto': 'treephoto__',
+                'mapFeaturePhoto': 'treephoto__',
                 'mapFeature': 'plot__'}
 
 PLOT_RELATED_MODELS = {Plot, Tree, Species, TreePhoto}


### PR DESCRIPTION
The client now always sends "mapFeaturePhoto", but the search mappings of
object name -> django orm string was missed when adding in MapFeaturePhoto
searching.
