### PR TITLE
Fix template for `solve` endpoint

### DIFF
--- a/opentreemap/importer/templates/importer/partials/import_table.html
+++ b/opentreemap/importer/templates/importer/partials/import_table.html
@@ -22,7 +22,6 @@
             <td>
                 {% if ie.is_finished %}
                     <a href="{% url 'importer:status' import_type=import_type import_event_id=ie.pk instance_url_name=request.instance.url_name %}">View</a>
-                    {% if ie.can_export %} | <a href="javascript:;">Export</a>{% endif %}
                 {% else %}
                     <img src="/static/img/spinnerSmall.gif">
                 {% endif %}

--- a/opentreemap/importer/views.py
+++ b/opentreemap/importer/views.py
@@ -735,7 +735,7 @@ show_status_panel_endpoint = _template_api_call(
     'GET', 'importer/partials/status_table.html', show_status_panel)
 
 solve_endpoint = _template_api_call(
-    'POST', 'importer/partials/status.html', solve)
+    'POST', 'importer/partials/row_status.html', solve)
 
 commit_endpoint = _template_api_call(
     'GET', 'importer/partials/imports.html', commit)


### PR DESCRIPTION
When `status.html` was changed to be a base template, the need to rename this usage was overlooked.

Also remove `Export` links from main importer page, as we've decided not to expose them for now.
