### PR TITLE
Add grunt watch task.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,6 +15,8 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-concat');
     grunt.loadNpmTasks('grunt-contrib-cssmin');
     grunt.loadNpmTasks('grunt-file-creator');
+    grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-shell');
 
     grunt.file.setBase('opentreemap');
 
@@ -69,6 +71,12 @@ module.exports = function(grunt) {
         });
     }
 
+    function getAliasFiles(aliases) {
+        return aliases.map(function(alias) {
+            return alias.split(':')[0];
+        });
+    }
+
     grunt.initConfig({
         'file-creator': {
             test: {
@@ -76,6 +84,17 @@ module.exports = function(grunt) {
                     fs.writeSync(fd, 'TEST_MODULES = ["' + getTestAliasNames().join('","') + '"];');
                     done();
                 }
+            }
+        },
+        watch: {
+            treemap: {
+                files: getAliasFiles(getRegularAliases()),
+                tasks: ['check', 'shell:check_static']
+            }
+        },
+        shell: {
+            check_static: {
+                command: 'fab vagrant static:dev'
             }
         },
         browserify: {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   "devDependencies": {
     "grunt-browserify": "1.2.5",
     "grunt": "0.4.1",
+    "grunt-contrib-watch": "0.6.1",
+    "grunt-shell": "1.1.1",
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-contrib-uglify": "~0.2.4",
     "grunt-sass": "~0.6.1",


### PR DESCRIPTION
Run `grunt watch` to auto rebuild scripts when any JS file has changed.

Notes:
- Run `grunt watch --dev` to build source maps.
- The list of files to watch is cached when you run grunt so you'll need to rerun this command when adding files.
