### PR TITLE
Refresh finished import table on completion

### DIFF
--- a/opentreemap/importer/views.py
+++ b/opentreemap/importer/views.py
@@ -138,9 +138,14 @@ def _get_table_context(instance, table_name, page_number):
     else:
         raise Exception('Unexpected import table name: %s' % table_name)
 
+    # Get has_pending before filtering by page so that completing an
+    # import on a non-visible page will still trigger a refresh of the
+    # finished table
+    has_pending = any(not ie.is_finished() for ie in rows)
+
     paginator = Paginator(rows, _EVENT_TABLE_PAGE_SIZE)
     rows = paginator.page(min(page_number, paginator.num_pages))
-    has_pending = any(not ie.is_finished() for ie in rows)
+
     paging_url = reverse('importer:get_import_table',
                          args=(instance.url_name, table_name))
     refresh_url = paging_url + '?page=%s' % page_number


### PR DESCRIPTION
This fixes the bug where a completed import would disappear because the active import table refreshed, but the finished import table did not.

I fixed the issue by keeping track of which tables are linked together, and the current state of the primary tables, and then refreshing the linked table when the primary table transitions out of the refreshing state.