### PR TITLE
Change password reset API endpoint

### DIFF
--- a/opentreemap/api/tests.py
+++ b/opentreemap/api/tests.py
@@ -35,7 +35,8 @@ from exporter.tests import UserExportsTestCase
 
 from api.test_utils import setupTreemapEnv, mkPlot, mkTree
 from api.models import APIAccessCredential
-from api.views import add_photo_endpoint, update_profile_photo_endpoint
+from api.views import (add_photo_endpoint, update_profile_photo_endpoint,
+                       reset_password)
 from api.instance import (instances_closest_to_point, instance_info,
                           public_instances)
 from api.user import create_user
@@ -1689,3 +1690,16 @@ class UserApiExportsTest(UserExportsTestCase):
 
     def test_json_requires_admin(self):
         self._test_requires_admin_access('users_json')
+
+
+class PasswordResetTest(OTMTestCase):
+    def setUp(self):
+        self.instance = setupTreemapEnv()
+        self.jim = User.objects.get(username="jim")
+
+    def test_send_password_reset_email(self):
+        data = {"email": self.jim.email}
+        r = sign_request(make_request(method='POST',
+                                      params=data))
+        response = reset_password(r)
+        self.assertEquals(response.status_code, 200)

--- a/opentreemap/api/urls.py
+++ b/opentreemap/api/urls.py
@@ -37,8 +37,9 @@ urlpatterns = patterns(
         name='update_user'),
     url(r'^user/(?P<user_id>\d+)/photo$', update_profile_photo_endpoint,
         name='update_user_photo'),
-    (r'^user/(?P<user_id>\d+)/reset_password$', reset_password),
     (r'^user/(?P<user_id>\d+)/edits$', edits),
+
+    (r'^send-password-reset-email$', reset_password),
 
     ('^locations/' + lat_lon_pattern + '/instances',
      instances_closest_to_point_endpoint),

--- a/opentreemap/api/views.py
+++ b/opentreemap/api/views.py
@@ -112,7 +112,7 @@ def reset_password(request):
             'use_https': request.is_secure(),
             'token_generator': default_token_generator,
             'from_email': None,
-            'email_template_name': 'reset_email_password.html',
+            'email_template_name': 'registration/password_reset_email.html',
             'request': request}
 
         resetform.save(**opts)


### PR DESCRIPTION
This endpoint has been broken since the creation of the API. Nesting the password reset under users/{user-id} is not possible. If the user is resorting to sending a password reset email, then they cannot log in and the app cannot know their user ID.

This is a major change to an endpoint, however this cannot break any clients, since no clients have ever hit this endpoint successfully. For that reason, I am _not_ bumping the API version up from 3 to 4.
