### PR TITLE
Use a bbox filter for bulk import proximity checking

### DIFF
--- a/opentreemap/importer/models/trees.py
+++ b/opentreemap/importer/models/trees.py
@@ -5,11 +5,10 @@ from __future__ import division
 
 from django.core.exceptions import ValidationError
 from django.contrib.gis.db import models
-from django.contrib.gis.geos import Point
-from django.contrib.gis.measure import D
+from django.contrib.gis.geos import Point, Polygon
 from django.utils.translation import ugettext as _
 
-from treemap.models import Species, Plot, Tree
+from treemap.models import Species, Plot, Tree, MapFeature
 from treemap.lib.object_caches import udf_defs
 
 from importer.models.base import GenericImportRow, GenericImportEvent
@@ -255,17 +254,26 @@ class TreeImportRow(GenericImportRow):
             .filter(plot__isnull=False)\
             .values_list('plot__pk', flat=True)
 
-        nearby = Plot.objects\
-                     .filter(instance=self.import_event.instance)\
-                     .filter(geom__distance_lte=(point, D(ft=10.0)))\
-                     .distance(point)\
-                     .exclude(pk__in=plot_ids_from_this_import)\
+        offset = 3.048  # 10ft in meters
+        nearby_bbox = Polygon(((point.x - offset, point.y - offset),
+                               (point.x - offset, point.y + offset),
+                               (point.x + offset, point.y + offset),
+                               (point.x + offset, point.y - offset),
+                               (point.x - offset, point.y - offset)))
+
+        # Using MapFeature directly avoids a join between the
+        # treemap_plot and treemap_mapfeature tables.
+        nearby = MapFeature.objects\
+                           .filter(instance=self.import_event.instance)\
+                           .filter(feature_type='Plot')\
+                           .filter(geom__intersects=nearby_bbox)\
+                           .exclude(pk__in=plot_ids_from_this_import)\
 
         oid = self.cleaned.get(fields.trees.OPENTREEMAP_PLOT_ID, None)
         if oid:
             nearby = nearby.exclude(pk=oid)
 
-        nearby = nearby.order_by('distance')[:5]
+        nearby = nearby.distance(point).order_by('distance')[:5]
 
         if len(nearby) > 0:
             flds = (fields.trees.POINT_X, fields.trees.POINT_Y)


### PR DESCRIPTION
Sorting all the trees by distance from a point gets very processor intensive when an instance has a lot of trees and dramatically slows down the import. Adding a where clause that filters by a small bounding box speeds up the query by up to three orders of magnitude on an instance with 500,000 plots and runs in 1ms on an brand new instance with no plots.

This is an example of the query produced by the Django ORM, and the
EXPLAIN ANALYZE output for a similar query.

```
SELECT "treemap_mapfeature"."id",
       "treemap_mapfeature"."udfs",
       "treemap_mapfeature"."instance_id",
       "treemap_mapfeature"."the_geom_webmercator",
       "treemap_mapfeature"."address_street",
       "treemap_mapfeature"."address_city",
       "treemap_mapfeature"."address_zip",
       "treemap_mapfeature"."readonly",
       "treemap_mapfeature"."updated_at",
       "treemap_mapfeature"."feature_type",
( St_distance("treemap_mapfeature"."the_geom_webmercator",
St_geomfromewkb('\001\001\000\000 \021\017\000\000\316\244\260vz\021i\301\232\313p\255\330\257NA' :: bytea)) ) AS "distance"
FROM   "treemap_mapfeature"
WHERE  ( "treemap_mapfeature"."instance_id" = 336
         AND "treemap_mapfeature"."feature_type" = 'Plot'
         AND St_intersects("treemap_mapfeature"."the_geom_webmercator",
             St_geomfromewkb(
'\001\003\000\000 \021\017\000\000\001\000\000\000\005\000\000\000\032\3349\330z\021i\301k\356K''\327\257NA\032\3349\330z\021i\301\311\250\2253\332\257NA\202m''\025z\021i\301\311\250\2253\332\257NA\202m''\025z\021i\301k\356K''\327\257NA\032\3349\330z\021i\301k\356K''\327\257NA'
:: bytea))
AND NOT ( "treemap_mapfeature"."id" IN (SELECT U0."plot_id"
                                        FROM   "importer_treeimportrow" U0
                                        WHERE  ( U0."import_event_id" = 482
                                                 AND U0."plot_id" IS NOT NULL ))
        ) )
ORDER  BY "distance" ASC
LIMIT  5;
```

```
 Limit  (cost=253.99..254.00 rows=1 width=123) (actual time=0.345..0.345 rows=1 loops=1)
   ->  Sort  (cost=253.99..254.00 rows=1 width=123) (actual time=0.344..0.344 rows=1 loops=1)
         Sort Key: (st_distance(treemap_mapfeature.the_geom_webmercator, '0101000020110F0000B9DDD866C51669C1F427F541BCAA4E41'::geometry))
         Sort Method: quicksort  Memory: 25kB
         ->  Index Scan using treemap_mapfeature_the_geom_webmercator_id on treemap_mapfeature  (cost=245.46..253.98 rows=1 width=123) (actual time=0.337..0.338 rows=1 loops=1)
               Index Cond: (the_geom_webmercator && '0103000020110F00000100000005000000051562C8C51669C1C54AD0BBBAAA4E41051562C8C51669C123051AC8BDAA4E416DA64F05C51669C123051AC8BDAA4E416DA64F05C51669C1C54AD0BBBAAA4E41051562C8C51669C1C54AD0BBBAAA4E41'::geometry)
               Filter: ((NOT (hashed SubPlan 1)) AND (instance_id = 336) AND ((feature_type)::text = 'Plot'::text) AND _st_intersects(the_geom_webmercator, '0103000020110F00000100000005000000051562C8C51669C1C54AD0BBBAAA4E41051562C8C51669C123051AC8BDAA4E416DA64F05C51669C123051AC8BDAA4E416DA64F05C51669C1C54AD0BBBAAA4E41051562C8C51669C1C54AD0BBBAAA4E41'::geometry))
               SubPlan 1
                 ->  Index Scan using importer_treeimportrow_import_event_id on importer_treeimportrow u0  (cost=0.43..244.66 rows=204 width=4) (actual time=0.274..0.274 rows=0 loops=1)
                       Index Cond: (import_event_id = 482)
                       Filter: (plot_id IS NOT NULL)
                       Rows Removed by Filter: 1000
 Planning time: 0.286 ms
 Execution time: 0.383 ms
```

Connects to #2261