### PR TITLE
Fix object_caches issue with creating new FieldPermissions

### DIFF
--- a/opentreemap/treemap/audit.py
+++ b/opentreemap/treemap/audit.py
@@ -143,6 +143,7 @@ def add_default_permissions(instance, roles=None, models=None):
     from treemap.models import MapFeaturePhoto
     if roles is None:
         roles = Role.objects.filter(instance=instance)
+
     if models is None:
         # We need permissions only on those subclasses of Authorizable
         # which we instantiate. Those are the leaf nodes of the
@@ -186,7 +187,14 @@ def _add_default_permissions(models, role, instance):
         perms = [FieldPermission(**perm) for perm in perms]
         for perm in perms:
             perm.permission_level = role.default_permission
+
         FieldPermission.objects.bulk_create(perms)
+        # Because we use bulk_create, we must manually trigger the save signal
+        # invalidate_adjuncts would get passed a FieldPermission object if we
+        # called save directly, but it doesn't use it for anything other than
+        # to get the associated instance, which is the same here for all perms,
+        # so just passing it the first FieldPermission should be fine
+        invalidate_adjuncts(instance=perms[0])
 
 
 def approve_or_reject_existing_edit(audit, user, approved):


### PR DESCRIPTION
Since bulk_create does not send signals, the object_caches for roles
were not invalidated when creating a new role, and the roles page would
incorrectly appear blank.

Connects to #2165