### PR TITLE
Fix add resource menu

### DIFF
--- a/opentreemap/treemap/lib/perms.py
+++ b/opentreemap/treemap/lib/perms.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from __future__ import division
 
 from django.contrib.gis.db.models import Field
-from treemap.models import InstanceUser, Role
+from treemap.models import InstanceUser, Role, Plot, MapFeature
 
 """
 Tools to assist in resolving permissions, specifically when the type of
@@ -61,33 +61,9 @@ def _allows_perm(role_related_obj, model_name,
     not exactly connected to permissions, it's convenient to check this here
     as well.
     """
-    if isinstance(role_related_obj, InstanceUser):
-        if _invalid_instanceuser(role_related_obj):
-            # TODO: in udf_write_level below, we do
-            # this same check, but instead of returning
-            # false, we go forward by assigning role
-            # to be the default role for the given instance.
-            # here, we won't always have instance in scope,
-            # but we should consider factoring udf_write_level
-            # into this method and optionally taking an instance
-            # so that one can go forward with the default role.
-            return False
-        else:
-            role = role_related_obj.role
-    elif isinstance(role_related_obj, type(None)):
-        # almost certainly this is being called with
-        # last_effective_instance_user without checking
-        # first if it is None. Since we haven't received
-        # the instance along with it, we can't resolve
-        # the default role, so perms must be blocked entirely.
-        # this is not so bad, because this block is mostly
-        # to prevent 500 errors.
+    role = _get_role_from_related_object(role_related_obj)
+    if role is None:
         return False
-    elif isinstance(role_related_obj, Role):
-        role = role_related_obj
-    else:
-        raise NotImplementedError("Please provide a condition for '%s'"
-                                  % type(role_related_obj))
 
     if feature_name and not role.instance.feature_enabled(feature_name):
         return False
