### PR TITLE
Cleanup some cruft with UDFs

### DIFF
--- a/opentreemap/treemap/lib/udf.py
+++ b/opentreemap/treemap/lib/udf.py
@@ -39,10 +39,7 @@ def udf_create(params, instance):
 
     udfs = UserDefinedFieldDefinition.objects.filter(
         instance=instance,
-        # TODO: why isn't this also checking model name
-        # is there some reason the same name can't appear
-        # on more than one model?
-        # Too scared to change this.
+        model_type=model_type,
         name=name)
 
     if udfs.exists():

--- a/opentreemap/treemap/migrations/0007_auto_20150902_1534.py
+++ b/opentreemap/treemap/migrations/0007_auto_20150902_1534.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0006_stop_tracking_polygonal_mapfeature_ptr'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='userdefinedfielddefinition',
+            unique_together=set([('instance', 'model_type', 'name')]),
+        ),
+    ]

--- a/opentreemap/treemap/udf.py
+++ b/opentreemap/treemap/udf.py
@@ -315,6 +315,9 @@ class UserDefinedFieldDefinition(models.Model):
     """
     name = models.CharField(max_length=255)
 
+    class Meta:
+        unique_together = ('instance', 'model_type', 'name')
+
     def __unicode__(self):
         return ('%s.%s%s' %
                 (self.model_type, self.name,
@@ -583,7 +586,7 @@ class UserDefinedFieldDefinition(models.Model):
                                     'multichoice']:
             raise ValidationError(_('invalid datatype'))
 
-        if datatype['type'] == 'choice':
+        if datatype['type'] in ('choice', 'multichoice'):
             choices = datatype.get('choices', None)
 
             if choices is None:


### PR DESCRIPTION
 - Validate the choices list for multichoice UDFs
 - Allow UDFs with the same name if they are on different models
 - Add a uniqueness constraint to UserDefinedFieldDefinition