### PR TITLE
Hide audits created by the system user.

### DIFF
--- a/opentreemap/treemap/lib/map_feature.py
+++ b/opentreemap/treemap/lib/map_feature.py
@@ -12,7 +12,7 @@ from django.db.models import Q
 
 from treemap.audit import Audit
 from treemap.ecobackend import BAD_CODE_PAIR
-from treemap.models import Tree, MapFeature
+from treemap.models import Tree, MapFeature, User
 
 from treemap.lib import format_benefits
 from treemap.lib.photo import context_dict_for_photo
@@ -41,7 +41,9 @@ def _map_feature_audits(user, instance, feature, filters=None,
     # (about a 50% inprovement!)
     # TODO: Verify this is still the case now that we are also getting
     # collection udf audits
-    iaudit = Audit.objects.filter(instance=instance)
+    iaudit = Audit.objects\
+        .filter(instance=instance)\
+        .exclude(user=User.system_user())
 
     audits = []
     for afilter in filters:

--- a/opentreemap/treemap/lib/user.py
+++ b/opentreemap/treemap/lib/user.py
@@ -8,7 +8,7 @@ import urllib
 from django.db.models import Q
 
 from treemap.audit import Audit, Authorizable, get_auditable_class
-from treemap.models import Plot, Tree, Instance, MapFeature, InstanceUser
+from treemap.models import Plot, Tree, Instance, MapFeature, InstanceUser, User
 from treemap.util import get_filterable_audit_models
 
 
@@ -87,6 +87,7 @@ def get_audits(logged_in_user, instance, query_vars, user, models,
         .filter(model_filter) \
         .filter(instance__in=instances) \
         .exclude(udf_bookkeeping_fields) \
+        .exclude(user=User.system_user()) \
         .order_by('-created', 'id')
 
     if user:


### PR DESCRIPTION
The OTM1 -> OTM2 migrater system saves models using the system user.
This is because the OTM1 audit system is not robust enough to fully
migrate over audits, and we would like every field to have at least one
audit.

Because of this, we don't want to show system user audits in the UI, as it
would clutter and hide the "real" edits.
