### PR TITLE
Fix incorrect initial Django Migrations

### DIFF
--- a/opentreemap/treemap/migrations/0001_initial.py
+++ b/opentreemap/treemap/migrations/0001_initial.py
@@ -28,10 +28,10 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('password', models.CharField(max_length=128, verbose_name='password')),
-                ('last_login', models.DateTimeField(null=True, verbose_name='last login', blank=True)),
+                ('last_login', models.DateTimeField(default=django.utils.timezone.now, verbose_name='last login')),
                 ('is_superuser', models.BooleanField(default=False, help_text='Designates that this user has all permissions without explicitly assigning them.', verbose_name='superuser status')),
                 ('username', models.CharField(help_text='Required. 30 characters or fewer. Letters, numbers and @/./+/-/_ characters', unique=True, max_length=30, verbose_name='username', validators=[django.core.validators.RegexValidator(re.compile('^[\\w.@+-]+$'), 'Enter a valid username.', 'invalid')])),
-                ('email', models.EmailField(unique=True, max_length=254, verbose_name='email address', blank=True)),
+                ('email', models.EmailField(unique=True, max_length=75, verbose_name='email address', blank=True)),
                 ('is_staff', models.BooleanField(default=False, help_text='Designates whether the user can log into this admin site.', verbose_name='staff status')),
                 ('is_active', models.BooleanField(default=True, help_text='Designates whether this user should be treated as active. Unselect this instead of deleting accounts.', verbose_name='active')),
                 ('date_joined', models.DateTimeField(default=django.utils.timezone.now, verbose_name='date joined')),

--- a/opentreemap/treemap/migrations/0004_auto_20150720_1523.py
+++ b/opentreemap/treemap/migrations/0004_auto_20150720_1523.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0003_change_audit_id_to_big_int_20150708_1612'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='user',
+            name='email',
+            field=models.EmailField(unique=True, max_length=254, verbose_name='email address', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='user',
+            name='last_login',
+            field=models.DateTimeField(null=True, verbose_name='last login', blank=True),
+        ),
+    ]


### PR DESCRIPTION
There were two backwards incompatible changes to the Django Abstract User
model, which were not properly captured when recreating initial
migrations for Django 1.8.

Because OTM uses a custom user model, we have to handle the migrations
for this change ourselves.

Connects to #2162