### PR TITLE
Ignore instance when creating a model hash

### DIFF
--- a/opentreemap/treemap/audit.py
+++ b/opentreemap/treemap/audit.py
@@ -981,8 +981,7 @@ class Auditable(UserTrackable):
         # manifest itself in the audit log, essentially keeping
         # a revision id of this instance. Since each primary
         # key will be unique, we can just use that for the hash
-        audits = Audit.objects.filter(instance__pk=self.instance_id)\
-                              .filter(model=self._model_name)\
+        audits = Audit.objects.filter(model=self._model_name)\
                               .filter(model_id=self.pk)\
                               .order_by('-updated')
 


### PR DESCRIPTION
When finding the latest audit of a particular model type and ID there's no need to filter by instance. Model IDs are already unique in their table.

It makes the query 30% faster. Here's a query filtering by instance:

```
otm=# explain analyze select id from treemap_audit where instance_id=20 and model='Plot' and model_id=202165 order by
updated desc;
                                                                  QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=24.96..24.97 rows=7 width=16) (actual time=0.211..0.226 rows=5 loops=1)
   Sort Key: updated
   Sort Method: quicksort  Memory: 25kB
   ->  Index Scan using treemap_audit_model_id on treemap_audit  (cost=0.00..24.86 rows=7 width=16) (actual
   time=0.034..0.072 rows=5 loops=1)
         Index Cond: (model_id = 202165)
         Filter: ((instance_id = 20) AND ((model)::text = 'Plot'::text))
 Total runtime: 0.293 ms
(7 rows)

Time: 1.608 ms
```

Same query not filtering by instance:

```
otm=# explain analyze select id from treemap_audit where model='Plot' and model_id=202165 order by updated desc limit 1;
                                                                     QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=24.87..24.87 rows=1 width=16) (actual time=0.238..0.241 rows=1 loops=1)
   ->  Sort  (cost=24.87..24.90 rows=13 width=16) (actual time=0.230..0.230 rows=1 loops=1)
         Sort Key: updated
         Sort Method: top-N heapsort  Memory: 25kB
         ->  Index Scan using treemap_audit_model_id on treemap_audit  (cost=0.00..24.80 rows=13 width=16) (actual
         time=0.031..0.189 rows=5 loops=1)
               Index Cond: (model_id = 202165)
               Filter: ((model)::text = 'Plot'::text)
 Total runtime: 0.293 ms
(8 rows)

Time: 1.137 ms
```