### PR TITLE
Work around Leaflet afterimage issue.

### DIFF
--- a/opentreemap/treemap/js/src/MapManager.js
+++ b/opentreemap/treemap/js/src/MapManager.js
@@ -55,6 +55,9 @@ MapManager.prototype = {
                 this._allPolygonsLayer = allPolygonsLayer;
                 allPolygonsLayer.setOpacity(0.3);
                 map.addLayer(polygonLayer);
+
+                fixZoomLayerSwitch(map, polygonLayer);
+                fixZoomLayerSwitch(map, allPolygonsLayer);
             }
         }
 
@@ -62,6 +65,8 @@ MapManager.prototype = {
             var boundariesLayer = createBoundariesTileLayer(config);
             map.addLayer(boundariesLayer);
             this.layersControl.addOverlay(boundariesLayer, 'Boundaries');
+
+            fixZoomLayerSwitch(map, boundariesLayer);
         }
 
         if (options.trackZoomLatLng) {
@@ -276,6 +281,16 @@ function getDomMapAttribute(dataAttName, domId) {
     var $map = $('#' + domId),
         value = $map.data(dataAttName);
     return value;
+}
+
+// Work around https://github.com/Leaflet/Leaflet/issues/1905
+function fixZoomLayerSwitch(map, layer) {
+    map.on('zoomend', function(e) {
+        var zoom = map.getZoom();
+        if (zoom < MIN_ZOOM_OPTION.minZoom) {
+            layer._clearBgBuffer();
+        }
+    });
 }
 
 module.exports = MapManager;


### PR DESCRIPTION
There is a known Leaflet issue which causes an "afterimage" when going one
zoom level beyond a layer's min/max zoom level.
(https://github.com/Leaflet/Leaflet/issues/1905)

This fix works around the issue.  We should be able to remove this once
we upgrade to Leaflet 1.0, once it is out.

Connects to #2089