### PR TITLE
fixes OpenTreeMap/otm2-addons#296

### DIFF
--- a/opentreemap/treemap/css/sass/partials/pages/_admin.scss
+++ b/opentreemap/treemap/css/sass/partials/pages/_admin.scss
@@ -84,6 +84,21 @@
         }
     }
 
+    #instances {
+        table {
+            > tbody {
+                > tr {
+                    > td:first-child, th:first-child {
+                        max-width: 140px;
+                        overflow:hidden;
+                        white-space:nowrap;
+                        text-overflow:ellipsis;
+                    }
+                }
+            }
+        }
+    }
+
     input {
         width: 50%;
         margin-bottom: 8px;


### PR DESCRIPTION
-Made the instance name column a fixed width with ellipses rather than
a horizontal scroll bar.

The primary goal of this screen is to edit the different instances.  Rather than having to scroll horizontally to click the edit button (requiring 2 clicks), I instead made the decision to limit the characters of column 1.  The instance name should be recognizable based on the number of characters shown and a user can click the edit button if they aren't completely sure. 
