### PR TITLE
Bug fix otm1 migrator

### DIFF
--- a/opentreemap/otm1_migrator/management/commands/perform_migration.py
+++ b/opentreemap/otm1_migrator/management/commands/perform_migration.py
@@ -50,6 +50,10 @@ def save_objects(migration_rules, model_name, model_dicts, relic_ids,
                      if dict['pk'] not in model_key_map)
 
     for model_dict in dicts_to_save:
+        if model_name != model_dict["model"].split(".")[1]:
+            continue
+        #if "treekey" in model_dict["model"] or "favorite" in model_dict["model"]:
+        #    continue
         dependencies = (migration_rules
                         .get(model_name, {})
                         .get('dependencies', {})
@@ -61,7 +65,7 @@ def save_objects(migration_rules, model_name, model_dicts, relic_ids,
         # their corresponding otm2 pks
         if dependencies:
             for name, field in dependencies:
-                old_id = model_dict['fields'][field]
+                old_id = model_dict['fields'].get(field,{})
                 if old_id:
                     old_id_to_new_id = relic_ids[name]
                     try:

--- a/opentreemap/otm1_migrator/management/commands/perform_migration.py
+++ b/opentreemap/otm1_migrator/management/commands/perform_migration.py
@@ -50,10 +50,9 @@ def save_objects(migration_rules, model_name, model_dicts, relic_ids,
                      if dict['pk'] not in model_key_map)
 
     for model_dict in dicts_to_save:
+        # short-circuit if the dict isn't a `model_name` record
         if model_name != model_dict["model"].split(".")[1]:
             continue
-        #if "treekey" in model_dict["model"] or "favorite" in model_dict["model"]:
-        #    continue
         dependencies = (migration_rules
                         .get(model_name, {})
                         .get('dependencies', {})


### PR DESCRIPTION
Here is the symptom that this patch fixes:
```
WARNINGS:
treemap.Instance.boundaries: (fields.W340) null has no effect on ManyToManyField.
treemap.Instance.users: (fields.W340) null has no effect on ManyToManyField.
Reading relics into memory........................
Done reading relics into memory...................
Loaded fixture 'user_fixture'.....................SUCCESS
Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/otm/env/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 338, in execute_from_command_line
    utility.execute()
  File "/usr/local/otm/env/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 330, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/otm/env/local/lib/python2.7/site-packages/django/core/management/base.py", line 390, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/otm/env/local/lib/python2.7/site-packages/django/core/management/base.py", line 441, in execute
    output = self.handle(*args, **options)
  File "/usr/local/otm/app/opentreemap/otm1_migrator/management/commands/perform_migration.py", line 295, in handle
    message_receiver=print)
  File "/usr/local/otm/app/opentreemap/otm1_migrator/management/commands/perform_migration.py", line 76, in save_objects
    model_dict, instance)
  File "/usr/local/otm/app/opentreemap/otm1_migrator/data_util.py", line 50, in dict_to_model
    validate_model_dict(config, model_name, data_dict)
  File "/usr/local/otm/app/opentreemap/otm1_migrator/data_util.py", line 41, in validate_model_dict
    expected_fields.symmetric_difference(provided_fields)))
Exception: model validation failure: "user".

Expected: set(['username', 'first_name', 'last_name', 'is_active', 'is_superuser', 'is_staff', 'last_login', 'groups', 'user_permissions', 'password', 'email', 'date_joined'])

Got: set([u'model', u'name', u'app_label'])

Symmetric Difference: set(['username', 'first_name', 'last_name', u'name', 'is_active', 'is_superuser', 'is_staff', 'last_login', 'groups', u'app_label', 'user_permissions', u'model', 'password', 'email', 'date_joined'])
(env)ddye@ubuntu:/usr/local/otm/app/opentreemap$
```