### PR TITLE
Upgrade dragula JS dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "baconjs": "~0.6",
     "console-browserify": "~1.0.1",
-    "dragula": "^1.6.1",
+    "dragula": "^2.0.2",
     "leaflet-pip": "~0.1.1",
     "lodash": "2.4.x",
     "moment": "~2.2.1",


### PR DESCRIPTION
This version include a fix to a dependency issue that was breaking the bundling of our javascript assets.

https://github.com/bevacqua/dragula/commit/d7342ace10b65dbe45be109139f1d7162e7e3efe