### PR TITLE
Only generate source maps via grunt-watch if --dev flag is used.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -106,7 +106,7 @@ module.exports = function(grunt) {
         },
         shell: {
             collect_static: {
-                command: 'fab vagrant static:dev'
+                command: 'fab vagrant static' + (debug ? ':dev_mode=True' : '')
             }
         },
         browserify: {


### PR DESCRIPTION
I had to make this configurable because using source maps in Chrome is very sluggish on my machine. I'm not sure if this should be on or off by default but I figured it makes sense to reuse the `--dev` flag for this.
