### PR TITLE
Add AJAX posting of comments

### DIFF
--- a/opentreemap/otm_comments/js/src/comments.js
+++ b/opentreemap/otm_comments/js/src/comments.js
@@ -1,0 +1,71 @@
+"use strict";
+
+var $ = require('jquery'),
+    _ = require('lodash'),
+    csrf = require('treemap/csrf'),
+    flagging = require('otm_comments/flagging');
+
+var TEMPLATE_SELECTOR = "#template-comment",
+    COMMENT_ID_ATTR = "data-comment-id";
+
+module.exports = function(config, commentContainerSelector) {
+    var $container = $(commentContainerSelector);
+
+    // Set up cross-site forgery protection
+    $.ajaxSetup(csrf.jqueryAjaxSetupOptions);
+
+    function makeForm(options) {
+        // We need to reload the comment form every time we use it, because it
+        // contains security values that change whenever a comment is posted
+        return _.template($(TEMPLATE_SELECTOR).html(), options);
+    }
+
+    function addMainForm() {
+        if (config.loggedIn) {
+            $container.append(makeForm({
+                parent: '',
+                classname: 'comment-create-form'
+            }));
+        }
+    }
+
+    $container.on('click', 'a[data-comment-id]', function (e) {
+        e.preventDefault();
+
+        var $link = $(e.target);
+
+        // Close other forms
+        $(".comment-reply-form").remove();
+
+        $link.closest('.comment').append(makeForm({
+            parent: $link.attr(COMMENT_ID_ATTR),
+            classname: 'comment-reply-form'
+        }));
+
+        $('#id_comment').focus();
+    });
+
+    // The default comment form is not part of the page by default
+    addMainForm();
+    flagging();
+
+    // Instead of a normal POST, we do a POST but then take the comment container
+    // contents out of the results and stuff them into the comments container
+    // on the page
+    $container.on('click', '[type="submit"]', function(e) {
+        e.preventDefault();
+        var $postButton = $(e.target),
+            $form = $postButton.closest('form'),
+            // "URL"s with a selector in them tell $.load to only load that
+            // part of the result into the element
+            url = $form.attr('action') + " " + commentContainerSelector,
+            paramsArray = $form.serializeArray(),
+            params = {};
+
+        _.each(paramsArray, function(paramObj) {
+            params[paramObj.name] = paramObj.value;
+        });
+
+        $container.load(url, params, addMainForm);
+    });
+};

--- a/opentreemap/treemap/js/src/mapFeature.js
+++ b/opentreemap/treemap/js/src/mapFeature.js
@@ -35,30 +35,6 @@ exports.init = function(options) {
         question: options.config.trans.exitQuestion
     });
 
-    // Add threaded comments "reply" links
-    var commentFormTempl = $("#template-comment").html();
-
-    $('a[data-comment-id]').click(function () {
-        var $a = $(this);
-
-        // Close other forms
-        $(".comment-reply-form").remove();
-
-        var templ = $("#template-comment").html();
-        $a.closest(".comment").append(_.template(commentFormTempl, {
-            parent: $a.data("comment-id"),
-            classname: 'comment-reply-form'
-        }));
-        $('#id_comment').focus();
-    });
-
-    if (options.config.loggedIn) {
-        $('#comments-container').append(_.template(commentFormTempl, {
-            parent: '',
-            classname: 'comment-create-form'
-        }));
-    }
-
     var imageFinishedStream = imageUploadPanel.init(options.imageUploadPanel);
 
     var shouldBeInEditModeBus = new Bacon.Bus();

--- a/opentreemap/treemap/templates/treemap/map_feature_detail.html
+++ b/opentreemap/treemap/templates/treemap/map_feature_detail.html
@@ -254,7 +254,7 @@ var mapFeatureOptions = {
 
 <script>
 (function(require) {
-    require('otm_comments/flagging')();
+    require('otm_comments/comments')(otm.settings, '#comments-container');
 })(require);
 </script>
 


### PR DESCRIPTION
Pull comments JS out of mapFeature.js into comments.js

In order to avoiding having to changing core parts of the Django comments
app or bringing in another commenting library like django-fluent-comments,
this gets the _entire_ plot detail page when adding a comment, and then
strips out the comment section from it and replaces that HTML content.
