### PR TITLE
Return instance bbox radius from API.

### DIFF
--- a/opentreemap/api/instance.py
+++ b/opentreemap/api/instance.py
@@ -227,6 +227,11 @@ def _instance_info_dict(instance):
     bounds = instance.bounds
     bounds.transform(4326)
     extent = bounds.extent
+    p1 = Point(float(extent[0]), float(extent[1]), srid=4326)
+    p2 = Point(float(extent[2]), float(extent[3]), srid=4326)
+    p1.transform(3857)
+    p2.transform(3857)
+    extent_radius = p1.distance(p2) / 2
 
     info = {'geoRevHash': instance.geo_rev_hash,
             'id': instance.pk,
@@ -238,6 +243,7 @@ def _instance_info_dict(instance):
                        'min_lat': extent[1],
                        'max_lng': extent[2],
                        'max_lat': extent[3]},
+            'extent_radius': extent_radius,
             'eco': _instance_eco_dict(instance)
             }
 


### PR DESCRIPTION
The iOS application uses the size of the instance to filter out search results
but this value was being specified at by the iOS app and was a hardcoded value
that was not in any way related to the actual instance. This was found to be a
problem because the radius accross LA is much larger than the radius that the
iOS app had hardcoded. Since this may be a useful feature in other applications
or contexts and since we do most geoprocessing at the API level anyway, we
calculate the radius on the server and provide it with the other data about the
instance.