@@ -121,6 +97,36 @@ def _allows_perm(role_related_obj, model_name,
         return False
     else:
         return predicate(perm_attrs)
+
+
+def _get_role_from_related_object(role_related_obj):
+    if isinstance(role_related_obj, InstanceUser):
+        if _invalid_instanceuser(role_related_obj):
+            # TODO: in udf_write_level below, we do
+            # this same check, but instead of returning
+            # None, we go forward by assigning role
+            # to be the default role for the given instance.
+            # here, we won't always have instance in scope,
+            # but we should consider factoring udf_write_level
+            # into this method and optionally taking an instance
+            # so that one can go forward with the default role.
+            return None
+        else:
+            return role_related_obj.role
+    elif isinstance(role_related_obj, type(None)):
+        # almost certainly this is being called with
+        # last_effective_instance_user without checking
+        # first if it is None. Since we haven't received
+        # the instance along with it, we can't resolve
+        # the default role, so perms must be blocked entirely.
+        # this is not so bad, because this block is mostly
+        # to prevent 500 errors.
+        return None
+    elif isinstance(role_related_obj, Role):
+        return role_related_obj
+    else:
+        raise NotImplementedError("Please provide a condition for '%s'"
+                                  % type(role_related_obj))
 
 
 def _invalid_instanceuser(instanceuser):
@@ -172,11 +178,17 @@ def udf_write_level(instanceuser, udf):
 
 
 def plot_is_creatable(role_related_obj):
-    from treemap.models import Plot
     return _allows_perm(role_related_obj, 'Plot',
                         perm_attr=ALLOWS_WRITES,
                         fields=Plot()._fields_required_for_create(),
                         feature_name='add_plot',
+                        predicate=all)
+
+
+def map_feature_is_creatable(role_related_obj, Model):
+    return _allows_perm(role_related_obj, Model.__name__,
+                        perm_attr=ALLOWS_WRITES,
+                        fields=Model()._fields_required_for_create(),
                         predicate=all)
 
 
@@ -198,6 +210,18 @@ def plot_is_writable(role_related_obj, field=None):
     return _allows_perm(role_related_obj, 'Plot',
                         perm_attr=ALLOWS_WRITES,
                         predicate=any, field=field)
+
+
+def any_resource_is_creatable(role_related_obj):
+    role = _get_role_from_related_object(role_related_obj)
+    if role is None:
+        return False
+
+    map_features = {MapFeature.get_subclass(m)
+                    for m in role.instance.map_feature_types}
+    resources = map_features - {Plot}
+
+    return any(map_feature_is_creatable(role, Model) for Model in resources)
 
 
 def geom_is_writable(instanceuser, model_name):

--- a/opentreemap/treemap/templates/base.html
+++ b/opentreemap/treemap/templates/base.html
@@ -56,7 +56,7 @@
               {% if last_instance|feature_enabled:'add_plot' and last_effective_instance_user %}
               <li data-feature="add_plot">
                 <a data-class='add-tree'
-                   data-always-enable='{{ last_effective_instance_user|plot_is_writable }}'
+                   data-always-enable='{{ last_effective_instance_user|plot_is_creatable }}'
                    data-disabled-title='{% trans "Adding trees is not available to all users" %}'
                    data-href="{% url 'map' instance_url_name=last_instance.url_name %}?m=addTree"
                    disabled='disabled'>{% trans "Add a Tree" %}</a>

--- a/opentreemap/treemap/templates/instance_base.html
+++ b/opentreemap/treemap/templates/instance_base.html
@@ -20,10 +20,7 @@
 {% if request.instance|feature_enabled:'add_plot' and last_effective_instance_user %}
   {% if request.instance.supports_resources %}
     <li class="add-menu dropdown" data-feature="add_plot">
-      <a class="dropdown-toggle" data-toggle="dropdown"
-         data-always-enable="true"
-         data-disabled-title='{% trans "Adding trees is not available to all users" %}'
-         disabled='disabled'>
+      <a class="dropdown-toggle" data-toggle="dropdown">
         <i class="icon-plus-circled"></i>
       </a>
       <ul class="dropdown-menu">

--- a/opentreemap/treemap/templates/instance_base.html
+++ b/opentreemap/treemap/templates/instance_base.html
@@ -26,12 +26,14 @@
       <ul class="dropdown-menu">
         <li>
           <a data-href="{% url 'map' instance_url_name=request.instance.url_name %}?m=addTree"
-             data-always-enable="{{ last_effective_instance_user|plot_is_writable }}"
+             data-always-enable="{{ last_effective_instance_user|plot_is_creatable }}"
+             data-disabled-title='{% trans "Adding trees is not available to all users" %}'
              data-action='addtree'>{% trans "Add a Tree" %}</a>
         </li>
         <li>
           <a data-href="{% url 'map' instance_url_name=request.instance.url_name %}?m=addResource"
              data-always-enable="{{ last_effective_instance_user|plot_is_writable }}"
+             data-disabled-title='{% blocktrans with resources=term.Resources %}Adding {{ resources }} is not available to all users{% endblocktrans %}'
              data-action='addresource'>{% trans "Add a" %} {{ term.Resource }}</a>
         </li>
       </ul>
@@ -39,7 +41,7 @@
   {% else %}
     <li data-feature="add_plot">
       <a data-action='addtree'
-         data-always-enable='{{ last_effective_instance_user|plot_is_writable }}'
+         data-always-enable='{{ last_effective_instance_user|plot_is_creatable }}'
          data-disabled-title='{% trans "Adding trees is not available to all users" %}'
          data-href="{% url 'map' instance_url_name=request.instance.url_name %}?m=addTree"
          disabled='disabled'>{% trans "Add a Tree" %}</a>
@@ -150,7 +152,7 @@
       <a class="btn btn-primary addBtn"
          data-action='addtree'
          data-feature="add_plot"
-         data-always-enable="{{ last_effective_instance_user|plot_is_writable }}"
+         data-always-enable="{{ last_effective_instance_user|plot_is_creatable }}"
          data-disabled-title="{% trans "Adding trees is not available to all users" %}"
          data-href="{% url 'map' instance_url_name=request.instance.url_name %}?m=addTree"
          disabled="disabled"><i class="icon-plus"></i> {% trans "Add a Tree" %}</a>

--- a/opentreemap/treemap/templates/instance_base.html
+++ b/opentreemap/treemap/templates/instance_base.html
@@ -32,7 +32,7 @@
         </li>
         <li>
           <a data-href="{% url 'map' instance_url_name=request.instance.url_name %}?m=addResource"
-             data-always-enable="{{ last_effective_instance_user|plot_is_writable }}"
+             data-always-enable="{{ last_effective_instance_user|any_resource_is_creatable }}"
              data-disabled-title='{% blocktrans with resources=term.Resources %}Adding {{ resources }} is not available to all users{% endblocktrans %}'
              data-action='addresource'>{% trans "Add a" %} {{ term.Resource }}</a>
         </li>
@@ -142,8 +142,7 @@
         {% if request.instance.supports_resources %}
         <a class="btn btn-primary addBtn"
            data-action='addresource'
-           data-feature="add_plot"
-           data-always-enable="{{ last_effective_instance_user|plot_is_writable }}"
+           data-always-enable="{{ last_effective_instance_user|any_resource_is_creatable }}"
            data-disabled-title=
              "{% blocktrans with resources=terms.resources %}Adding {{ resources }} is not available to all users {% endblocktrans %}"
            data-href="{% url 'map' instance_url_name=request.instance.url_name %}?m=addResource"

--- a/opentreemap/treemap/templatetags/instance_config.py
+++ b/opentreemap/treemap/templatetags/instance_config.py
@@ -60,4 +60,5 @@ is_read_or_write = register.filter(perms.is_read_or_write)
 treephoto_is_writable = register.filter(perms.treephoto_is_writable)
 mapfeaturephoto_is_writable = register.filter(
     perms.mapfeaturephoto_is_writable)
+any_resource_is_creatable = register.filter(perms.any_resource_is_creatable)
 plot_is_creatable = register.filter(perms.plot_is_creatable)

--- a/opentreemap/treemap/templatetags/instance_config.py
+++ b/opentreemap/treemap/templatetags/instance_config.py
@@ -52,11 +52,12 @@ def get_udfc_search_fields(instance, user):
 
 udf_write_level = register.filter(perms.udf_write_level)
 geom_is_writable = register.filter(perms.geom_is_writable)
-mapfeature_is_writable = register.filter(perms.map_feature_is_writable)
-mapfeature_is_deletable = register.filter(perms.map_feature_is_deletable)
+map_feature_is_writable = register.filter(perms.map_feature_is_writable)
+map_feature_is_deletable = register.filter(perms.map_feature_is_deletable)
 plot_is_writable = register.filter(perms.plot_is_writable)
 is_deletable = register.filter(perms.is_deletable)
 is_read_or_write = register.filter(perms.is_read_or_write)
 treephoto_is_writable = register.filter(perms.treephoto_is_writable)
 mapfeaturephoto_is_writable = register.filter(
     perms.mapfeaturephoto_is_writable)
+plot_is_creatable = register.filter(perms.plot_is_creatable)


### PR DESCRIPTION
 - The add resource menu was broken due to using `true` instead of `True`.  Since it should always be enabled, I removed all of the button enabler related attributes.
 - Add plot and resource permissions were incorrect for _all_ of the add tree/resource buttons on the site.  I registered the `plot_is_creatable` helper function as a template filter, and switched to using it in several places.
 - We were checking plot permissions instead of resource permissions when enabling/disabling buttons for resources.  I added separate helper functions for these, and fixed some typos in other places where they were already being used.

Connects to #2198