### PR TITLE
Change password reset API endpoint

### DIFF
--- a/opentreemap/api/tests.py
+++ b/opentreemap/api/tests.py
@@ -1689,3 +1689,12 @@ class UserApiExportsTest(UserExportsTestCase):
 
     def test_json_requires_admin(self):
         self._test_requires_admin_access('users_json')
+
+
+class PasswordResetTest(OTMTestCase):
+    def test_send_password_reset_email_url(self):
+        data = {"email": self.user1.email}
+        response = post_json(
+            "%s/send-password-reset-email" % API_PFX,
+            data, self.client, None)
+        self.assertEquals(response.status_code, 200)

--- a/opentreemap/api/urls.py
+++ b/opentreemap/api/urls.py
@@ -37,8 +37,9 @@ urlpatterns = patterns(
         name='update_user'),
     url(r'^user/(?P<user_id>\d+)/photo$', update_profile_photo_endpoint,
         name='update_user_photo'),
-    (r'^user/(?P<user_id>\d+)/reset_password$', reset_password),
     (r'^user/(?P<user_id>\d+)/edits$', edits),
+
+    (r'^send-password-reset-email$', reset_password),
 
     ('^locations/' + lat_lon_pattern + '/instances',
      instances_closest_to_point_endpoint),


### PR DESCRIPTION
This endpoint has been broken since the creation of the API. Nesting the password reset under users/{user-id} is not possible. If the user is resorting to sending a password reset email, then they cannot log in and the app cannot know their user ID.

This is a major change to an endpoint, however this cannot break any clients, since no clients have ever hit this endpoint successfully. For that reason, I am _not_ bumping the API version from 3 to 4.
