### PR TITLE
Increase maxZoom to 21

### DIFF
--- a/opentreemap/treemap/js/shim/leaflet.google.js
+++ b/opentreemap/treemap/js/shim/leaflet.google.js
@@ -1,7 +1,8 @@
 /*
  * Google layer using Google Maps API
  */
-//(function (google, L) {
+
+/* global google: true */
 
 L.Google = L.Class.extend({
 	includes: L.Mixin.Events,
@@ -15,14 +16,17 @@ L.Google = L.Class.extend({
 		attribution: '',
 		opacity: 1,
 		continuousWorld: false,
-		noWrap: false
+		noWrap: false,
+		mapOptions: {
+			backgroundColor: '#dddddd'
+		}
 	},
 
 	// Possible types: SATELLITE, ROADMAP, HYBRID, TERRAIN
 	initialize: function(type, options) {
 		L.Util.setOptions(this, options);
 
-		this._ready = google.maps.Map != undefined;
+		this._ready = google.maps.Map !== undefined;
 		if (!this._ready) L.Google.asyncWait.push(this);
 
 		this._type = type || 'SATELLITE';
@@ -42,29 +46,25 @@ L.Google = L.Class.extend({
 		this._limitedUpdate = L.Util.limitExecByInterval(this._update, 150, this);
 		map.on('move', this._update, this);
 
-		map.on('zoomanim', function (e) {
-			var center = e.center;
-			var _center = new google.maps.LatLng(center.lat, center.lng);
+		map.on('zoomanim', this._handleZoomAnim, this);
 
-			this._google.setCenter(_center);
-			this._google.setZoom(e.zoom);
-		}, this);
-
-		map._controlCorners['bottomright'].style.marginBottom = "1em";
+		//20px instead of 1em to avoid a slight overlap with google's attribution
+		map._controlCorners.bottomright.style.marginBottom = '20px';
 
 		this._reset();
 		this._update();
 	},
 
 	onRemove: function(map) {
-		this._map._container.removeChild(this._container);
-		//this._container = null;
+		map._container.removeChild(this._container);
 
-		this._map.off('viewreset', this._resetCallback, this);
+		map.off('viewreset', this._resetCallback, this);
 
-		this._map.off('move', this._update, this);
-		map._controlCorners['bottomright'].style.marginBottom = "0em";
-		//this._map.off('moveend', this._update, this);
+		map.off('move', this._update, this);
+
+		map.off('zoomanim', this._handleZoomAnim, this);
+
+		map._controlCorners.bottomright.style.marginBottom = '0em';
 	},
 
 	getAttribution: function() {
@@ -79,8 +79,8 @@ L.Google = L.Class.extend({
 	},
 
 	setElementSize: function(e, size) {
-		e.style.width = size.x + "px";
-		e.style.height = size.y + "px";
+		e.style.width = size.x + 'px';
+		e.style.height = size.y + 'px';
 	},
 
 	_initContainer: function() {
@@ -89,40 +89,53 @@ L.Google = L.Class.extend({
 
 		if (!this._container) {
 			this._container = L.DomUtil.create('div', 'leaflet-google-layer leaflet-top leaflet-left');
-			this._container.id = "_GMapContainer_" + L.Util.stamp(this);
-			this._container.style.zIndex = "auto";
+			this._container.id = '_GMapContainer_' + L.Util.stamp(this);
+			this._container.style.zIndex = 'auto';
 		}
 
-		if (true) {
-			tilePane.insertBefore(this._container, first);
+		tilePane.insertBefore(this._container, first);
 
-			this.setOpacity(this.options.opacity);
-			this.setElementSize(this._container, this._map.getSize());
-		}
+		this.setOpacity(this.options.opacity);
+		this.setElementSize(this._container, this._map.getSize());
 	},
 
 	_initMapObject: function() {
 		if (!this._ready) return;
 		this._google_center = new google.maps.LatLng(0, 0);
 		var map = new google.maps.Map(this._container, {
-		    center: this._google_center,
-		    zoom: 0,
-		    tilt: 0,
-		    mapTypeId: google.maps.MapTypeId[this._type],
-		    disableDefaultUI: true,
-		    keyboardShortcuts: false,
-		    draggable: false,
-		    disableDoubleClickZoom: true,
-		    scrollwheel: false,
-		    streetViewControl: false
+			center: this._google_center,
+			zoom: 0,
+			tilt: 0,
+			mapTypeId: google.maps.MapTypeId[this._type],
+			disableDefaultUI: true,
+			keyboardShortcuts: false,
+			draggable: false,
+			disableDoubleClickZoom: true,
+			scrollwheel: false,
+			streetViewControl: false,
+			styles: this.options.mapOptions.styles,
+			backgroundColor: this.options.mapOptions.backgroundColor
 		});
 
 		var _this = this;
-		this._reposition = google.maps.event.addListenerOnce(map, "center_changed",
+		this._reposition = google.maps.event.addListenerOnce(map, 'center_changed',
 			function() { _this.onReposition(); });
-
-		map.backgroundColor = '#ff0000';
 		this._google = map;
+
+		google.maps.event.addListenerOnce(map, 'idle',
+			function() { _this._checkZoomLevels(); });
+		//Reporting that map-object was initialized.
+		this.fire('MapObjectInitialized', { mapObject: map });
+	},
+
+	_checkZoomLevels: function() {
+		//setting the zoom level on the Google map may result in a different zoom level than the one requested
+		//(it won't go beyond the level for which they have data).
+		// verify and make sure the zoom levels on both Leaflet and Google maps are consistent
+		if (this._google.getZoom() !== this._map.getZoom()) {
+			//zoom levels are out of sync. Set the leaflet zoom level to match the google one
+			this._map.setZoom( this._google.getZoom() );
+		}
 	},
 
 	_resetCallback: function(e) {
@@ -137,26 +150,37 @@ L.Google = L.Class.extend({
 		if (!this._google) return;
 		this._resize();
 
-		var center = e && e.latlng ? e.latlng : this._map.getCenter();
+		var center = this._map.getCenter();
 		var _center = new google.maps.LatLng(center.lat, center.lng);
 
 		this._google.setCenter(_center);
-		this._google.setZoom(this._map.getZoom());
-		//this._google.fitBounds(google_bounds);
+		this._google.setZoom(Math.round(this._map.getZoom()));
+
+		this._checkZoomLevels();
 	},
 
 	_resize: function() {
 		var size = this._map.getSize();
-		if (this._container.style.width == size.x &&
-		    this._container.style.height == size.y)
+		if (this._container.style.width === size.x &&
+				this._container.style.height === size.y)
 			return;
 		this.setElementSize(this._container, size);
 		this.onReposition();
 	},
 
+
+	_handleZoomAnim: function (e) {
+		var center = e.center;
+		var _center = new google.maps.LatLng(center.lat, center.lng);
+
+		this._google.setCenter(_center);
+		this._google.setZoom(Math.round(e.zoom));
+	},
+
+
 	onReposition: function() {
 		if (!this._google) return;
-		google.maps.event.trigger(this._google, "resize");
+		google.maps.event.trigger(this._google, 'resize');
 	}
 });
 
@@ -172,5 +196,4 @@ L.Google.asyncInitialize = function() {
 		}
 	}
 	L.Google.asyncWait = [];
-}
-//})(window.google, L)
+};

--- a/opentreemap/treemap/js/src/MapManager.js
+++ b/opentreemap/treemap/js/src/MapManager.js
@@ -6,7 +6,9 @@ var $ = require('jquery'),
     U = require('treemap/utility'),
     BU = require('treemap/baconUtils'),
     makeLayerFilterable = require('treemap/makeLayerFilterable'),
-    urlState = require('treemap/urlState');
+    urlState = require('treemap/urlState'),
+
+    _ZOOM_OPTIONS = {maxZoom: 21};
 
 // Leaflet extensions
 require('utfgrid');
@@ -148,28 +150,26 @@ function getBasemapLayers(config) {
             'Hybrid': makeBingLayer('AerialWithLabels')
         };
     } else if (config.instance.basemap.type === 'tms') {
-        layers = [L.tileLayer(config.instance.basemap.data, { maxZoom: 20 })];
+        layers = [L.tileLayer(config.instance.basemap.data, _ZOOM_OPTIONS)];
     } else {
-        return {'Streets': new L.Google('ROADMAP', { maxZoom: 20 }),
-                'Hybrid': new L.Google('HYBRID', { maxZoom: 20 }),
-                'Satellite': new L.Google('SATELLITE', { maxZoom: 20 })};
+        return {'Streets': new L.Google('ROADMAP', _ZOOM_OPTIONS),
+                'Hybrid': new L.Google('HYBRID', _ZOOM_OPTIONS),
+                'Satellite': new L.Google('SATELLITE', _ZOOM_OPTIONS)};
     }
     return layers;
 }
 
 function createPlotTileLayer(config) {
     var url = getPlotLayerURL(config, 'png'),
-        layer = L.tileLayer(url, { maxZoom: 20 });
+        layer = L.tileLayer(url, _ZOOM_OPTIONS);
     makeLayerFilterable(layer, url, config);
     return layer;
 }
 
 function createPlotUTFLayer(config) {
     var layer, url = getPlotLayerURL(config, 'grid.json'),
-        options = {
-            resolution: 4,
-            maxZoom: 20
-        };
+        options = _.extend({resolution: 4}, _ZOOM_OPTIONS);
+
     // Need to use JSONP on on browsers that do not support CORS (IE9)
     // Only applies to plot layer because only UtfGrid is using XmlHttpRequest
     // for cross-site requests
@@ -214,9 +214,7 @@ function getBoundsLayerURL(config, extension) {
 }
 
 function createBoundsTileLayer(config) {
-    return L.tileLayer(
-        getBoundsLayerURL(config, 'png'),
-        { maxZoom: 20 });
+    return L.tileLayer(getBoundsLayerURL(config, 'png'), _ZOOM_OPTIONS);
 }
 
 function deserializeZoomLatLngAndSetOnMap(mapManager, state) {


### PR DESCRIPTION
Originally, turning the zoom level up to 21 caused bugs on the satellite
layer when zooming in on areas that don't support such high
levels. Fixes in the google plugin for leaflet made it possible to go up
to 21 universally and it will disallow levels that aren't supported.