### PR TITLE
Add Validation to Forgot Username

### DIFF
--- a/opentreemap/treemap/templates/treemap/forgot_username.html
+++ b/opentreemap/treemap/templates/treemap/forgot_username.html
@@ -13,7 +13,7 @@
       </label>
       <div class="row">
           <div class="col-md-9">
-              <input type="email" name="email" />
+              <input type="email" name="email" required />
           </div>
           <div class="col-md-3">
               <input type="submit" class="btn btn-block btn-primary" value="{% trans 'Send' %}" />

--- a/opentreemap/treemap/views/user.py
+++ b/opentreemap/treemap/views/user.py
@@ -11,7 +11,7 @@ from django.template.loader import render_to_string
 from django.utils.translation import ugettext as trans
 from django.core.urlresolvers import reverse
 from django.shortcuts import get_object_or_404
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, HttpResponseBadRequest
 
 from opentreemap.util import json_from_request
 
@@ -130,6 +130,9 @@ def profile_to_user(request):
 
 def forgot_username(request):
     user_email = request.REQUEST['email']
+    if not user_email:
+          return HttpResponseBadRequest("email field is required!")
+
     users = User.objects.filter(email=user_email)
 
     # Don't reveal if we don't have that email, to prevent email harvesting


### PR DESCRIPTION
Added a `required` HTML5 attribute to prevent submitting an empty username
and we throw an appropriate error if a blank username is sent to the
server. Fixes #1374!
