### PR TITLE
Fix testem file watching

### DIFF
--- a/testem.json
+++ b/testem.json
@@ -2,7 +2,7 @@
     "test_page": "opentreemap/treemap/js/test/test.html",
     "before_tests": "grunt --dev",
     "src_files": [
-        "opentreemap/**/js/**/*.js"
+        "opentreemap/*/js/*/*.js"
     ],
     "serve_files": [
         "opentreemap/treemap/static/js/treemap.test.js"


### PR DESCRIPTION
We were using too general of a globbing pattern, so it included the test
bundle as part of the watched files.

This caused testem to go into an infinite loop after the first file change.

By being more restrictive with the glob pattern, we ignore the /static/
directory, and thus avoid the infinite loop.
