### PR TITLE
Handle unstructured text errors from ecoservice

### DIFF
--- a/opentreemap/treemap/lib/map_feature.py
+++ b/opentreemap/treemap/lib/map_feature.py
@@ -11,7 +11,7 @@ from django.utils.translation import ugettext as trans
 from django.db.models import Q
 
 from treemap.audit import Audit
-from treemap.ecobackend import BAD_CODE_PAIR
+from treemap.ecobackend import ECOBENEFIT_ERRORS
 from treemap.models import Tree, MapFeature, User
 
 from treemap.lib import format_benefits
@@ -72,8 +72,9 @@ def _add_eco_benefits_to_context_dict(instance, feature, context):
     benefits, basis, error = FeatureClass.benefits\
                                          .benefits_for_object(
                                              instance, feature)
-    if error == BAD_CODE_PAIR:
-        context['invalid_eco_pair'] = True
+
+    if error in ECOBENEFIT_ERRORS:
+        context[error] = True
     elif benefits:
         context.update(format_benefits(instance, benefits, basis))
 

--- a/opentreemap/treemap/templates/treemap/partials/plot_eco.html
+++ b/opentreemap/treemap/templates/treemap/partials/plot_eco.html
@@ -7,6 +7,12 @@
   <p>The tree's location falls within a climate region that does not support benefit calculations for this species.</p>
   {% endblocktrans %}
 </div>
+{% elif unknown_ecobenefit_error %}
+  {% blocktrans %}
+  <!-- TODO: When the ecoservice returns structured errors, replace this with real conditions -->
+  <!-- Or, maybe always leave this to avoid 500s -->
+  <p>{% trans "We were unable to calculate ecosystem benefits for this tree."}</p>
+  {% endblocktrans %}
 {% elif benefits.plot %}
 <table class="table table-hover">
   <tbody>


### PR DESCRIPTION
fixes #1542 on github

This is a stopgap until the ecoservice can return JSON errors.
