### PR TITLE
Update password reset request API

### DIFF
--- a/opentreemap/api/tests.py
+++ b/opentreemap/api/tests.py
@@ -35,8 +35,7 @@ from exporter.tests import UserExportsTestCase
 
 from api.test_utils import setupTreemapEnv, mkPlot, mkTree
 from api.models import APIAccessCredential
-from api.views import (add_photo_endpoint, update_profile_photo_endpoint,
-                       reset_password)
+from api.views import (add_photo_endpoint, update_profile_photo_endpoint)
 from api.instance import (instances_closest_to_point, instance_info,
                           public_instances)
 from api.user import create_user
@@ -1697,9 +1696,7 @@ class PasswordResetTest(OTMTestCase):
         self.instance = setupTreemapEnv()
         self.jim = User.objects.get(username="jim")
 
-    def test_send_password_reset_email(self):
-        data = {"email": self.jim.email}
-        r = sign_request(make_request(method='POST',
-                                      params=data))
-        response = reset_password(r)
-        self.assertEquals(response.status_code, 200)
+    def test_send_password_reset_email_url(self):
+        url = "%s/send-password-reset-email?email=%s"
+        response = post_json(url % (API_PFX, self.jim.email),
+                             {}, self.client, None)

--- a/opentreemap/api/urls.py
+++ b/opentreemap/api/urls.py
@@ -11,7 +11,7 @@ from api.views import (status_view, version_view, public_instances_endpoint,
                        remove_current_tree_from_plot, plots_endpoint,
                        species_list_endpoint, approve_pending_edit,
                        reject_pending_edit, update_user_endpoint,
-                       reset_password, user_endpoint,
+                       reset_password_endpoint, user_endpoint,
                        plot_endpoint, edits, plots_closest_to_point_endpoint,
                        instance_info_endpoint, add_photo_endpoint,
                        export_users_csv_endpoint, export_users_json_endpoint,
@@ -39,7 +39,7 @@ urlpatterns = patterns(
         name='update_user_photo'),
     (r'^user/(?P<user_id>\d+)/edits$', edits),
 
-    (r'^send-password-reset-email$', reset_password),
+    (r'^send-password-reset-email$', reset_password_endpoint),
 
     ('^locations/' + lat_lon_pattern + '/instances',
      instances_closest_to_point_endpoint),

--- a/opentreemap/api/views.py
+++ b/opentreemap/api/views.py
@@ -17,7 +17,7 @@ from django.contrib.auth.tokens import default_token_generator
 
 from opentreemap.util import route, decorate as do
 
-from treemap.models import Plot, Tree
+from treemap.models import Plot, Tree, User
 from treemap.views import species_list
 from treemap.lib.map_feature import context_dict_for_plot
 from treemap.lib.tree import add_tree_photo_helper
@@ -102,11 +102,14 @@ def edits(request, instance, user_id):
     return keys
 
 
-@require_http_methods(["POST"])
-@json_api_call
 def reset_password(request):
-    resetform = PasswordResetForm({"email": request.REQUEST["email"]})
+    email =  request.REQUEST["email"]
+    try:
+        User.objects.get(email=email)
+    except User.DoesNotExist:
+        return {"status": "failure", "message": "Email address not found."}
 
+    resetform = PasswordResetForm({"email": email})
     if (resetform.is_valid()):
         opts = {
             'use_https': request.is_secure(),
@@ -354,3 +357,5 @@ export_users_json_endpoint = do(
     set_api_version,
     admin_instance_request,
     route(GET=users_json))
+
+reset_password_endpoint = api_do(route(POST=reset_password))


### PR DESCRIPTION
My first crack at fixing this did not work. The passing unit test did not reflect the runtime behavior, which was a 403 CSRF-relates error.

I rewrote the test to make sure it passed through the entire web stack, and then refactored the endpoint using the nested function style, incorporating signature checking and CSRF-exemption. I also added a check to see if the email was associated with an account and return a failure message if not. This prevents clients from showing a "check your email" message when the server did not even attempt to send an email.
