### PR TITLE
Get valid i-Tree codes by region from ecoservice

### DIFF
--- a/opentreemap/importer/species.py
+++ b/opentreemap/importer/species.py
@@ -7,10 +7,10 @@ import itertools
 from django.contrib.gis.db import models
 from django.db import transaction
 
+from treemap.ecobenefits import has_itree_code, all_itree_codes
 from treemap.models import (Species, ITreeCodeOverride, ITreeRegion, User)
 from treemap.species import species_for_scientific_name
-from treemap.species.codes import (has_itree_code, all_itree_region_codes,
-                                   all_itree_codes)
+from treemap.species.codes import all_itree_region_codes
 
 from importer.models import GenericImportEvent, GenericImportRow
 from importer import fields
@@ -31,7 +31,6 @@ class SpeciesImportEvent(GenericImportEvent):
     def __init__(self, *args, **kwargs):
         super(SpeciesImportEvent, self).__init__(*args, **kwargs)
         self.all_region_codes = all_itree_region_codes()
-        self.all_itree_codes = all_itree_codes()
         self.instance_region_codes = self.instance.itree_region_codes()
 
     def create_row(self, *args, **kwargs):
@@ -174,7 +173,7 @@ class SpeciesImportRow(GenericImportRow):
         elif region not in self.import_event.instance_region_codes:
             error = errors.ITREE_REGION_NOT_IN_INSTANCE
 
-        elif code not in self.import_event.all_itree_codes:
+        elif code not in all_itree_codes():
             error = errors.INVALID_ITREE_CODE
 
         elif not has_itree_code(region, code):
@@ -194,7 +193,7 @@ class SpeciesImportRow(GenericImportRow):
 
         else:
             region = self.import_event.instance_region_codes[0]
-            if itree_code not in self.import_event.all_itree_codes:
+            if itree_code not in all_itree_codes():
                 error = errors.INVALID_ITREE_CODE
 
             elif not has_itree_code(region, itree_code):

--- a/opentreemap/treemap/species/codes.py
+++ b/opentreemap/treemap/species/codes.py
@@ -1,13 +1,8 @@
 # flake8: noqa
 
+
 def all_itree_region_codes():
     return _CODES.keys()
-
-def all_itree_codes():
-    codes = set.union(
-        *[set(d.values()) for d in _CODES.values()]
-    )
-    return codes
 
 def all_species_codes():
     return species_codes_for_regions(all_itree_region_codes())
@@ -28,10 +23,6 @@ def get_itree_code(region_code, otm_code):
                 return _CODES[region_code][otm_code]
     return None
 
-def has_itree_code(region_code, itree_code):
-    # TODO: Pull i-Tree codes from eco csv's rather than _CODES[region_code],
-    # which is not guaranteed to have all values
-    return region_code in _CODES and itree_code in _CODES[region_code].values()
 
 # The ``_CODES`` dictionary has the following format
 #


### PR DESCRIPTION
Fixes false negatives when an i-Tree code is valid for a region but no OTM code references it.

Requires OpenTreeMap/ecobenefits#43
