### PR TITLE
Cleanups to Field Permission and Roles

### DIFF
--- a/opentreemap/treemap/audit.py
+++ b/opentreemap/treemap/audit.py
@@ -22,7 +22,8 @@ from django.conf import settings
 
 from treemap.units import (is_convertible, is_convertible_or_formattable,
                            get_display_value, get_units, get_unit_name)
-from treemap.util import all_models_of_class, leaf_models_of_class
+from treemap.util import (all_models_of_class, leaf_models_of_class,
+                          to_object_name)
 from treemap.lib.object_caches import (permissions, role_permissions,
                                        invalidate_adjuncts, udf_defs)
 from treemap.lib.dates import datesafe_eq
@@ -603,12 +604,10 @@ class FieldPermission(models.Model):
     WRITE_WITH_AUDIT = 2
     WRITE_DIRECTLY = 3
     choices = (
-        # reserving zero in case we want
-        # to create a "null-permission" later
-        (NONE, "None"),
-        (READ_ONLY, "Read Only"),
-        (WRITE_WITH_AUDIT, "Write with Audit"),
-        (WRITE_DIRECTLY, "Write Directly"))
+        (NONE, _("Invisible")),
+        (READ_ONLY, _("Read Only")),
+        (WRITE_WITH_AUDIT, _("Pending Write Access")),
+        (WRITE_DIRECTLY, _("Full Write Access")))
     permission_level = models.IntegerField(choices=choices, default=NONE)
 
     class Meta:
@@ -636,6 +635,10 @@ class FieldPermission(models.Model):
             base_name = self.field_name
 
         return base_name.replace('_', ' ').title()
+
+    @property
+    def full_name(self):
+        return "{}.{}".format(to_object_name(self.model_name), self.field_name)
 
     def clean(self):
         try:

--- a/opentreemap/treemap/css/sass/partials/pages/_admin.scss
+++ b/opentreemap/treemap/css/sass/partials/pages/_admin.scss
@@ -166,6 +166,50 @@
         }
     }
 
+    .role-table-fixed {
+        width: 25%;
+        float: left;
+        clear: left;
+        border-right: 1px solid #EEE;
+        margin-bottom: 10px;
+
+        td {
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            overflow: hidden;
+        }
+    }
+
+    .role-table {
+        table-layout: fixed;
+        tr {
+            height: 50px;
+            border-bottom: 1px solid #EEE;
+
+            th {
+                background: #DDD;
+                padding: 10px;
+                white-space: nowrap;
+                text-overflow: ellipsis;
+                overflow: hidden;
+            }
+            td {
+                padding: 10px;
+            }
+        }
+    }
+
+    .role-table-scroll {
+        width: 75%;
+        float: left;
+        overflow-x: scroll;
+        margin-bottom: 10px;
+
+        th {
+            min-width: 200px;
+            max-width: 200px;
+        }
+    }
 }
 
 // .field-group and .field-row-container are not nested under anything, because they are

