### PR TITLE
Fix cache saving stale data

### DIFF
--- a/opentreemap/treemap/lib/object_caches.py
+++ b/opentreemap/treemap/lib/object_caches.py
@@ -52,8 +52,17 @@ def invalidate_adjuncts(*args, **kwargs):
         instance = adjunct_object.instance
         if instance.id in _adjuncts:
             del _adjuncts[instance.id]
-        instance.adjuncts_timestamp += 1
-        instance.save()
+        increment_adjuncts_timestamp(instance)
+
+
+def increment_adjuncts_timestamp(instance):
+    from treemap.models import Instance
+    # The instance passed to this function may have stale data, so we
+    # don't want to save stale fields along with the new timestamp.
+    instance = Instance.objects.get(pk=instance.id)
+    instance.adjuncts_timestamp += 1
+    instance.save()
+
 
 # ------------------------------------------------------------------------
 # Fetch info from database when not using cache


### PR DESCRIPTION
After fixing a problem with object caches not being correctly invalidated we discovered a regression. Saving instance properties would trigger the object cache system to increment the timestamp on the instance and save it a second time. Unfortunately, it was also saving old field values, overwriting the changes.

The solution is to fetch the object from the database before incrementing the counter, ensuring that we do not write back stale values.
