### PR TITLE
`getStateFromCurrentUrl` must include all possible keys

### DIFF
--- a/opentreemap/treemap/js/src/urlState.js
+++ b/opentreemap/treemap/js/src/urlState.js
@@ -132,9 +132,10 @@ module.exports = {
 
 function getStateFromCurrentUrl() {
     var newState = {},
-        query = url.parse(window.location.href, true).query;
+        query = url.parse(window.location.href, true).query,
+        allKeys = _.union(_.keys(deserializers, _.keys(query)));
 
-    _.each(query, function(v, k) {
+    _.each(allKeys, function(k) {
         var deserialize = deserializers[k];
         if (deserialize) {
             deserialize(newState, query);


### PR DESCRIPTION
When initializing state from a URL include keys for all possible fields,
even those not present in the query. Modules initializing themselves from the state
change stream need to be triggered even for empty values.

When this ability was recently lost (in an excellent refactor), the initial state lacked a
"mode" key which the treemap page depended on to set the initial mode correctly.
Trees were not selectable, and UI tests failed.
