### PR TITLE
Update gunicorn and django debug toolbar

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
 django-extensions==1.2.5
 six==1.4.1
-django-debug-toolbar==1.2
+django-debug-toolbar==1.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ django-storages==1.1.8
 Django==1.8.2
 Pillow==2.3.1
 argparse==1.2.1
-gunicorn==0.17.2
+gunicorn==19.3.0
 psycopg2==2.4.6
 django-hstore==1.4.0
 wsgiref==0.1.2


### PR DESCRIPTION
Gunicorn got the reload option in version 19, which is handy.
The Django Debug Toolbar got Django 1.8 support in 1.3, and it wouldn't
work until I upgraded it.

It _looks_ like Gunicorn got a big version increase, but I think what happened is they decided to drop the leading `0.`