### PR TITLE
Add warning to api.

### DIFF
--- a/opentreemap/api/user.py
+++ b/opentreemap/api/user.py
@@ -101,6 +101,8 @@ def create_user(request):
     if dup_username.exists():
         return _conflict_response(trans('Username is already in use'))
     if dup_email.exists():
+        # BE WARNED - The iOS application relies on this error message string.
+        # If you change this you WILL NEED TO ALTER CODE THERE AS WELL.
         return _conflict_response(trans('Email is already in use'))
 
     user = User(**data)


### PR DESCRIPTION
Since this endpoint doesn't currently returned structured data about the failure
we need to decide what message to show the user based on the body text of the
message. This means that changing this string in the api could cause failures.
Until this is fixed this warning will hopefully prevent changes that might have
such an effect.
