### PR TITLE
Fix broken UI tests

### DIFF
--- a/opentreemap/treemap/tests/__init__.py
+++ b/opentreemap/treemap/tests/__init__.py
@@ -275,7 +275,8 @@ def make_user_and_role(instance, username, rolename, permissions):
     return make_user(instance, username, make_role)
 
 
-def make_instance(name=None, is_public=False, url_name=None, point=None):
+def make_instance(name=None, is_public=False, url_name=None, point=None,
+                  edge_length=600):
     if name is None:
         max_instance = Instance.objects.all().aggregate(
             Max('id'))['id__max'] or 0
@@ -299,11 +300,12 @@ def make_instance(name=None, is_public=False, url_name=None, point=None):
     instance.default_role.instance = instance
     instance.default_role.save()
 
-    square = Polygon(((p1.x - 300, p1.y - 300),
-                      (p1.x - 300, p1.y + 300),
-                      (p1.x + 300, p1.y + 300),
-                      (p1.x + 300, p1.y - 300),
-                      (p1.x - 300, p1.y - 300)))
+    d = edge_length / 2
+    square = Polygon(((p1.x - d, p1.y - d),
+                      (p1.x - d, p1.y + d),
+                      (p1.x + d, p1.y + d),
+                      (p1.x + d, p1.y - d),
+                      (p1.x - d, p1.y - d)))
     instance.bounds = MultiPolygon((square,))
     instance.save()
 

--- a/opentreemap/treemap/tests/management.py
+++ b/opentreemap/treemap/tests/management.py
@@ -31,15 +31,7 @@ class CreateInstanceManagementTest(OTMTestCase):
 
 class RandomTreesManagementTest(OTMTestCase):
     def setUp(self):
-        self.instance = make_instance()
-        p1 = self.instance.center
-        square = Polygon(((p1.x - 10000, p1.y - 10000),
-                        (p1.x - 10000, p1.y + 10000),
-                        (p1.x + 10000, p1.y + 10000),
-                        (p1.x + 10000, p1.y - 10000),
-                        (p1.x - 10000, p1.y - 10000)))
-        self.instance.bounds = MultiPolygon((square,))
-        self.instance.save()
+        self.instance = make_instance(edge_length=20000)
         user = make_commander_user(instance=self.instance)
         species = Species(instance=self.instance, otm_code='',
                           common_name='', genus='')

--- a/opentreemap/treemap/tests/ui/__init__.py
+++ b/opentreemap/treemap/tests/ui/__init__.py
@@ -1,9 +1,8 @@
 import importlib
 
-from time import sleep
-
 from django.test import LiveServerTestCase
 from django.conf import settings
+from django.contrib.gis.geos import Point
 
 from selenium.common.exceptions import (WebDriverException,
                                         StaleElementReferenceException)
@@ -11,8 +10,8 @@ from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.firefox.webdriver import WebDriver
 from selenium.webdriver.support.wait import WebDriverWait
 
-from treemap.tests import create_mock_system_user, make_commander_user
-from treemap.models import Tree, Plot, Instance
+from treemap.tests import make_commander_user
+from treemap.models import Instance
 from treemap.lib.object_caches import clear_caches
 from treemap.plugin import setup_for_ui_test
 
@@ -203,7 +202,8 @@ class TreemapUITestCase(UITestCase):
         self.instance = create_instance(
             name=instance_name,
             is_public=False,
-            url_name='autotest-instance')
+            url_name='autotest-instance',
+            edge_length=20000)
 
         self.user = make_commander_user(instance=self.instance,
                                         username='username')

--- a/opentreemap/treemap/tests/ui/plot_detail.py
+++ b/opentreemap/treemap/tests/ui/plot_detail.py
@@ -88,6 +88,7 @@ class PlotDeleteTest(TreemapUITestCase):
     def _click_delete(self):
         self._select_buttons()
         self.delete_begin.click()
+        self.wait_until_visible(self.delete_confirm)
         self.delete_confirm.click()
         self.wait_until_invisible(self.delete_confirm)
 

--- a/opentreemap/treemap/tests/urls.py
+++ b/opentreemap/treemap/tests/urls.py
@@ -257,8 +257,7 @@ class TreemapUrlTests(UrlTestCase):
 
 class InstanceUrlTests(RequestTestCase):
     def setUp(self):
-        make_instance(name='The inztance',
-                      is_public=True,
+        make_instance(name='The inztance', is_public=True,
                       url_name='ThEiNsTaNCe')
 
     def test_case_insensitive_url_lookup_upper(self):

--- a/opentreemap/treemap/views/__init__.py
+++ b/opentreemap/treemap/views/__init__.py
@@ -192,8 +192,8 @@ get_plot_eco_view = do(
 #####################################
 
 delete_tree_view = do(
-    json_api_edit,
     instance_request,
+    json_api_edit,
     delete_tree)
 
 tree_detail_view = instance_request(tree_detail)


### PR DESCRIPTION
- UI tests were making plots outside the instance bounds (`make_instance` had a default radius of 300 units WebMercator)
- `make_instance` now takes a `radius` argument, and the UI tests set it to 10000
- Also simplify management tests by using the `radius` argument
- Clean up imports in UI tests
- Add `wait_until_visible` for safety in `_click_delete`
- Fix misplaced `json_api_edit` in `delete_tree_view`
