### PR TITLE
Fix circular import via lazy translation

### DIFF
--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -7,7 +7,7 @@ from django.contrib.gis.db import models
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import RegexValidator
 from django.conf import settings
-from django.utils.translation import ugettext as trans
+from django.utils.translation import ugettext_lazy as trans
 
 import hashlib
 import json

--- a/opentreemap/treemap/units.py
+++ b/opentreemap/treemap/units.py
@@ -7,7 +7,7 @@ from functools import partial
 from numbers import Number
 
 from django.conf import settings
-from django.utils.translation import ugettext as trans
+from django.utils.translation import ugettext_lazy as trans
 from django.utils.formats import number_format
 
 from treemap.json_field import get_attr_from_json_field


### PR DESCRIPTION
EnhancedThreadedCommentFlag inherits from Auditable, which was importing ugettext, which imports all models, including EnhancedThreadedCommentFlag, which created a circular import. This is ok in runserver, but crashes gunicorn. (I was able to get a stack trace from gunicorn by editing the upstart job to include the --debug flag)
