### PR TITLE
Return JSON for unhandled errors to API views.

### DIFF
--- a/opentreemap/treemap/routes.py
+++ b/opentreemap/treemap/routes.py
@@ -67,9 +67,9 @@ instances_geojson = do(
     json_api_call,
     misc_views.public_instances_geojson)
 
-error_404_page = render_template('404.html')(statuscode=404)
-error_500_page = render_template('500.html')(statuscode=500)
-error_503_page = render_template('503.html')(statuscode=503)
+error_404_page = misc_views.error_page(status_code=404)
+error_500_page = misc_views.error_page(status_code=500)
+error_503_page = misc_views.error_page(status_code=503)
 
 #####################################
 # utility views


### PR DESCRIPTION
I investigated changing our explicit error responses from API views to be JSON instead of plain text strings, but since the existing mobile apps use the textual responses in several places to report errors to the user, I opted to leave them as is.

To test, you will have to change your settings in Django settings to set `DEBUG=False` and `ALLOWED_HOSTS=['localhost']`.

You should see that any URL starting with `/api/` should return JSON for an unhandled error like a 404 or a 500 error, and that other URLs continue to return our custom error pages.

Connects to #2069 