### PR TITLE
Make settings.py into a package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ env
 *~
 .vagrant
 .#*
-local_settings.py
+opentreemap/opentreemap/settings/local_settings.py
 /static
 .coverage
 .sass-cache

--- a/fabfile.py
+++ b/fabfile.py
@@ -133,7 +133,7 @@ def check():
         print(jshint)
 
         with cd(env.site_path):
-            flake8 = run(_venv_exec('flake8 --exclude migrations,opentreemap/local_settings.py *'))
+            flake8 = run(_venv_exec('flake8 --exclude migrations,opentreemap/settings/local_settings.py *'))
 
     if jshint.failed or flake8.failed:
         abort('Code linting failed')

--- a/opentreemap/opentreemap/settings/__init__.py
+++ b/opentreemap/opentreemap/settings/__init__.py
@@ -1,0 +1,53 @@
+# The purpose of this package is to provide fine-grained control
+# over how settings are initialized and overridden
+#
+# file summary
+# * ./__init__.py         - the canonical place to manage importing settings
+# * ./default_settings.py - the canonical place to add new settings
+# * ./local_settings.py   - the canonical place to override settings
+#
+# WARNING: !!! DO NOT ADD SETTINGS TO THIS FILE !!!
+# WARNING: !!! USE THIS FILE EXCLUSIVELY TO MANAGE SETTING IMPORTS !!!
+
+STORAGE_UNITS = {}
+DISPLAY_DEFAULTS = {}
+MIDDLEWARE_CLASSES = ()
+RESERVED_INSTANCE_URL_NAMES = ()
+MANAGED_APPS = ()
+UNMANAGED_APPS = ()
+
+from opentreemap.settings.default_settings import *  # NOQA
+
+EXTRA_URLS = (
+    # Mount extra urls. These should be a
+    # tuple of (url path, url module). Something like:
+    #
+    # ('/extra_api/', 'apiv2.urls),
+    # ('/local/', 'local.urls)),
+)
+
+EXTRA_MANAGED_APPS = ()
+EXTRA_UNMANAGED_APPS = ()
+EXTRA_MIDDLEWARE_CLASSES = ()
+EXTRA_RESERVED_INSTANCE_URL_NAMES = ()
+EXTRA_UI_TESTS = ()
+
+EXTRA_DISPLAY_DEFAULTS = {}
+EXTRA_STORAGE_UNITS = {}
+
+from opentreemap.settings.local_settings import *  # NOQA
+
+MANAGED_APPS = EXTRA_MANAGED_APPS + MANAGED_APPS
+UNMANAGED_APPS = EXTRA_UNMANAGED_APPS + UNMANAGED_APPS
+INSTALLED_APPS = MANAGED_APPS + UNMANAGED_APPS
+MIDDLEWARE_CLASSES += EXTRA_MIDDLEWARE_CLASSES
+RESERVED_INSTANCE_URL_NAMES += EXTRA_RESERVED_INSTANCE_URL_NAMES
+
+DISPLAY_DEFAULTS.update(EXTRA_DISPLAY_DEFAULTS)
+STORAGE_UNITS.update(EXTRA_STORAGE_UNITS)
+
+# CELERY
+# NOTE: BROKER_URL and CELERY_RESULT_BACKEND must be set
+#       to a valid redis URL in local_settings.py
+import djcelery
+djcelery.setup_loader()

--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -290,43 +290,6 @@ DISPLAY_DEFAULTS = {
     }
 }
 
-#
-# Mount extra urls from local settings. These should be a
-# tuple of (url path, url module). Something like:
-#
-# EXTRA_URLS = (('/extra_api/', 'apiv2.urls),
-#               ('/local/', 'local.urls))
-#
-EXTRA_URLS = ()
-
-EXTRA_MANAGED_APPS = ()
-EXTRA_UNMANAGED_APPS = ()
-EXTRA_MIDDLEWARE_CLASSES = ()
-EXTRA_RESERVED_INSTANCE_URL_NAMES = ()
-EXTRA_UI_TESTS = ()
-
-EXTRA_DISPLAY_DEFAULTS = {}
-EXTRA_STORAGE_UNITS = {}
-
-BING_API_KEY = None
-
-from opentreemap.local_settings import *  # NOQA
-
-MANAGED_APPS = EXTRA_MANAGED_APPS + MANAGED_APPS
-UNMANAGED_APPS = EXTRA_UNMANAGED_APPS + UNMANAGED_APPS
-INSTALLED_APPS = MANAGED_APPS + UNMANAGED_APPS
-MIDDLEWARE_CLASSES += EXTRA_MIDDLEWARE_CLASSES
-RESERVED_INSTANCE_URL_NAMES += EXTRA_RESERVED_INSTANCE_URL_NAMES
-
-DISPLAY_DEFAULTS.update(EXTRA_DISPLAY_DEFAULTS)
-STORAGE_UNITS.update(EXTRA_STORAGE_UNITS)
-
-# CELERY
-# NOTE: BROKER_URL and CELERY_RESULT_BACKEND must be set
-#       to a valid redis URL in local_settings.py
-import djcelery
-djcelery.setup_loader()
-
 # Time in ms for two clicks to be considered a double-click in some scenarios
 DOUBLE_CLICK_INTERVAL = 300
 
@@ -337,3 +300,5 @@ IE_VERSION_MINIMUM = 9 if DEBUG else 10
 IE_VERSION_UNSUPPORTED_REDIRECT_PATH = '/unsupported'
 
 USE_OBJECT_CACHES = True
+
+BING_API_KEY = None

--- a/opentreemap/treemap/tests/urls.py
+++ b/opentreemap/treemap/tests/urls.py
@@ -14,7 +14,7 @@ from treemap.tests import (make_instance, make_commander_user, login,
                            make_simple_boundary, RequestTestCase)
 from treemap.tests.base import OTMTestCase
 
-from opentreemap.local_settings import STATIC_ROOT
+from opentreemap.settings import STATIC_ROOT
 
 
 class UrlTestCase(OTMTestCase):


### PR DESCRIPTION
The reason for doing this is that it is problematic to have a single
settings.py that is responsible for introduce new settings, handling
overrides, and initializing code paths that use settings.

The problem that turned up is that settings that are _introduced_ lower in
the lexical layout than the statements for responsible _overriding_
settings are left incapable of overrides. Any statement placed in the
canonical default settings should be subject to overrides, unless
explicitly setup to not allow them. We accumulated a bunch of settings
that a developer may wish to override during development but cannot
easily do so.
