### PR TITLE
Show layer for polygonal map features

### DIFF
--- a/opentreemap/treemap/js/src/MapManager.js
+++ b/opentreemap/treemap/js/src/MapManager.js
@@ -204,17 +204,16 @@ function createBoundariesTileLayer(config) {
     return L.tileLayer(url, options);
 }
 
-// Leaflet uses {s} to indicate subdomains
+function getPlotLayerURL(config, extension) {
+    return getLayerURL(config, 'treemap_mapfeature', extension);
+}
+
 function getLayerURL(config, layer, extension) {
     var host = config.tileHost || '';
     return host + '/tile/' +
         config.instance.rev +
         '/database/otm/table/' + layer + '/{z}/{x}/{y}.' +
         extension + '?instance_id=' + config.instance.id;
-}
-
-function getPlotLayerURL(config, extension) {
-    return getLayerURL(config, 'treemap_mapfeature', extension);
 }
 
 function deserializeZoomLatLngAndSetOnMap(mapManager, state) {

--- a/opentreemap/treemap/js/src/MapManager.js
+++ b/opentreemap/treemap/js/src/MapManager.js
@@ -25,7 +25,7 @@ MapManager.prototype = {
         var config = options.config,
             plotLayer = createPlotTileLayer(config),
             allPlotsLayer = createPlotTileLayer(config),
-            boundsLayer = createBoundsTileLayer(config),
+            boundariesLayer = createBoundariesTileLayer(config),
             utfLayer = createPlotUTFLayer(config);
 
         this._config = config;
@@ -47,8 +47,8 @@ MapManager.prototype = {
             map.utfEvents = BU.leafletEventStream(utfLayer, 'click');
         }
 
-        map.addLayer(boundsLayer);
-        this.layersControl.addOverlay(boundsLayer, 'Boundaries');
+        map.addLayer(boundariesLayer);
+        this.layersControl.addOverlay(boundariesLayer, 'Boundaries');
 
         if (options.trackZoomLatLng) {
             map.on("moveend", _.partial(serializeZoomLatLngFromMap, map));
@@ -209,12 +209,12 @@ function getPlotLayerURL(config, extension) {
     return getLayerURL(config, 'treemap_mapfeature', extension);
 }
 
-function getBoundsLayerURL(config, extension) {
+function getBoundariesLayerURL(config, extension) {
     return getLayerURL(config, 'treemap_boundary', extension);
 }
 
-function createBoundsTileLayer(config) {
-    return L.tileLayer(getBoundsLayerURL(config, 'png'), _ZOOM_OPTIONS);
+function createBoundariesTileLayer(config) {
+    return L.tileLayer(getBoundariesLayerURL(config, 'png'), _ZOOM_OPTIONS);
 }
 
 function deserializeZoomLatLngAndSetOnMap(mapManager, state) {

--- a/opentreemap/treemap/js/src/MapManager.js
+++ b/opentreemap/treemap/js/src/MapManager.js
@@ -8,7 +8,9 @@ var $ = require('jquery'),
     makeLayerFilterable = require('treemap/makeLayerFilterable'),
     urlState = require('treemap/urlState'),
 
-    MAX_ZOOM_OPTION = {maxZoom: 21};
+    MAX_ZOOM_OPTION = {maxZoom: 21},
+    // Min zoom level for detail layers
+    MIN_ZOOM_OPTION = {minZoom: 15};
 
 // Leaflet extensions
 require('utfgrid');
@@ -214,7 +216,8 @@ function getBoundariesLayerURL(config, extension) {
 }
 
 function createBoundariesTileLayer(config) {
-    return L.tileLayer(getBoundariesLayerURL(config, 'png'), MAX_ZOOM_OPTION);
+    var options = _.extend({}, MAX_ZOOM_OPTION, MIN_ZOOM_OPTION);
+    return L.tileLayer(getBoundariesLayerURL(config, 'png'), options);
 }
 
 function deserializeZoomLatLngAndSetOnMap(mapManager, state) {

--- a/opentreemap/treemap/js/src/MapManager.js
+++ b/opentreemap/treemap/js/src/MapManager.js
@@ -198,6 +198,12 @@ function createPlotUTFLayer(config) {
     return layer;
 }
 
+function createBoundariesTileLayer(config) {
+    var url = getLayerURL(config, 'treemap_boundary', 'png'),
+        options = _.extend({}, MAX_ZOOM_OPTION, MIN_ZOOM_OPTION);
+    return L.tileLayer(url, options);
+}
+
 // Leaflet uses {s} to indicate subdomains
 function getLayerURL(config, layer, extension) {
     var host = config.tileHost || '';
@@ -209,15 +215,6 @@ function getLayerURL(config, layer, extension) {
 
 function getPlotLayerURL(config, extension) {
     return getLayerURL(config, 'treemap_mapfeature', extension);
-}
-
-function getBoundariesLayerURL(config, extension) {
-    return getLayerURL(config, 'treemap_boundary', extension);
-}
-
-function createBoundariesTileLayer(config) {
-    var options = _.extend({}, MAX_ZOOM_OPTION, MIN_ZOOM_OPTION);
-    return L.tileLayer(getBoundariesLayerURL(config, 'png'), options);
 }
 
 function deserializeZoomLatLngAndSetOnMap(mapManager, state) {

--- a/opentreemap/treemap/js/src/MapManager.js
+++ b/opentreemap/treemap/js/src/MapManager.js
@@ -192,9 +192,9 @@ function createPlotTileLayer(config) {
 }
 
 function createPolygonTileLayer(config) {
-    var url = getPlotLayerURL(config, 'png'),
+    var url = getPolygonLayerURL(config, 'png'),
         options = _.extend({}, MAX_ZOOM_OPTION, MIN_ZOOM_OPTION),
-        layer = L.tileLayer(getPolygonLayerURL(config, 'png'), options);
+        layer = L.tileLayer(url, options);
     makeLayerFilterable(layer, url, config);
     return layer;
 }

--- a/opentreemap/treemap/js/src/MapManager.js
+++ b/opentreemap/treemap/js/src/MapManager.js
@@ -8,7 +8,7 @@ var $ = require('jquery'),
     makeLayerFilterable = require('treemap/makeLayerFilterable'),
     urlState = require('treemap/urlState'),
 
-    _ZOOM_OPTIONS = {maxZoom: 21};
+    MAX_ZOOM_OPTION = {maxZoom: 21};
 
 // Leaflet extensions
 require('utfgrid');
@@ -150,25 +150,25 @@ function getBasemapLayers(config) {
             'Hybrid': makeBingLayer('AerialWithLabels')
         };
     } else if (config.instance.basemap.type === 'tms') {
-        layers = [L.tileLayer(config.instance.basemap.data, _ZOOM_OPTIONS)];
+        layers = [L.tileLayer(config.instance.basemap.data, MAX_ZOOM_OPTION)];
     } else {
-        return {'Streets': new L.Google('ROADMAP', _ZOOM_OPTIONS),
-                'Hybrid': new L.Google('HYBRID', _ZOOM_OPTIONS),
-                'Satellite': new L.Google('SATELLITE', _ZOOM_OPTIONS)};
+        return {'Streets': new L.Google('ROADMAP', MAX_ZOOM_OPTION),
+                'Hybrid': new L.Google('HYBRID', MAX_ZOOM_OPTION),
+                'Satellite': new L.Google('SATELLITE', MAX_ZOOM_OPTION)};
     }
     return layers;
 }
 
 function createPlotTileLayer(config) {
     var url = getPlotLayerURL(config, 'png'),
-        layer = L.tileLayer(url, _ZOOM_OPTIONS);
+        layer = L.tileLayer(url, MAX_ZOOM_OPTION);
     makeLayerFilterable(layer, url, config);
     return layer;
 }
 
 function createPlotUTFLayer(config) {
     var layer, url = getPlotLayerURL(config, 'grid.json'),
-        options = _.extend({resolution: 4}, _ZOOM_OPTIONS);
+        options = _.extend({resolution: 4}, MAX_ZOOM_OPTION);
 
     // Need to use JSONP on on browsers that do not support CORS (IE9)
     // Only applies to plot layer because only UtfGrid is using XmlHttpRequest
@@ -214,7 +214,7 @@ function getBoundariesLayerURL(config, extension) {
 }
 
 function createBoundariesTileLayer(config) {
-    return L.tileLayer(getBoundariesLayerURL(config, 'png'), _ZOOM_OPTIONS);
+    return L.tileLayer(getBoundariesLayerURL(config, 'png'), MAX_ZOOM_OPTION);
 }
 
 function deserializeZoomLatLngAndSetOnMap(mapManager, state) {

--- a/opentreemap/treemap/templates/treemap/map.html
+++ b/opentreemap/treemap/templates/treemap/map.html
@@ -24,7 +24,9 @@
 <div class="content map">
   <div id="streetview" style="display: none">
   </div>
-  <div id="map" class="map">
+  <div id="map" class="map"
+       data-has-boundaries="{{ has_boundaries }}"
+       data-has-polygons="{{ has_polygons }}">
   </div>
   <div class="sidebar">
     <div id="sidebar-browse-trees">

--- a/opentreemap/treemap/templates/treemap/map_feature_detail.html
+++ b/opentreemap/treemap/templates/treemap/map_feature_detail.html
@@ -206,7 +206,10 @@
 
         <!-- Maps -->
         <div class="col-md-4">
-          <div id="map" class="map-small"></div>
+          <div id="map" class="map-small"
+               data-has-boundaries="False"
+               data-has-polygons="{{ has_polygons }}">
+          </div>
           <button
              disabled="disabled"
              data-always-enable="{{ last_effective_instance_user|geom_is_writable:feature.feature_type }}"

--- a/opentreemap/treemap/views/map_feature.py
+++ b/opentreemap/treemap/views/map_feature.py
@@ -29,6 +29,7 @@ from treemap.lib.map_feature import (get_map_feature_or_404,
                                      context_dict_for_plot,
                                      context_dict_for_resource,
                                      context_dict_for_map_feature)
+from treemap.views.misc import add_map_info_to_context
 
 
 def _request_to_update_map_feature(request, feature):
@@ -74,6 +75,7 @@ def map_feature_detail(request, instance, feature_id, render=False):
     ctx_fn = (context_dict_for_plot if feature.is_plot
               else context_dict_for_resource)
     context = ctx_fn(request, feature)
+    add_map_info_to_context(context, instance)
 
     if render:
         if feature.is_plot:


### PR DESCRIPTION
Show layer only if
* instance has polygonal map feature types, and
* zoom is 15 or higher

And while we're at it, likewise show boundary layer only if
* instance has boundaries, and
* zoom is 15 or higher

Communicate `has_polygons` and `has_boundaries` via data attributes on the map DOM element, for both the main map and detail map.

To test:
0) Get OpenTreeMap/otm-tiler#63 and restart the tiler
1) Add the `Bioswale` map feature type to an instance
2) Create a bioswale -- its polygon should be displayed
3) Open network tab and zoom out to level 14. There should be no tile requests for the boundary or polygonal map feature
layers.
4) Go to an instance that doesn't have the `Bioswale` map feature type.
5) Zoom in to level 15. There should be no tile requests for the polygonal map feature layer.

Connects #2037
Connects #2061

Requires OpenTreeMap/otm-tiler#63