### PR TITLE
Fix custom keys not appearing in urlState stateChangeStream

### DIFF
--- a/opentreemap/treemap/js/src/urlState.js
+++ b/opentreemap/treemap/js/src/urlState.js
@@ -133,7 +133,7 @@ module.exports = {
 function getStateFromCurrentUrl() {
     var newState = {},
         query = url.parse(window.location.href, true).query,
-        allKeys = _.union(_.keys(deserializers, _.keys(query)));
+        allKeys = _.union(_.keys(deserializers), _.keys(query));
 
     _.each(allKeys, function(k) {
         var deserialize = deserializers[k];


### PR DESCRIPTION
Looks like a misplaced paren was filtering out all keys _except_ those
that were predefined in our list of deserializers.
