### PR TITLE
Restore ability to cancel imports

### DIFF
--- a/opentreemap/importer/views.py
+++ b/opentreemap/importer/views.py
@@ -610,7 +610,7 @@ def cancel(request, instance, import_type, import_event_id):
 
     # If verifications tasks are still scheduled, we need to revoke them
     if ie.task_id:
-        GroupResult(ie.task_id).revoke()
+        GroupResult.restore(ie.task_id).revoke()
 
     return list_imports(request, instance)
 


### PR DESCRIPTION
I'm not sure how this ever worked. Notes:
* `Chord` returns an `AsyncResult` (not documented)
* Use `AsyncResult.parent` to get a `GroupResult`
* Use `save()` and `restore()` on the `GroupResult` as suggested in http://stackoverflow.com/questions/13685344/retrieving-groupresult-from-taskset-id-in-celery

Connects #2030