### PR TITLE
Prevent pre-populating date fields

### DIFF
--- a/opentreemap/treemap/js/src/fieldHelpers.js
+++ b/opentreemap/treemap/js/src/fieldHelpers.js
@@ -37,8 +37,15 @@ exports.applyDateToDatepicker = function($elem, value) {
 };
 
 var getTimestampFromDatepicker = exports.getTimestampFromDatepicker = function($elem) {
-    var format = getDateFieldFormat($elem);
-    return moment($elem.datepicker("getDate")).format(format);
+    // The datepicker always has a value, so we must check the
+    // text box to which the date picker is attached for a non-empty
+    // value before fetching the value from the datepicker
+    if ($elem.val()) {
+        var format = getDateFieldFormat($elem);
+        return moment($elem.datepicker("getDate")).format(format);
+    } else {
+        return '';
+    }
 };
 
 exports.formToDictionary = function ($form, $editFields, $displayFields) {


### PR DESCRIPTION
On the tree detail page, the actions edit->save->edit would cause any date fields on the page to be populated with the current date. This was caused by the fact that calling "getDate" on the date picker will always return a value, even if the text box to which the date picker is connected is empty.

Fixes #1581
