### PR TITLE
Fix collectstatic sometimes missing updated files.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -100,7 +100,7 @@ module.exports = function(grunt) {
         },
         shell: {
             collect_static: {
-                command: 'python manage.py collectstatic --noinput'
+                command: 'python manage.py collectstatic --noinput -c'
             }
         },
         browserify: {


### PR DESCRIPTION
Django's `collectstatic` command uses file modification time to determine
if it should overwrite a file.  Unfortunately inside VirtualBox shared
folder file modification times are often inconsistent, and this can lead
to newly updated files not being collected, especially when running
`grunt watch`.

Adding `-c` to the command tells Django to always overwrite every file,
which fixes the problem, though it does add a slight amount of overhead.