### PR TITLE
Add sort key to default mobile api fields

### DIFF
--- a/opentreemap/api/tests.py
+++ b/opentreemap/api/tests.py
@@ -1083,7 +1083,8 @@ class Instance(LocalMediaTestCase):
 
         self.assertIn({'header': 'Stewardship',
                        'collection_udf_keys': ['plot.udf:Stewardship',
-                                               'tree.udf:Stewardship']},
+                                               'tree.udf:Stewardship'],
+                       'sort_key': 'Date'},
                       info_dict['field_key_groups'])
 
     def test_collection_udfs_removed_in_v2(self):

--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -46,7 +46,8 @@ DEFAULT_MOBILE_API_FIELDS = [
     {'header': trans('Planting Site Information'),
      'field_keys': ['plot.width', 'plot.length']},
     {'header': trans('Stewardship'),
-     'collection_udf_keys': ['plot.udf:Stewardship', 'tree.udf:Stewardship']}
+     'collection_udf_keys': ['plot.udf:Stewardship', 'tree.udf:Stewardship'],
+     'sort_key': 'Date'}
 ]
 
 DEFAULT_TREE_STEWARDSHIP_CHOICES = [


### PR DESCRIPTION
Because the mobile clients will merge together plot and tree stewardship,
we need to signal to the clients how to sort the merged lists of
stewardship events.

We have no mechanism for changing collection UDF field
definitions at the moment, but if/when we add it this will cause us to need
to take care to not allow the definitions of plot and tree stewardship to
get out of sync
