### PR TITLE
Fix missing photo search on mobile apps

### DIFF
--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -37,7 +37,7 @@ DEFAULT_MOBILE_SEARCH_FIELDS = {
                  'label': 'Missing Species'},
                 {'identifier': 'tree.diameter',
                  'label': 'Missing Diameter'},
-                {'identifier': 'treePhoto.id',
+                {'identifier': 'mapFeaturePhoto.id',
                  'label': 'Missing Photo'}]
 }
 


### PR DESCRIPTION
OpenTreeMap/OTM2-tiler@46f6c4 switched from using treePhoto to
mapFeaturePhoto for photo search.  We updated the website search
configuration but neglected to change the mobile search configuration.
