### PR TITLE
Update the ecobenefits and plot/tree counts when saving via quick edit.

### DIFF
--- a/opentreemap/treemap/js/src/treeMapModes.js
+++ b/opentreemap/treemap/js/src/treeMapModes.js
@@ -108,6 +108,7 @@ function init(config, mapManager, triggerSearchBus) {
             activateBrowseTreesMode(true);
         }
     });
+    form.saveOkStream.onValue(triggerSearchBus.push);
 
     plotMarker.init(config, mapManager.map);
 


### PR DESCRIPTION
Ensures that adding a tree or changing diameter or species is reflected
in tree counts and ecobenefits results.

Connects to #1991 

To test:
1. Ensure that adding a tree to an existing plot via "Quick Edit" will increment the plot/tree counts and update the ecobenefits.