### PR TITLE
Wrap disabled buttons in a titled label element

### DIFF
--- a/opentreemap/treemap/css/sass/partials/_navbar.scss
+++ b/opentreemap/treemap/css/sass/partials/_navbar.scss
@@ -138,6 +138,22 @@
     }
 }
 
+//Patch for label wrapping disabled buttons
+.navbar-inverse{
+    .navbar-nav{
+        li{
+            label{
+                padding: 10px 0;
+
+                a{
+                    color: #9d9d9d;
+                    font-weight: normal;
+                }
+            }
+        }
+    }
+}
+
 @media (max-width: 767px) {
     .navbar {
         margin: 0;

--- a/opentreemap/treemap/css/sass/partials/_subheader.scss
+++ b/opentreemap/treemap/css/sass/partials/_subheader.scss
@@ -356,7 +356,12 @@
                 width: inherit;
                 padding: 0px;
             }
+
+            label{
+                float: right;
+            }
         }
+
         .exportBtn {
             margin-left: 10px;
             margin-top: -2px;

--- a/opentreemap/treemap/js/src/buttonEnabler.js
+++ b/opentreemap/treemap/js/src/buttonEnabler.js
@@ -15,12 +15,15 @@
 
 var $ = require('jquery'),
     _ = require('lodash'),
+    format = require('util').format,
 
     enablePermAttr = 'data-always-enable',
     disabledTitleAttr = 'data-disabled-title',
     redirectUrlAttr = 'data-redirect-url',
     hrefAttr = 'data-href',
     enablePermSelector = '[' + enablePermAttr + ']',
+    disabledButtonWrapperAttrPair = 'data-class="disabled-button-wrapper"',
+    disabledButtonWrapperSelector = '[' + disabledButtonWrapperAttrPair + ']',
     config;
 
 function removeActionableDataAttributes($el) {
@@ -52,9 +55,15 @@ function fullyEnable($el, href) {
 }
 
 function fullyDisable($el, disabledTitle) {
+    var wrapperTemplate =
+            '<label ' + disabledButtonWrapperAttrPair +
+            ' title="%s"></label>';
+
     $el.off('click');
     removeActionableDataAttributes($el);
-    if (disabledTitle) { $el.attr('title', disabledTitle); }
+    if (disabledTitle && !$el.parent().is(disabledButtonWrapperSelector)) {
+        $el.wrap(format(wrapperTemplate, disabledTitle));
+    }
 }
 
 exports.run = function (options) {


### PR DESCRIPTION
connects #2020 on github

Title (help) text is not shown for disabled buttons. However, we want to
explain why buttons are disabled so the user can take action to enable
them.

The recommended fix for twitter bootstrap tooltips is to wrap disabled
buttons in a div or label. In this case, we are using this technique,
but not activating the bootstrap tooltip. This gives us native title
text instead of tooltip windows. This is advantageous because running
$container.tooltip() is expensive, and with how our code is currently structured,
would have to be done on each map_feature click. The downside is that
bootstrap tooltips look prettier than native title text. This change
could me made easily at a later time.

This commit breaks styling in at least two known places:
* The counts/export/add titlebar is misaligned. Unchecking 'display:
  inline-block' on the label fixes this, but breaks the newly added title
  text.
* The 'Add a Tree' option in the topmost navbar is broken. @jfrankl helped
  me identify that this is because we use '>' selectors in the CSS, which
  don't respond flexibly to heirarchy changes.