### PR TITLE
Don't require more data attributes than necessary

### DIFF
--- a/opentreemap/treemap/js/src/udfcSearch.js
+++ b/opentreemap/treemap/js/src/udfcSearch.js
@@ -68,13 +68,9 @@ var nameTemplate = _.template('udf:<%= modelName %>:<%= udfFieldDefId %>.<%= fie
         .value();
 
 function makeNameAttribute (state, fieldKey) {
-
     var modelName = state.modelName,
         udfFieldDefId = state[state.modelName + 'UdfFieldDefId'],
         requiredFields = [modelName,
-                          state.plotUdfFieldDefId,
-                          state.bioswaleUdfFieldDefId,
-                          state.treeUdfFieldDefId,
                           state.actionFieldKey,
                           state.dateFieldKey,
                           udfFieldDefId],


### PR DESCRIPTION
connects #2129 on github

They dynamically generated udfFieldDefId for the given modelName is
enough to build the name.