### PR TITLE
Upgrade from django 1.8.2 to 1.8.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto==2.11.0
 django-storages==1.1.8
-Django==1.8.2
+Django==1.8.4
 Pillow==2.3.1
 argparse==1.2.1
 gunicorn==19.3.0


### PR DESCRIPTION
1.8.3 and 1.8.4 include security fixes.

https://docs.djangoproject.com/en/1.8/releases/1.8.3/
https://docs.djangoproject.com/en/1.8/releases/1.8.4/

Connects to #2283 