### PR TITLE
Genericize the map page browse mode detail header

### DIFF
--- a/opentreemap/treemap/templates/treemap/map-browse-trees.html
+++ b/opentreemap/treemap/templates/treemap/map-browse-trees.html
@@ -4,7 +4,7 @@
 <div class="panel" id="map-info">
   <div class="panel-group">
     <div class="panel-heading">
-      <a class="panel-toggle collapsed" data-toggle="collapse" data-parent="#map-info" href="#tree-detail">{% trans "Tree Details" %} <span class="arrow pull-right"><i class="icon-right-open"></i></span></a>
+      <a class="panel-toggle collapsed" data-toggle="collapse" data-parent="#map-info" href="#tree-detail">{% trans "Details" %} <span class="arrow pull-right"><i class="icon-right-open"></i></span></a>
     </div>
     <div id="tree-detail" class="panel-body collapse">
       <div class="panel-body-buttons" id="map-plot-details-button" style="display: none;">


### PR DESCRIPTION
I have changed the first header on the sidebar of the browse trees mode of the map page to "Details" instead of the overly specific "Tree Details." We are showing the details for green infrastructure features in this same area.

Tree selected 

<img width="891" alt="screen shot 2015-08-12 at 3 23 20 pm" src="https://cloud.githubusercontent.com/assets/17363/9238310/329281fe-4106-11e5-9e8a-ba388d0986dd.png">

Stormwater feature selected

<img width="865" alt="screen shot 2015-08-12 at 3 23 38 pm" src="https://cloud.githubusercontent.com/assets/17363/9238314/3a10e524-4106-11e5-81bb-4f220dd8ddd7.png">

The eco benefits being shown are for the entire map, and are always shown. Single-tree benefits are correctly removed from the sidebar when switching from displaying a tree to displaying a stormwater feature.

Connects to #2184