### PR TITLE
Fix comment moderation UI tests.

### DIFF
--- a/opentreemap/otm_comments/js/src/moderation.js
+++ b/opentreemap/otm_comments/js/src/moderation.js
@@ -91,5 +91,8 @@ module.exports = function(options) {
         return Bacon.fromPromise(promise);
     });
 
+    // We need an onValue to force evaluation of the lazy stream
+    containerUpdatedStream.onValue($.noop);
+
     return containerUpdatedStream;
 };


### PR DESCRIPTION
Because the Bacon.js stream was change from using onValue to using flatMap
to support further usage, it stopped working when it was *not* used,
due to Bacon's lazy evaluation.

Adding a noop onValue fixes the issue.

Connects to #2247