### PR TITLE
Fix share link

### DIFF
--- a/opentreemap/treemap/lib/map_feature.py
+++ b/opentreemap/treemap/lib/map_feature.py
@@ -377,8 +377,12 @@ def _add_share_context(context, request, photos):
             'treemap': request.instance.name
         }
 
+    url = reverse('map_feature_detail',
+                  kwargs={'instance_url_name': request.instance.url_name,
+                          'feature_id': context['feature'].pk})
+
     context['share'] = {
-        'url': request.build_absolute_uri(),
+        'url': request.build_absolute_uri(url),
         'title': title,
         'description': description,
         'image': photo_url,


### PR DESCRIPTION
connects #2073 on github

the share context was using the same url used to produce the feature,
which is incorrect for the API. Here we explicitly use the url to the
map_feature_detail page in the webapp.