### PR TITLE
Convert species "choice" fields to unstructured text

### DIFF
--- a/opentreemap/importer/fields.py
+++ b/opentreemap/importer/fields.py
@@ -41,17 +41,11 @@ class species(object):
     # when a matching itree code is found
     ITREE_PAIRS = 'calc__itree'
 
-    # TODO: support i18n
-    CHOICE_MAP = {
-        FLOWERING_PERIOD: ['spring', 'summer', 'fall', 'winter'],
-        FRUIT_OR_NUT_PERIOD: ['spring', 'summer', 'fall', 'winter'],
-    }
-
     DATE_FIELDS = set()
 
     STRING_FIELDS = {GENUS, SPECIES, CULTIVAR, OTHER_PART_OF_NAME, COMMON_NAME,
-                     USDA_SYMBOL, ITREE_CODE, GENDER, FACT_SHEET_URL,
-                     PLANT_GUIDE_URL}
+                     USDA_SYMBOL, ITREE_CODE, GENDER, FLOWERING_PERIOD,
+                     FRUIT_OR_NUT_PERIOD, FACT_SHEET_URL, PLANT_GUIDE_URL}
 
     POS_FLOAT_FIELDS = {MAX_DIAMETER, MAX_HEIGHT}
 
@@ -63,8 +57,7 @@ class species(object):
                       FLOWER_CONSPICUOUS, HAS_WILDLIFE_VALUE}
 
     ALL = DATE_FIELDS | STRING_FIELDS | POS_FLOAT_FIELDS | \
-        FLOAT_FIELDS | POS_INT_FIELDS | BOOLEAN_FIELDS | \
-        set(CHOICE_MAP.keys())
+        FLOAT_FIELDS | POS_INT_FIELDS | BOOLEAN_FIELDS
 
     PLOT_CHOICES = set()
 
@@ -123,8 +116,6 @@ class trees(object):
     POS_INT_FIELDS = {OPENTREEMAP_ID_NUMBER}
 
     BOOLEAN_FIELDS = {READ_ONLY, TREE_PRESENT}
-
-    CHOICE_MAP = {}
 
     ALL = {POINT_X, POINT_Y, PLOT_WIDTH, PLOT_LENGTH, READ_ONLY, TREE_PRESENT,
            STREET_ADDRESS, CITY_ADDRESS, POSTAL_CODE, OPENTREEMAP_ID_NUMBER,

--- a/opentreemap/importer/models.py
+++ b/opentreemap/importer/models.py
@@ -314,19 +314,6 @@ class GenericImportRow(models.Model):
 
         return has_errors
 
-    def validate_choice_fields(self):
-        has_errors = False
-        for field, choices in self.model_fields.CHOICE_MAP.iteritems():
-            value = self.datadict.get(field, None)
-            if value:
-                if value in choices:
-                    self.cleaned[field] = value
-                else:
-                    has_errors = True
-                    self.append_error(errors.INVALID_CHOICE, field, value)
-
-        return has_errors
-
     def validate_string_fields(self):
         has_errors = False
         for field in self.model_fields.STRING_FIELDS:
@@ -359,7 +346,6 @@ class GenericImportRow(models.Model):
     def validate_and_convert_datatypes(self):
         self.validate_numeric_fields()
         self.validate_boolean_fields()
-        self.validate_choice_fields()
         self.validate_string_fields()
         self.validate_date_fields()
 


### PR DESCRIPTION
The species fields "flowering period" and "fruit and nut period" were a choice field in OTM1,
with choices hardcoded to spring/summer/fall/winter. There are two problems with this:
- Hardcoded strings won't work for i18n
- The LA species import file has values like "spring,summer,fall"

The right solution is to support UDF's on Species objects, make these multi-select choice fields, and
let international users edit the values.

That's not going to happen soon. Switching to unstructured text seems like a reasonable solution for now,
since we don't actually do anything with these fields.

Also:
- Remove "choice fields" logic from the importer. Choice fields for trees will be UDFs and validated there.
