### PR TITLE
Use the provided domain for password_reset

### DIFF
--- a/opentreemap/treemap/templates/registration/password_reset_email.html
+++ b/opentreemap/treemap/templates/registration/password_reset_email.html
@@ -3,7 +3,7 @@
 
 We received a request to reset your tree map account password. To continue the password reset process, please click on the link below or copy and paste it into your web browser.{% endblocktrans %}
 {% block reset_link %}
-https://opentreemap.org{% url 'auth_password_reset_confirm' uidb64=uid token=token %}
+https://{{ domain }}{% url 'auth_password_reset_confirm' uidb64=uid token=token %}
 {% endblock %}{% blocktrans %}
 If you did not make a request to reset your password then no further action is required.
 {% endblocktrans %}


### PR DESCRIPTION
The context has a domain in it, use it. This requires the sites
framework to be configured properly on the deployment target.
