### PR TITLE
Exclude local_settings.py from flake8 check

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -133,7 +133,13 @@ def check():
         print(jshint)
 
         with cd(env.site_path):
-            flake8 = run(_venv_exec('flake8 --exclude migrations,opentreemap/settings/local_settings.py *'))
+            exclusions = [
+                'migrations',
+                'opentreemap/settings/local_settings.py',
+                # Obsolete?
+                'opentreemap/local_settings.py'
+            ]
+            flake8 = run(_venv_exec('flake8 --exclude ' + ','.join(exclusions)  + ' *'))
 
     if jshint.failed or flake8.failed:
         abort('Code linting failed')


### PR DESCRIPTION
This file was moved recently so this commit is to exclude the new file
location from flake8.
