### PR TITLE
Add a tabindex to the username, password, and log in button

### DIFF
--- a/opentreemap/treemap/templates/registration/login.html
+++ b/opentreemap/treemap/templates/registration/login.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% load util %}
 
 {% block page_title %} | {% trans "Login" %}{% endblock %}
 
@@ -30,11 +31,11 @@
                         </a>
                     {% endif %}
                     {{ field.label_tag}}
-                    {{ field }}
+                    {{ field|tabindex:forloop.counter }}
                     {{ field.errors|safe }}
                 </div>
             {% endfor %}
-            <button type="submit" value="{% trans 'Log in' %}" class="btn btn-lg btn-primary">{% trans 'Log in' %}</button>
+            <button type="submit" value="{% trans 'Log in' %}" class="btn btn-lg btn-primary" tabindex="3">{% trans 'Log in' %}</button>
             <input type="hidden" name="next" value="{{ next }}" />
         </fieldset>
     </form>

--- a/opentreemap/treemap/templatetags/util.py
+++ b/opentreemap/treemap/templatetags/util.py
@@ -103,3 +103,12 @@ def is_filterable_audit_model(model_name):
     allowed_models = get_filterable_audit_models()
 
     return model_name in allowed_models.values()
+
+
+@register.filter
+def tabindex(value, index):
+    """
+    Adds a tabindex to a Django forms widget
+    """
+    value.field.widget.attrs['tabindex'] = index
+    return value


### PR DESCRIPTION
This allows you to log in using only the keyboard, without accidentally
going to "Recover my password".

Fixes #1486
