### PR TITLE
Stop running syncdb for Travis and Circle CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ before_script:
   - psql -c "CREATE EXTENSION hstore;" -U postgres -d template1
   - psql -c "CREATE DATABASE ci;" -U postgres
   - psql -c "CREATE EXTENSION postgis;" -U postgres -d ci
-  - python opentreemap/manage.py syncdb --noinput
   - python opentreemap/manage.py migrate --noinput
   - mkdir -p /tmp/otm/static
   - mkdir -p /tmp/otm/media

--- a/circle.yml
+++ b/circle.yml
@@ -17,7 +17,6 @@ database:
     - psql -c "CREATE EXTENSION hstore;" -U postgres -d template1
     - psql -c "CREATE DATABASE ci;" -U postgres
     - psql -c "CREATE EXTENSION postgis;" -U postgres -d ci
-    - python opentreemap/manage.py syncdb --noinput
     - python opentreemap/manage.py migrate --noinput
     - npm run grunt
     - python opentreemap/manage.py collectstatic --noinput


### PR DESCRIPTION
We no longer need to do this now that we've switched to using Django
migrations.