### PR TITLE
Increment API to version 4 and hide multichoice fields from older APIs

### DIFF
--- a/opentreemap/api/decorators.py
+++ b/opentreemap/api/decorators.py
@@ -17,7 +17,7 @@ from api.auth import (create_401unauthorized, get_signature_for_request,
                       parse_user_from_request)
 
 SIG_TIMESTAMP_FORMAT = '%Y-%m-%dT%H:%M:%S'
-API_VERSIONS = {2, 3}
+API_VERSIONS = {2, 3, 4}
 
 
 def check_signature_and_require_login(view_f):

--- a/opentreemap/treemap/udf.py
+++ b/opentreemap/treemap/udf.py
@@ -780,6 +780,8 @@ class UserDefinedFieldDefinition(models.Model):
                 return value
             else:
                 values = json.loads(value)
+                if values is None:
+                    values = []
                 map(_validate, values)
                 return values
         else:


### PR DESCRIPTION
Our mobile apps do not currently support multichoice fields.
In order to prevent crashes, we need to hide multichoice fields from API
version 3 and below.

When we upgrade the mobile apps to support multichoice fields, we will
switch them from API version 3 to API version 4

Connects to #2235