### PR TITLE
Fix accidental mutation of default api fields.

### DIFF
--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -44,7 +44,7 @@ DEFAULT_MOBILE_SEARCH_FIELDS = {
                  'label': 'Missing Photo'}]
 }
 
-DEFAULT_MOBILE_API_FIELDS = [
+DEFAULT_MOBILE_API_FIELDS = (
     {'header': ugettext_noop('Tree Information'),
      'model': 'tree',
      'field_keys': ['tree.species', 'tree.diameter',
@@ -55,7 +55,7 @@ DEFAULT_MOBILE_API_FIELDS = [
     {'header': ugettext_noop('Stewardship'),
      'collection_udf_keys': ['plot.udf:Stewardship', 'tree.udf:Stewardship'],
      'sort_key': 'Date'}
-]
+)
 
 DEFAULT_TREE_STEWARDSHIP_CHOICES = [
     'Watered',


### PR DESCRIPTION
We were accidentally mutating the DEFAULT_MOBILE_API_FIELDS module-level
variable when handling UDF deletion.

Depending on the order the unit tests were run in, this could cause a
test to fail, and almost certainly could have occurred in production
as well.