### PR TITLE
Add missing terminology

### DIFF
--- a/opentreemap/stormwater/models.py
+++ b/opentreemap/stormwater/models.py
@@ -137,6 +137,10 @@ class RainBarrel(MapFeature):
         'plural': _('Rain Barrels'),
     }
 
+    @classproperty
+    def benefits(cls):
+        return CountOnlyBenefitCalculator(cls)
+
     @property
     def is_editable(self):
         # this is a holdover until we can support editing for all resources

--- a/opentreemap/treemap/ecobenefits.py
+++ b/opentreemap/treemap/ecobenefits.py
@@ -408,7 +408,7 @@ def get_benefits_for_filter(filter):
     benefits, basis = {}, {}
 
     for C in MapFeature.subclass_dict().values():
-        if not hasattr(C, 'benefits') or C.__name__ not in allowed_types:
+        if C.__name__ not in allowed_types:
             continue
 
         ft_benefit_groups, ft_basis = _benefits_for_class(C, filter)

--- a/opentreemap/treemap/lib/map_feature.py
+++ b/opentreemap/treemap/lib/map_feature.py
@@ -78,9 +78,6 @@ def _map_feature_audits(user, instance, feature, filters=None,
 def _add_eco_benefits_to_context_dict(instance, feature, context):
     FeatureClass = feature.__class__
 
-    if not hasattr(FeatureClass, 'benefits'):
-        return
-
     benefits, basis, error = FeatureClass.benefits\
                                          .benefits_for_object(
                                              instance, feature)

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -606,8 +606,8 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
             raise ValidationError({
                 "geom": [
                     _(
-                        "%(model)ss must be created inside the map boundaries")
-                    % {'model': self.terminology(self.instance)['singular']}]
+                        "%(model)s must be created inside the map boundaries")
+                    % {'model': self.terminology(self.instance)['plural']}]
             })
 
     def delete_with_user(self, user, *args, **kwargs):
@@ -771,6 +771,9 @@ class Plot(MapFeature):
     objects = GeoHStoreUDFManager()
     is_editable = True
 
+    _terminology = {'singular': _('Planting Site'),
+                    'plural': _('Planting Sites')}
+
     udf_settings = {
         'Stewardship': {
             'iscollection': True,
@@ -846,10 +849,6 @@ class Plot(MapFeature):
                 "Cannot delete plot with existing trees."))
         super(Plot, self).delete_with_user(user, *args, **kwargs)
 
-    @classproperty
-    def display_name(cls):
-        return _('Planting Site')
-
 
 # UDFModel overrides implementations of methods in
 # authorizable and auditable, thus needs to be inherited first
@@ -914,7 +913,7 @@ class Tree(Convertible, UDFModel, PendingAuditable):
                          if self.species else "")
         return "%s%s" % (diameter_chunk, species_chunk)
 
-    _terminology = {'singular': _('Tree')}
+    _terminology = {'singular': _('Tree'), 'plural': _('Trees')}
 
     def dict(self):
         props = self.as_dict()

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -754,8 +754,13 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
     def _terminology(cls):
         return {'singular': cls.__name__}
 
+    @classproperty
+    def benefits(cls):
+        from treemap.ecobenefits import CountOnlyBenefitCalculator
+        return CountOnlyBenefitCalculator(cls)
 
-#TODO:
+
+# TODO:
 # Exclusion Zones
 # Proximity validation
 # UDFModel overrides implementations of methods in

--- a/opentreemap/treemap/templatetags/util.py
+++ b/opentreemap/treemap/templatetags/util.py
@@ -6,7 +6,8 @@ import json
 
 from opentreemap.util import dotted_split
 
-from treemap.models import MapFeature, Tree, TreePhoto, MapFeaturePhoto, Audit
+from treemap.models import (MapFeature, Tree, TreePhoto,
+                            MapFeaturePhoto, Audit, Plot)
 from treemap.udf import UserDefinedCollectionValue
 from treemap.util import get_filterable_audit_models, to_model_name
 
@@ -112,8 +113,13 @@ def display_name(audit_or_model_or_name):
     else:
         name = audit_or_model_or_name.__class__.__name__
 
+    # TODO: this should really call `.terminology()` with an instance arg
+    # to actually support instance-overrideable plot terminology.
+    # I am deferring this fix because this feature is not planned asnd it's
+    # non-trivial to put instance in scope here, which is required for
+    # getting terminology
     if name.lower() == 'plot':
-        return 'Planting Site'
+        return Plot.terminology()['singular']
     else:
         return name
 


### PR DESCRIPTION
It was originally planned to dynamically generate plural terminology if
it was absent but it was then decided to be more complex than
necessary. Plural terminology was supposed to be added in when that
decision was made, but fell through for a few models.