### PR TITLE
Rename 'supports_resource' -> 'has_resources'

### DIFF
--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -385,7 +385,7 @@ class Instance(models.Model):
         return models
 
     @property
-    def supports_resources(self):
+    def has_resources(self):
         """
         Determine whether this instance has multiple map feature
         types (plots + "resources") or not.

--- a/opentreemap/treemap/templates/instance_base.html
+++ b/opentreemap/treemap/templates/instance_base.html
@@ -18,7 +18,7 @@
 
 {% block instancetopnav %}
 {% if request.instance|feature_enabled:'add_plot' and last_effective_instance_user %}
-  {% if request.instance.supports_resources %}
+  {% if request.instance.has_resources %}
     <li class="add-menu dropdown" data-feature="add_plot">
       <a class="dropdown-toggle" data-toggle="dropdown">
         <i class="icon-plus-circled"></i>
@@ -139,7 +139,7 @@
     </div>
     <div class="half">
       {% if request.instance|feature_enabled:'add_plot' and last_effective_instance_user %}
-        {% if request.instance.supports_resources %}
+        {% if request.instance.has_resources %}
         <a class="btn btn-primary addBtn"
            data-action='addresource'
            data-always-enable="{{ last_effective_instance_user|any_resource_is_creatable }}"

--- a/opentreemap/treemap/templates/treemap/partials/eco_benefits.html
+++ b/opentreemap/treemap/templates/treemap/partials/eco_benefits.html
@@ -16,7 +16,7 @@
     {% endwith %}
 
     {% with resource_benefits=benefits.resource %}
-      {% if not hide_summary and request.instance.supports_resources and resource_benefits %}
+      {% if not hide_summary and request.instance.has_resources and resource_benefits %}
         <div class="benefit-value-title">{{ term.Resource }} {% trans "Benefits" %}</div>
       {% endif %}
       {% include "treemap/partials/benefit_value_row.html" with benefit=resource_benefits.runoff_reduced icon='tint' %}
@@ -25,7 +25,7 @@
 
     {% if not hide_summary and not hidecounts %}
     <div class="benefit-tree-count">
-      {% with has_resources=request.instance.supports_resources plot_basis=basis.plot resource_basis=basis.resource %}
+      {% with has_resources=request.instance.has_resources plot_basis=basis.plot resource_basis=basis.resource %}
         {% blocktrans with used=plot_basis.n_objects_used total=plot_basis.n_total %}
         Based on {{ used }} out of {{ total }} total trees{% endblocktrans %}{% if not has_resources %}.{% endif %}
         {% if has_resources %}
@@ -44,7 +44,7 @@
   {% localize on %}
   <span id="tree-count">{{ basis.plot.n_total }}</span> {{ tree_count_label }}
   <span id="planting-site-count">{{ basis.plot.n_plots }}</span> {{ plot_count_label }}
-  {% if request.instance.supports_resources and basis.resource %}
+  {% if request.instance.has_resources and basis.resource %}
     {% with resource_count=basis.resource.n_total %}
       <span id="resource-count">{{ resource_count }}</span>
       {% if resource_count == 1 %}

--- a/opentreemap/treemap/views/tree.py
+++ b/opentreemap/treemap/views/tree.py
@@ -95,7 +95,7 @@ def search_tree_benefits(request, instance):
         'tree,' if basis['plot']['n_total'] == 1 else 'trees,')
     formatted['plot_count_label'] = (
         'planting site' if basis['plot']['n_plots'] == 1 else 'planting sites')
-    if instance.supports_resources and 'resource' in basis:
+    if instance.has_resources and 'resource' in basis:
         formatted['plot_count_label'] += ','
 
     return formatted


### PR DESCRIPTION
Determining if an instance has resources is now a poor fit for
determining support for resources because it imposes an inception
problem. An instance must support resources for a resource to be added,
but a resource must be added for an instance to support
resources. Renaming this function will make it semantically clearer to
use other criteria for testing resource support.