### PR TITLE
Solidify getting an instance's itree region codes

### DIFF
--- a/opentreemap/treemap/ecobenefits.py
+++ b/opentreemap/treemap/ecobenefits.py
@@ -97,9 +97,9 @@ class TreeBenefitsCalculator(BenefitCalculator):
         # When calculating benefits we can skip region information
         # if there is only one intersecting region or if the
         # instance forces a region on us
-        regions = instance.itree_regions()
-        if len(regions) == 1:
-            region_code = regions[0].code
+        region_codes = instance.itree_region_codes()
+        if len(region_codes) == 1:
+            region_code = region_codes[0]
         else:
             region_code = None
 

--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -327,16 +327,17 @@ class Instance(models.Model):
 
         return names
 
-    def itree_regions(self):
+    def itree_region_codes(self):
         from treemap.models import ITreeRegion
 
         if self.itree_region_default:
-            regions = [self.itree_region_default]
+            region_codes = [self.itree_region_default]
         else:
-            regions = ITreeRegion.objects.filter(
-                geometry__intersects=self.bounds)
+            region_codes = ITreeRegion.objects \
+                .filter(geometry__intersects=self.bounds) \
+                .values_list('code', flat=True)
 
-        return regions
+        return region_codes
 
     def has_itree_region(self):
         from treemap.models import ITreeRegion  # prevent circular import


### PR DESCRIPTION
It was failing for the (Edmonton) case where an instance outside the US has an iTree region assigned.
