### PR TITLE
Fix unit tests

### DIFF
--- a/opentreemap/otm1_migrator/migration_rules/standard_otm1.py
+++ b/opentreemap/otm1_migrator/migration_rules/standard_otm1.py
@@ -131,7 +131,15 @@ MIGRATION_RULES = {
             'common_name': coerce_null_string,
             'v_max_height': (lambda x: x or 10000),
             'v_max_dbh': (lambda x: x or 10000),
-            'native_status': (lambda x: x and x.lower() == 'true')
+            'native_status': (lambda x: x and x.lower() == 'true'),
+            'species': coerce_null_string,
+            'cultivar_name': coerce_null_string,
+            'other_part_of_name': coerce_null_string,
+            'gender': coerce_null_string,
+            'bloom_period': coerce_null_string,
+            'fruit_period': coerce_null_string,
+            'fact_sheet': coerce_null_string,
+            'plant_guide': coerce_null_string
         },
     },
     'user': {

--- a/opentreemap/otm1_migrator/tests.py
+++ b/opentreemap/otm1_migrator/tests.py
@@ -227,15 +227,15 @@ class MigrationCommandTests(LocalMediaTestCase):
         self.assertEqual(species.gender, '')
         self.assertEqual(species.common_name, "Basket willow")
         self.assertEqual(species.native_status, False)
-        self.assertEqual(species.bloom_period, None)
-        self.assertEqual(species.fruit_period, None)
+        self.assertEqual(species.bloom_period, '')
+        self.assertEqual(species.fruit_period, '')
         self.assertEqual(species.fall_conspicuous, None)
         self.assertEqual(species.flower_conspicuous, None)
         self.assertEqual(species.palatable_human, None)
         self.assertEqual(species.wildlife_value, None)
         self.assertEqual(species.fact_sheet,
                          'http://eol.org/search?q=Salix viminalis')
-        self.assertEqual(species.plant_guide, None)
+        self.assertEqual(species.plant_guide, '')
 
     @media_dir
     def test_userphoto_dict_to_model(self):

--- a/opentreemap/treemap/tests/views.py
+++ b/opentreemap/treemap/tests/views.py
@@ -1473,10 +1473,10 @@ class SpeciesViewTests(ViewTestCase):
             {'tokens': {'oak', 'acorn', 'oakenitus'}}
         ]
         for i, item in enumerate(self.species_dict):
-            species = Species(common_name=item.get('common_name'),
-                              genus=item.get('genus'),
-                              species=item.get('species'),
-                              cultivar=item.get('cultivar'),
+            species = Species(common_name=item.get('common_name', ''),
+                              genus=item.get('genus', ''),
+                              species=item.get('species', ''),
+                              cultivar=item.get('cultivar', ''),
                               otm_code=str(i),
                               instance=self.instance)
             species.save_with_user(self.commander)


### PR DESCRIPTION
Bringing over the OTM1 importer required changing species fields to remove
null=True on charFields (which is a Django best practice anyways)

A few unit tests were explicitly saving None for species fields, which
caused DB constraint errors
