### PR TITLE
Fix comment styling

### DIFF
--- a/opentreemap/treemap/templates/treemap/map_feature_detail.html
+++ b/opentreemap/treemap/templates/treemap/map_feature_detail.html
@@ -119,7 +119,7 @@
           <h3>{% trans "Comments" %}</h3>
           <div id="comments-container">
             {% get_comment_list for feature as comments %}
-            {% for comment in comments %}
+            {% for comment in comments|fill_tree|annotate_tree %}
                {% ifchanged comment.parent_id %}{% else %}</li>{% endifchanged %}
                {% if not comment.open and not comment.close %}</li>{% endif %}
                {% if comment.open %}<ul>{% endif %}


### PR DESCRIPTION
Commit 59426e72cb broke the styling for threaded comments by ommiting
`|fill_tree|annotate_tree` template tag filters on the comment list.

These filters add the parent_id, open, and close attributes to comments,
and are essential for rendering comments.

Fixes #1549, #1550, and #1551
