### PR TITLE
Fix eco request content type

### DIFF
--- a/opentreemap/treemap/ecobackend.py
+++ b/opentreemap/treemap/ecobackend.py
@@ -46,8 +46,7 @@ def json_benefits_call(endpoint, params, post=False):
         data = json.dumps(paramdata)
         req = urllib2.Request(url,
                               data,
-                              #{'Content-Type': 'application/json'},
-                              {'Content-Type': 'text/plain'})
+                              {'Content-Type': 'application/json'})
     else:
         paramString = "&".join(["%s=%s" % (urllib.quote_plus(str(name)),
                                            urllib.quote_plus(str(val)))


### PR DESCRIPTION
The go-rest dependency of the eco service was updated to use the more
correct application/json content type when posting JSON encoded data

https://github.com/ungerik/go-rest/commit/c3ee1de9e2197fe2812b818f25d2fc59fab9a13e
