### PR TITLE
Adds rate limiting to importer commit tasks to prevent database overutilization

### DIFF
--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -323,6 +323,12 @@ DISPLAY_DEFAULTS = {
 # Time in ms for two clicks to be considered a double-click in some scenarios
 DOUBLE_CLICK_INTERVAL = 300
 
+# The number of plots to import per task
+IMPORT_BATCH_SIZE = 85
+
+# The rate limit for how frequently batches of imports can happen per worker
+IMPORT_COMMIT_RATE_LIMIT = "1/m"
+
 # We have... issues on IE9 right now
 # Disable it on production, but enable it in Debug mode
 IE_VERSION_MINIMUM = 9 if DEBUG else 10


### PR DESCRIPTION
Based on the timing information reported in OpenTreeMap/otm-core#2267
we expect a single batch of 250 trees running on a single worker to take
approximately 1 minute per batch, once the distance validation refactor
in that PR is integrated.

Based on this, I reduced the batch size to 85 which should take around 20
seconds, and I added a rate limit of 1 batch per minute.  Since we have
two Celery workers in production, this should provide a combined rate
limit of 2 batches/minute (since rate limits affect workers individually),
with an expected "quiet period" of 20 seconds per minute.

Since our production environment differs significantly from our
development environments, we should obviously test these assumptions
and timings after this change is deployed to production.

Connects to #2258