### PR TITLE
Make bioswale polygons on map pages clickable

### DIFF
--- a/opentreemap/opentreemap/urls.py
+++ b/opentreemap/opentreemap/urls.py
@@ -36,6 +36,7 @@ urlpatterns = patterns(
         url='/static/img/favicon.png', permanent=False)),
     url('^comments/', include('django_comments.urls')),
     url(r'^', include('geocode.urls')),
+    url(r'^stormwater/', include('stormwater.urls')),
     url(r'^$', routes.landing_page),
     url(r'^config/settings.js$', routes.root_settings_js),
     url(r'^users/%s/$' % USERNAME_PATTERN,

--- a/opentreemap/stormwater/routes.py
+++ b/opentreemap/stormwater/routes.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django_tinsel.decorators import json_api_call, route
+from django_tinsel.utils import decorate as do
+
+from treemap.decorators import instance_request
+
+from stormwater import views
+
+
+polygon_for_point = route(GET=do(
+    instance_request, json_api_call, views.polygon_for_point))

--- a/opentreemap/stormwater/urls.py
+++ b/opentreemap/stormwater/urls.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django.conf.urls import patterns, url
+
+from opentreemap.urls import instance_pattern
+from stormwater import routes
+
+
+urlpatterns = patterns(
+    '',
+    url(r'%s/polygon-for-point/$' % instance_pattern,
+        routes.polygon_for_point, name='polygon_for_point'),
+)

--- a/opentreemap/stormwater/views.py
+++ b/opentreemap/stormwater/views.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django.conf import settings
+from django.contrib.gis.geos import Point
+from django.contrib.gis.measure import D
+
+from django_tinsel.exceptions import HttpBadRequestException
+
+from stormwater.models import PolygonalMapFeature
+
+
+def polygon_for_point(request, instance):
+    lng = request.GET['lng']
+    lat = request.GET['lat']
+    point = Point(float(lng), float(lat), srid=4326)
+
+    try:
+        distance = float(request.GET.get(
+            'distance', settings.MAP_CLICK_RADIUS))
+    except ValueError:
+        raise HttpBadRequestException(
+            'The distance parameter must be a number')
+
+    features = PolygonalMapFeature.objects.distance(point)\
+        .filter(instance=instance)\
+        .filter(polygon__distance_lte=(point, D(m=distance)))\
+        .order_by('distance')[0:1]
+
+    if len(features) > 0:
+        # This is currently only being used to complement UTF grid plot data,
+        # so the structure of the response is designed to mirror the utf grid
+        return {
+            'data': {
+                'id': features[0].pk
+            }
+        }
+
+    return {
+        'data': None
+    }

--- a/opentreemap/treemap/templates/treemap/settings.js
+++ b/opentreemap/treemap/templates/treemap/settings.js
@@ -65,6 +65,7 @@ otm.settings.doubleClickInterval = '{{ settings.DOUBLE_CLICK_INTERVAL }}';
         'id': '{{ request.instance.id }}',
         'url': '{{ SITE_ROOT }}{{ request.instance.url_name }}/',
         'mapUrl': "{% url 'map' instance_url_name=last_instance.url_name %}",
+        'polygonForPointUrl': "{% url 'polygon_for_point' instance_url_name=last_instance.url_name %}",
         'addTreeUrl': "{% url 'map' instance_url_name=last_instance.url_name %}{{ settings.ADD_TREE_URL_HASH }}",
         'name': '{{ request.instance.name }}',
         'rev': '{{ request.instance.geo_rev_hash }}',


### PR DESCRIPTION
I explored using multiple UTF grids but ran into several issues:
 - clicks do not "fall through" to the lower UTF grid
 - max/min zoom properties are not respected

Instead, I implemented a WMS-style server backend for determining if a
polygon is present at a given lat/lng.  UTF grids are still used for point
based map features, and no network requests are made if the map does not
support polygonal map features.

Connects to #2114