### PR TITLE
Clean up the JS watch task and add a few more.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -87,13 +87,21 @@ module.exports = function(grunt) {
             }
         },
         watch: {
-            treemap: {
+            js: {
                 files: getAliasFiles(getRegularAliases()),
-                tasks: ['check', 'shell:check_static']
+                tasks: ['shell:collect_static']
+            },
+            css: {
+                files: 'treemap/css/sass/**/*.scss',
+                tasks: ['shell:collect_static']
+            },
+            lint: {
+                files: getAliasFiles(getRegularAliases()),
+                tasks: ['check']
             }
         },
         shell: {
-            check_static: {
+            collect_static: {
                 command: 'fab vagrant static:dev'
             }
         },


### PR DESCRIPTION
Linting before rebuilding JS can be kind of a drag, since if the linting
fails it won't rebuild the JS, and things like `console.log` statements will
make linting fail.
This basically makes using `grunt watch` for interactive debugging impossible

So, I've separated check into a separate step from lint.

If you want to watch everything, you can continue to use `grunt watch`.
If you only want to rebuild JS, you can use `grunt watch:js`.
If you only want to check lint, you can use `grunt watch:lint`

I also added a css task, so if you can automatically rebuild sass using
`grunt watch:css`
