### PR TITLE
Fix running JS tests via testem CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
 install:
   - pip install -r travis-requirements.txt
   - npm install
+  - npm install -g grunt-cli@0.1.9
 
 before_script:
   - cp ci/local_settings.py opentreemap/opentreemap/settings/local_settings.py
@@ -37,6 +38,7 @@ before_script:
 script:
   - flake8 --exclude migrations,opentreemap/settings/local_settings.py,*.pyc opentreemap
   - npm run check
+  - testem ci -l Firefox
   - cd opentreemap && coverage run --rcfile=../coveragerc --source=. manage.py test
 
 after_success:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,8 @@ module.exports = function(grunt) {
     grunt.registerTask('check', ['jshint']);
     grunt.registerTask('js', debug ? ['browserify', 'file-creator'] : ['browserify', 'uglify']);
     grunt.registerTask('css', debug ? ['sass', 'concat'] : ['sass', 'concat', 'cssmin']);
-    grunt.registerTask('default', ['js', 'css', 'shell:collect_static']);
+    grunt.registerTask('build', ['js', 'css']);
+    grunt.registerTask('default', ['build', 'shell:collect_static']);
 
     /*
      * Maps all src/*.js files by their Django app name.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "grunt-sass": "~0.6.1",
     "grunt-shell": "1.1.1",
     "mocha": "~1.14.0",
-    "testem": "^0.6.24"
+    "testem": "^0.9.2"
   },
   "repository": {
     "type": "git",
@@ -39,7 +39,8 @@
   "scripts": {
     "test": "testem ci",
     "check": "grunt check",
-    "grunt": "grunt"
+    "grunt": "grunt",
+    "grunt-dev-build": "grunt build --dev"
   },
   "author": "Azavea",
   "license": "GPL3",

--- a/testem.json
+++ b/testem.json
@@ -1,6 +1,6 @@
 {
     "test_page": "opentreemap/treemap/js/test/test.html",
-    "before_tests": "npm run grunt -- --dev",
+    "before_tests": "npm run grunt-dev-build",
     "src_files": [
         "opentreemap/*/js/*/*.js"
     ],


### PR DESCRIPTION
The `before_tests` script specified in our testem config was failing
since Grunt needs to run in the virtualenv in order to run collectstatic.

When this script fails, testem just hangs forever for some reason.

I fixed the issue by adding a new Grunt task which just runs the `js` and
`css` tasks (which used to be the default Grunt task).