### PR TITLE
Show "Boundaries" checkbox in Leaflet layer control

### DIFF
--- a/opentreemap/treemap/js/src/MapManager.js
+++ b/opentreemap/treemap/js/src/MapManager.js
@@ -46,6 +46,7 @@ MapManager.prototype = {
         }
 
         map.addLayer(boundsLayer);
+        this.layersControl.addOverlay(boundsLayer, 'Boundaries');
 
         if (options.trackZoomLatLng) {
             map.on("moveend", _.partial(serializeZoomLatLngFromMap, map));


### PR DESCRIPTION
This lets users toggle boundaries (e.g. neighborhoods, zip codes) via a checkbox in the Leaflet layers control.
