### PR TITLE
Fix issue preventing global errors from being shown.

### DIFF
--- a/opentreemap/treemap/js/src/inlineEditForm.js
+++ b/opentreemap/treemap/js/src/inlineEditForm.js
@@ -253,7 +253,7 @@ exports.init = function(options) {
         },
 
         showValidationErrorsInline = function (errors) {
-            $(validationFields).each(function() {
+            $(validationFields).not(globalErrorSection).each(function() {
                 $(this).html('');
             });
             _.each(errors, function (errorList, fieldName) {


### PR DESCRIPTION
We were correctly writing non-field errorss to a global error message
section, but then accidentally overwriting those global errors when
attempting to show inline field errors.

Excluding the global error section when clearing the field errors fixes
this bug.