### PR TITLE
Don't Save trees and plots marked present=False

### DIFF
--- a/opentreemap/otm1_migrator/migration_rules/philadelphia.py
+++ b/opentreemap/otm1_migrator/migration_rules/philadelphia.py
@@ -59,7 +59,8 @@ SORT_ORDER_INDEX = {
 }
 
 
-def mutate_boundary(boundary_obj, otm1_fields):
+def mutate_boundary(boundary_obj, boundary_dict):
+    otm1_fields = boundary_dict.get('fields')
     if ((boundary_obj.name.find('County') != -1
          or boundary_obj.name == 'Philadelphia')):
         boundary_obj.category = 'County'
@@ -71,8 +72,11 @@ def mutate_boundary(boundary_obj, otm1_fields):
         county = otm1_fields['county']
         boundary_obj.category = county + ' Township'
         boundary_obj.sort_order = SORT_ORDER_INDEX[county]
+    return boundary_obj
 
-MIGRATION_RULES['boundary']['record_mutators'] = [mutate_boundary]
+MIGRATION_RULES['boundary']['record_mutators'] = (MIGRATION_RULES['boundary']
+                                                  .get('record_mutators', [])
+                                                  + [mutate_boundary])
 MIGRATION_RULES['species']['missing_fields'] |= {'other'}
 
 # these fields don't exist in the ptm fixture, so can't be specified

--- a/opentreemap/otm1_migrator/migration_rules/standard_otm1.py
+++ b/opentreemap/otm1_migrator/migration_rules/standard_otm1.py
@@ -5,6 +5,8 @@ from threadedcomments.models import ThreadedComment
 
 from django.contrib.gis.geos import fromstr
 
+from otm1_migrator.data_util import discard_deleted
+
 # model specification:
 #
 # model_class:        the django class object used to instantiate objects
@@ -68,7 +70,8 @@ MIGRATION_RULES = {
         'value_transformers': {
             'readonly':
             (lambda x: False if (x is None or x is False) else True),
-        }
+        },
+        'record_mutators': [discard_deleted]
     },
     'audit': {
         'command_line_flag': '-a',
@@ -103,6 +106,7 @@ MIGRATION_RULES = {
             (lambda x: False if (x is None or x is False) else True),
             'geometry': (lambda x: fromstr(x, srid=4326)),
         },
+        'record_mutators': [discard_deleted]
     },
     'species': {
         'command_line_flag': '-s',
@@ -141,7 +145,8 @@ MIGRATION_RULES = {
     },
     'userprofile': {
         'command_line_flag': '-z',
-        'dependencies': {'user': 'user'}
+        'dependencies': {'user': 'user'},
+        'common_fields': {'photo'}
     },
     'comment': {
         'command_line_flag': '-n',


### PR DESCRIPTION
The flow of data through the migrator has changed a little bit with this
commit. Now, dict_to_model is called outside of the individual
model_save_fn functions, so that it can bail without a save
happening. This behavior needs to happen for all models, so it has been
lifted up a level.

dict_to_model now has two ways it can bail out early
1) if the provided model rule does not have an accompanying class (for
models that we don't actually save, just process, like UserProfile)
2) If the list of record_mutators ever returns None. record_mutators can
now support validation failures because if they return none, it stops
the save process and skips the record.
