### PR TITLE
Set data attribute when resolving alerts

### DIFF
--- a/opentreemap/treemap/js/src/plot.js
+++ b/opentreemap/treemap/js/src/plot.js
@@ -123,6 +123,7 @@ exports.init = function(options) {
         $tables.find('.resolveBtn').click(function () {
             $(this).closest('tr')
                 .find('td:contains("Unresolved")')
+                .attr('data-value', 'Resolved')
                 .text('Resolved');
         });
     }


### PR DESCRIPTION
Fixes #1698

This fixed a regression introduced by 1f0f44e1, which stopped reading values from .html() and started reading values from .attr(). The resolve button was setting the body text of the element, but not the data attribute.
