### PR TITLE
Fixes a bug with a unit test failing at certain times of day.

### DIFF
--- a/opentreemap/treemap/tests/dates.py
+++ b/opentreemap/treemap/tests/dates.py
@@ -30,7 +30,8 @@ class DatesafeEqTest(OTMTestCase):
 
     def test_tz_naive_neq(self):
         d1 = datetime.now()
-        d2 = datetime(d1.year, d1.month, d1.day, d1.hour - 1)
+        d1 = d1.replace(hour=1)
+        d2 = datetime(d1.year, d1.month, d1.day, 0)
         self.assertFalse(datesafe_eq(d1, d2))
 
     def test_mixed_tz_awareness_eq(self):
@@ -41,7 +42,8 @@ class DatesafeEqTest(OTMTestCase):
 
     def test_mixed_tz_awareness_neq(self):
         d1 = timezone.now()
-        d2 = datetime(d1.year, d1.month, d1.day, d1.hour - 1)
+        d1 = d1.replace(hour=1)
+        d2 = datetime(d1.year, d1.month, d1.day, 0)
         self.assertFalse(datesafe_eq(d1, d2))
 
     def test_non_dates_eq(self):


### PR DESCRIPTION
https://travis-ci.org/OpenTreeMap/OTM2/builds/43048572 failed with the
following output:

```
 File "/home/travis/build/OpenTreeMap/OTM2/opentreemap/treemap/tests/dates.py",
 line 44, in test_mixed_tz_awareness_neq

 d2 = datetime(d1.year, d1.month, d1.day, d1.hour - 1)

 ValueError: hour must be in 0..23
```

The test took place at around 7:30PM ET, which would put it at 12:30PM UTC.
This caused `d1.hour` to be 0, which meant `d1.hour - 1` was -1, an invalid value.