--- a/opentreemap/treemap/js/src/editableForm.js
+++ b/opentreemap/treemap/js/src/editableForm.js
@@ -1,0 +1,167 @@
+"use strict";
+
+var $ = require('jquery'),
+    _ = require('lodash'),
+    FH = require('treemap/fieldHelpers'),
+    getDatum = require('treemap/otmTypeahead').getDatum;
+
+// Placed onto the jquery object
+require('bootstrap-datepicker');
+
+// Boolean fields values are provided as "True" and "False"
+// from the server-side template tags as well as in this module.
+// In order to provide custom values for these fields, this function
+// can be run after writing a value to the boolean field, it will
+// comb through the provided data attributes to see if custom text
+// is provided.
+//
+// To make a field/element function with customizable boolean labels:
+// * specify the data-bool-true-text attribute on the element
+// * specify the data-bool-false-text attribute on the element
+function getBooleanFieldText (boolField, boolText) {
+    var $boolField = $(boolField),
+        attributes = {True: 'data-bool-true-text',
+                      False: 'data-bool-false-text'},
+        attribute = attributes[boolText];
+
+    // .is() is the recommended way of doing 'hasattr'
+    return $boolField.is("[" + attribute + "]") ?
+        $boolField.attr(attribute) : boolText;
+}
+
+exports.editStartAction = 'edit:start';
+
+exports.init = function(options) {
+    var displayFields = options.displayFields || '[data-class="display"]',
+        editFields = options.editFields || '[data-class="edit"]',
+
+        displayValuesToTypeahead = function() {
+            $('[data-typeahead-restore]').each(function(index, el) {
+                var field = $(el).attr('data-typeahead-restore');
+                if (field) {
+                    $('input[name="' + field + '"]').trigger('restore', $(el).val());
+                }
+            });
+        },
+
+        displayValuesToFormFields = function() {
+            $(displayFields).each(function(index, el) {
+                var $el = $(el),
+                    field = $el.attr('data-field'),
+                    value = $el.attr('data-value'),
+                    $input;
+
+                if (field && $el.is('[data-value]')) {
+                    $input = FH.getSerializableField($(editFields), field);
+                    if ($input.is('[type="checkbox"]')) {
+                        $input.prop('checked', value == "True");
+                    }
+                    else if ($input.is('[data-date-format]')) {
+                        FH.applyDateToDatepicker($input, value);
+                    } else {
+                        $input.val(value);
+                    }
+                }
+            });
+            displayValuesToTypeahead();
+        },
+
+        typeaheadToDisplayValues = function() {
+            $('[data-typeahead-input]').each(function(index, el) {
+                var datum = getDatum($(el)),
+                    field = $(el).attr('data-typeahead-input');
+                if (typeof datum != "undefined") {
+                    $('[data-typeahead-restore="' + field + '"]').each(function(index, el) {
+                        $(el).val(datum[$(el).attr('data-datum')]);
+                    });
+                    $('[data-typeahead="' + field + '"]').each(function(index, el) {
+                        $(el).html(datum[$(el).attr('data-datum')]);
+                    });
+                }
+            });
+        },
+
+        formFieldsToDisplayValues = function() {
+            $(editFields).each(function(index, el){
+                var field = $(el).attr('data-field'),
+                    $input, value, display, digits, units,
+                    displayValue;
+
+                // if the edit field has a data-field property,
+                // look for a corresponding display value and if
+                // found, populate the display value
+                if ($(el).is('[data-field]')) {
+                    display = FH.getField($(displayFields), field);
+
+                    if ($(display).is('[data-value]')) {
+                        $input = FH.getSerializableField($(editFields), field);
+                        if ($input.is('[type="checkbox"]')) {
+                            value = $input.is(':checked') ? "True" : "False";
+                        } else if ($input.is('[data-date-format]')) {
+                            value = FH.getTimestampFromDatepicker($input);
+                        } else {
+                            value = $input.val();
+                        }
+
+                        $(display).attr('data-value', value);
+                        displayValue = value;
+
+                        if ($input.is('select')) {
+                            // Use dropdown text (not value) as display value
+                            displayValue = $input.find('option:selected').text();
+                        } else if ($input.is('[type="checkbox"]')) {
+                            displayValue = getBooleanFieldText(display, value);
+                        } else if (value && $input.is('[data-date-format]')) {
+                            displayValue = $input.val();
+                        } else if (value) {
+                            digits = $(display).data('digits');
+                            if (digits) {
+                                displayValue = parseFloat(value).toFixed(digits);
+                            }
+                            units = $(display).data('units');
+                            if (units) {
+                                displayValue = value + ' ' + units;
+                            }
+                        }
+                        $(display).text(displayValue);
+                    }
+                }
+            });
+            typeaheadToDisplayValues();
+        },
+
+        hideAndShowElements = function (fields, actions, action) {
+            if (_.contains(actions, action)) {
+                $(fields).show();
+            } else {
+                if (action === exports.editStartAction) {
+                    // always hide the applicable runmode buttons
+                    $(fields).filter('.btn').hide();
+
+                    // hide the display fields if there is a corresponding
+                    // edit field to show in its place
+                    _.each($(fields).filter(":not(.btn)"), function (field) {
+                        var $field = $(field),
+                            $edit = FH.getField($(editFields),
+                                                $field.attr('data-field'));
+
+                        if ($edit.length === 1) {
+                            $field.hide();
+                        }
+
+                    });
+
+                } else {
+                    $(fields).hide();
+                }
+            }
+        };
+
+    $(editFields).find("input[data-date-format]").datepicker();
+
+    return {
+        displayValuesToFormFields: displayValuesToFormFields,
+        formFieldsToDisplayValues: formFieldsToDisplayValues,
+        hideAndShowElements: hideAndShowElements,
+    };
+};

