### PR TITLE
Cleanup UI properly after error

### DIFF
--- a/opentreemap/treemap/js/src/export.js
+++ b/opentreemap/treemap/js/src/export.js
@@ -10,7 +10,11 @@ var $ = require('jquery'),
     START_URL_ATTR = 'data-export-start-url',
     ENABLE_EXPORT_SELECTOR = '[' + START_URL_ATTR + ']',
     PANEL_SELECTOR = '#export-panel',
-    CANCEL_SELECTOR = PANEL_SELECTOR + " * [data-dismiss]",
+    PREP_LABEL_SELECTOR = PANEL_SELECTOR + " .prep-msg",
+    ERROR_LABEL_SELECTOR = PANEL_SELECTOR + " .error-msg",
+    BUTTON_SELECTOR = PANEL_SELECTOR + " * [data-dismiss]",
+    CANCEL_BUTTON_SELECTOR = PANEL_SELECTOR + " .dismiss-cancel",
+    OK_BUTTON_SELECTOR = PANEL_SELECTOR + " .dismiss-ok",
 
     // While there is an active job id, query the
     // check exporter end-point
@@ -65,65 +69,43 @@ function makeJobCheckStream (attrStream) {
 ////////////////////////////////////////
 
 
-var RadioGroup = function(elementMap) {
-    // Given a map of logical names to jquery elements
-    // (such as {e1: $(...), e2: $(...)})
-    //
-    // return a new RadioGroup with a single method
-    // show(name) that will hide all elements except
-    // name
-    this.show = function(elementToShow) {
-        _.each(elementMap, function($thing, name) {
-            if (name === elementToShow) {
-                $thing.show();
-            } else {
-                $thing.hide();
-            }
-        });
-    };
-};
-
-function getDisplayManager () {
+function getDisplayManager (defaultErrorMessage) {
     var $panel = $(PANEL_SELECTOR),
-        messageRadioGroup = new RadioGroup({
-            prep: $panel.find('.prep-msg'),
-            err: $panel.find('.error-msg')
-        }),
+        $prepLabel = $(PREP_LABEL_SELECTOR),
+        $errorLabel = $(ERROR_LABEL_SELECTOR),
+        $cancel = $(CANCEL_BUTTON_SELECTOR),
+        $ok = $(OK_BUTTON_SELECTOR);
 
-        dismissRadioGroup = new RadioGroup({
-            cancel: $panel.find('.dismiss-cancel'),
-            ok: $panel.find('.dismiss-ok')
-        });
+    function hideInnerElements() {
+        $prepLabel.hide();
+        $errorLabel.hide();
+        $cancel.hide();
+        $ok.hide();
+    }
 
     function wait() {
-        messageRadioGroup.show('prep');
-        dismissRadioGroup.show('cancel');
+        hideInnerElements();
+        $prepLabel.show();
+        $cancel.show();
         $panel.modal('show');
     }
     function dismiss() {
-        messageRadioGroup.show('prep');
-        dismissRadioGroup.show('cancel');
+        hideInnerElements();
         $panel.modal('hide');
     }
-    function error() {
-        messageRadioGroup.show('err');
-        dismissRadioGroup.show('ok');
-        $panel.modal('show');
-    }
     function fail(msg) {
-        // Error response or something we can't handle
-        if (msg === null || msg === '') {
-            error();
-        } else {
-            dismissRadioGroup.show('ok');
-            $panel.find('.modal-body').html(msg);
-            $panel.modal('show');
+        if (msg === null || msg === '' || !_.isString(msg)) {
+            msg = defaultErrorMessage;
         }
+        hideInnerElements();
+        $errorLabel.html(msg);
+        $errorLabel.show();
+        $ok.show();
+        $panel.modal('show');
     }
 
     return {wait: wait,
             dismiss: dismiss,
-            error: error,
             fail: fail};
 }
 
@@ -132,8 +114,9 @@ exports.run = function (options) {
 
     var startStreams = _.map($(ENABLE_EXPORT_SELECTOR), getJobStartStream),
         startStream = Bacon.mergeAll(startStreams),
-        displayManager = getDisplayManager(),
-        cancelStream = $(CANCEL_SELECTOR).asEventStream('click'),
+        defaultErrorMessage = $(ERROR_LABEL_SELECTOR).html(),
+        displayManager = getDisplayManager(defaultErrorMessage),
+        cancelStream = $(BUTTON_SELECTOR).asEventStream('click'),
         checkStream = makeJobCheckStream(startStream.map('.job_id')),
         fileUrlStream = checkStream.filter(isComplete).map('.url'),
         checkFailureMessageStream = checkStream.filter(isFailed).map('.message'),
@@ -141,25 +124,16 @@ exports.run = function (options) {
         exitStream = Bacon.mergeAll(normalExitStream, checkFailureMessageStream),
         globalStream = Bacon.mergeAll(exitStream, checkStream, startStream);
 
-    // pass server failure message through to UI
-    startStream.onError(displayManager.error);
-
     // start waiting when a job is initiated
     startStream.onValue(displayManager.wait);
 
-    // an error can result from a generic javascript error
-    // or a specific error condition returned by the server
-    checkStream.onError(displayManager.error);
+    // handle errors
+    globalStream.onError(jobManager.stop);
+    globalStream.onError(displayManager.fail);
     checkFailureMessageStream.onValue(displayManager.fail);
 
-    fileUrlStream.onValue(function (url) { window.location.href = url; });
-
-    // dismiss the display manager when there's no error
-    // to leave in the modal for acknowledgement
+    // normal exit cleanup
     normalExitStream.onValue(displayManager.dismiss);
-
-    // clear the active job and stop polling if an error occurs
-    // or a finish condition occurs
+    fileUrlStream.onValue(function (url) { window.location.href = url; });
     exitStream.onValue(jobManager.stop);
-    globalStream.onError(jobManager.stop);
 };


### PR DESCRIPTION
I observed that after a failure, the UI did not clean itself up
properly. Subsequent exports worked, but would continue to display the
earlier failure message.

I reworked the displayManager to be a little simpler as well.
