### PR TITLE
Merge species

### DIFF
--- a/opentreemap/importer/errors.py
+++ b/opentreemap/importer/errors.py
@@ -11,8 +11,8 @@ EMPTY_FILE = (1, 'No rows found', True)
 MISSING_POINTS = (2, 'You must specify a "%s" and "%s" field' %
                   (trees.POINT_X, trees.POINT_Y), True)
 
-UNMATCHED_FIELDS = (3, "Some fields in the uploaded dataset "
-                    "didn't match the template", False)
+UNMATCHED_FIELDS = (3, "The uploaded dataset contains "
+                    "unrecognized field names", False)
 
 MISSING_SPECIES_FIELDS = (4, 'You must specify Common Name and Genus', True)
 
@@ -53,8 +53,7 @@ INSTANCE_HAS_NO_ITREE_REGION = (64, 'This treemap intersects no i-Tree '
 INSTANCE_HAS_MULTIPLE_ITREE_REGIONS = (65, 'This treemap intersects more than '
                                        'one i-Tree region', True)
 
-TOO_MANY_SPECIES = (70, 'More than one species was matched by this row', False)
-MERGE_REQ = (71, 'This row must be merged', False)
+MERGE_REQUIRED = (71, 'This row must be merged', False)
 
 NEARBY_TREES = (1050, 'There are already trees very close to this one', False)
 

--- a/opentreemap/importer/fields.py
+++ b/opentreemap/importer/fields.py
@@ -27,7 +27,6 @@ class species(object):
     # Other import and/or export fields
     ID = 'database id of species'
     SCIENTIFIC_NAME = 'scientific name'
-    USDA_SYMBOL = 'usda symbol'
     ITREE_CODE = 'i-tree code'
     TREE_COUNT = 'number of trees in database'
 
@@ -44,7 +43,7 @@ class species(object):
     DATE_FIELDS = set()
 
     STRING_FIELDS = {GENUS, SPECIES, CULTIVAR, OTHER_PART_OF_NAME, COMMON_NAME,
-                     USDA_SYMBOL, ITREE_CODE, GENDER, FLOWERING_PERIOD,
+                     ITREE_CODE, GENDER, FLOWERING_PERIOD,
                      FRUIT_OR_NUT_PERIOD, FACT_SHEET_URL, PLANT_GUIDE_URL}
 
     POS_FLOAT_FIELDS = {MAX_DIAMETER, MAX_HEIGHT}

--- a/opentreemap/importer/templates/importer/partials/imports.html
+++ b/opentreemap/importer/templates/importer/partials/imports.html
@@ -6,9 +6,10 @@
           <div class="row">
             <div class="col-md-6">
               <div class="well">
-                <h4>Tree Import</h4>
                 <form id="import-trees-form">
                   {% csrf_token %}
+                  <button class="btn btn-info pull-right" type="submit" disabled>Import</button>
+                  <h4>Tree Import</h4>
                   <input type="hidden" name="type" value="tree">
                   <input name="unit_plot_length" value="1" type="hidden">
                   <input name="unit_plot_width" value="1" type="hidden">
@@ -17,24 +18,19 @@
                   <input name="unit_canopy_height" value="1" type="hidden">
                   <div class="input-group">
                     File to Upload: <input type="file" name="file">
-                    <span class="input-group-btn">
-                      <button class="btn btn-info" type="submit" disabled>Import</button>
-                    </span>
                   </div><!-- /input-group -->
                 </form>
               </div>
             </div>
             <div class="col-md-6">
               <div class="well">
-                <h4>Species Import</h4>
                 <form id="import-species-form">
                   {% csrf_token %}
+                  <button class="btn btn-info pull-right" type="submit" disabled>Import</button>
+                  <h4>Species Import</h4>
                   <input type="hidden" name="type" value="species">
                   <div class="input-group">
                     File to Upload: <input type="file" name="file">
-                    <span class="input-group-btn">
-                      <button class="btn btn-info" type="submit" disabled>Import</button>
-                    </span>
                   </div><!-- /input-group -->
                 </form>
               </div>

--- a/opentreemap/importer/templates/importer/partials/merge_species.html
+++ b/opentreemap/importer/templates/importer/partials/merge_species.html
@@ -1,0 +1,45 @@
+{% load l10n %}
+
+<tr {#style="display: none;"#}>
+    <td colspan="{{ panel.field_names|length }}">
+        <table>
+            <thead>
+                <tr>
+                    <th>Field</th>
+                  {% for column in row.columns_for_merge %}
+                    <th>{{ column.title }}</th>
+                  {% endfor %}
+                </tr>
+            </thead>
+            <tbody>
+                {% for field in row.fields_to_merge %}
+                    <tr>
+                        <td>{{ field.name }}</td>
+                      {% for value in field.values %}
+                        <td>
+                            <input type="radio"
+                                   id="{{ value.id }}"
+                                   name="{{ field.id }}"
+                                   {% if value.checked %}checked{% endif %}>
+                            <label for="{{ value.id }}">{{ value.value }}</label>
+                        </td>
+                      {% endfor %}
+                    </tr>
+                {% endfor %}
+                <tr>
+                    <td><button class="btn btn-sm">Cancel</button></td>
+                  {% for column in row.columns_for_merge %}
+                    <td>
+                      {% if column.species_id %}
+                        <a class="btn btn-sm"
+                           href="{% url 'importer:solve' instance_url_name=request.instance.url_name import_event_id=panel.import_event_id row_index=row.index %}?species={{ column.species_id|unlocalize }}">
+                            {{ column.action_title }}
+                        </a>
+                      {% endif %}
+                    </td>
+                  {% endfor %}
+                </tr>
+            </tbody>
+        </table>
+    </td>
+</tr>

--- a/opentreemap/importer/templates/importer/partials/status_table.html
+++ b/opentreemap/importer/templates/importer/partials/status_table.html
@@ -19,10 +19,14 @@
                                     {{ field.value }}
                             </td>
                         {% endfor %}
+                    </tr>
+                    {% if panel.name == 'merge_required' %}
+                        {% include 'importer/partials/merge_species.html' %}
+                    {% endif %}
                 {% endfor %}
             {% else %}
                 <tr>
-                    <td class="no-rows" colspan="{{ field_names|length|add:'1' }}">
+                    <td class="no-rows" colspan="{{ panel.field_names|length }}">
                         {% trans 'No rows' %}
                     </td>
                 </tr>

--- a/opentreemap/importer/urls.py
+++ b/opentreemap/importer/urls.py
@@ -40,7 +40,7 @@ urlpatterns = patterns(
     url(r'^api/merge$', merge_species, name='merge'),
     url(r'^api/%s/commit$' % _import_api_pattern, commit, name='commit'),
     url(r'^api/%s/update$' % _import_api_pattern, update, name='update'),
-    url(r'^api/species/(?P<import_event_id>\d+)/(?P<import_row_idx>\d+)/solve$',  # NOQA
+    url(r'^api/species/(?P<import_event_id>\d+)/(?P<row_index>\d+)/solve$',  # NOQA
         solve, name='solve'),
     url(r'^api/counts', counts, name='counts'),
     url(r'^api/species/similar', find_similar_species,

--- a/opentreemap/treemap/css/sass/partials/pages/_importer.scss
+++ b/opentreemap/treemap/css/sass/partials/pages/_importer.scss
@@ -19,4 +19,8 @@
    td.warning {
         background-color: #fdef8d;
    }
+
+   input {
+       width: auto;
+   }
 }

--- a/opentreemap/treemap/migrations/0084_trim_species_field_values.py
+++ b/opentreemap/treemap/migrations/0084_trim_species_field_values.py
@@ -36,7 +36,7 @@ class Migration(DataMigration):
                 species.save()
 
     def backwards(self, orm):
-        "Write your backwards methods here."
+        print('Unwanted whitespace around species fields trimmed by this migration cannot be restored.')
 
     models = {
         u'auth.group': {


### PR DESCRIPTION
"Merge Required" tab shows controls for resolving diffs and "solving" a merge
- Set up context for merge table (including unique names & ID's for radio buttons)
- Currently showing the merge table below its associated table row; could be changed to a popup.
- When a merge is required, only allow creating a new species if "common name" doesn't match

Bug fixing and refactoring in Species validation, including:
- Filter Species by instance when matching
- Extract function `_prepare_merge_data` and rewrite
- Don't show diffs for a field if the matched Species' value is empty (as it will be for most fields).
- If all diffs are with such empty values, don't require a merge
- Add tests for row status and merge data

Also:
- Fix layout problems in main `imports.html` template
- Rename errors.MERGE_REQ as errors.MERGE_REQUIRED
- Remove errors.TOO_MANY_SPECIES; it's subsumed by errors.MERGE_REQUIRED

Also, remove everything related to USDA code -- because it doesn't match OTM code like we thought.

We thought that OTM codes matched USDA codes except when there's a cultivar. But that's not the case. For example:
    Silver maple:  OTM code "ACSA1", USDA code "ACSA2"
    Sugar maple :  OTM code "ACSA2", USDA code "ACSA3"
    Willow acacia: OTM code "ACSA3", USDA code "ACSA10"

So matching USDA code introduces false matches (and was a marginal feature to start with) so it's now gone.