--- a/opentreemap/treemap/js/src/fieldHelpers.js
+++ b/opentreemap/treemap/js/src/fieldHelpers.js
@@ -16,7 +16,9 @@ var getField = exports.getField = function ($fields, name) {
 var getSerializableField = exports.getSerializableField = function ($fields, name) {
     // takes a jQuery collection of edit fields and returns the
     // actual input or select field that will be serialized
-    return getField($fields, name).find('[name="' + name + '"]');
+    var $subfields = getField($fields, name),
+        selector = '[name="' + name + '"]';
+    return $subfields.find(selector).add($subfields.filter(selector));
 };
 
 var excludeButtons = exports.excludeButtons = function (selector) {

--- a/opentreemap/treemap/js/src/simpleEditForm.js
+++ b/opentreemap/treemap/js/src/simpleEditForm.js
@@ -1,0 +1,45 @@
+"use strict";
+
+var $ = require('jquery'),
+    Bacon = require('baconjs'),
+    R = require('ramda'),
+    BU = require('treemap/baconUtils'),
+    U = require('treemap/utility'),
+    _ = require('lodash'),
+    moment = require('moment'),
+    FH = require('treemap/fieldHelpers'),
+    console = require('console-browserify'),
+    editableForm = require('treemap/editableForm'),
+
+    eventsLandingInEditMode = [editableForm.editStartAction, 'save:error'],
+    eventsLandingInDisplayMode = ['save:ok', 'cancel'];
+
+exports.init = function(options) {
+    var $edit = $(options.edit),
+        $save = $(options.save),
+        $cancel = $(options.cancel),
+        displayFields = options.displayFields || '[data-class="display"]',
+        editFields = options.editFields || '[data-class="edit"]',
+        saveStream = options.saveStream,
+
+        editStream = $edit.asEventStream('click').map(editableForm.editStartAction),
+        cancelStream = $cancel.asEventStream('click').map('cancel'),
+        actionStream = new Bacon.Bus(),
+
+        editForm = editableForm.init(options),
+
+        saveOkStream = saveStream.map('save:ok'),
+        saveErrorStream = saveStream.mapError('save:error');
+
+    // Merge the major streams on the page together so that it can centrally
+    // manage the cleanup of ui forms after the change in run mode
+    actionStream.plug(editStream);
+    actionStream.plug(saveOkStream);
+    actionStream.plug(cancelStream);
+    actionStream.onValue(editForm.hideAndShowElements, editFields, eventsLandingInEditMode);
+    actionStream.onValue(editForm.hideAndShowElements, displayFields, eventsLandingInDisplayMode);
+
+    saveOkStream.onValue(editForm.formFieldsToDisplayValues);
+
+    editStream.onValue(editForm.displayValuesToFormFields);
+};

--- a/opentreemap/treemap/udf.py
+++ b/opentreemap/treemap/udf.py
@@ -623,10 +623,12 @@ class UserDefinedFieldDefinition(models.Model):
                         self.instance.save()
 
         # remove field permissions for this udf
-        FieldPermission.objects.filter(
-            model_name=self.model_type,
-            field_name=self.canonical_name,
-            instance=self.instance).delete()
+        perms = FieldPermission.objects.filter(model_name=self.model_type,
+                                               field_name=self.canonical_name,
+                                               instance=self.instance)
+        # iterating instead of doing a bulk delete in order to trigger signals
+        for perm in perms:
+            perm.delete()
 
         super(UserDefinedFieldDefinition, self).delete(*args, **kwargs)
 


### PR DESCRIPTION
 - Update FieldPermission choices and translate them.
 - Split inlineEditForm.js into 2 modules, and add a "simple" version
   The simple version is intended to be used for forms that want the
   edit/save/cancel behaviour but want to handle form serialization and
   error reporting in a custom way.
 - Add basic styling for updated roles page
 - Fix potential object_caches invalidation issue with field permissions