### PR TITLE
Refactor get_cached_plot_count to make it easier to use.

### DIFF
--- a/opentreemap/treemap/ecocache.py
+++ b/opentreemap/treemap/ecocache.py
@@ -7,6 +7,8 @@ import hashlib
 from django.conf import settings
 from django.core.cache import cache
 
+from treemap.models import Plot
+
 # Cache the results of plot counts and tree ecobenefit summary searches.
 # Plot key is count/plots/<url_name>/<geo_rev>/<filter_hash>
 # Eco key is eco/trees/<url_name>/<eco_rev>/<filter_hash>
@@ -21,9 +23,11 @@ def get_cached_tree_benefits(filter, compute_value):
     return _get_or_compute(prefix, version, filter, compute_value)
 
 
-def get_cached_plot_count(filter, compute_value):
+def get_cached_plot_count(filter):
     prefix = 'count/plots'
     version = filter.instance.geo_rev
+    compute_value = lambda: filter.get_object_count(Plot)
+
     return _get_or_compute(prefix, version, filter, compute_value)
 
 
@@ -33,7 +37,7 @@ def _get_or_compute(prefix, version, filter, compute_value):
     else:
         key = _get_key(prefix, version, filter)
         value = cache.get(key)
-        if not value:
+        if value is None:
             value = compute_value()
             cache.set(key, value, _TIMEOUT)
     return value

--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -573,6 +573,12 @@ class Instance(models.Model):
         except ObjectDoesNotExist:
             return False
 
+    def plot_count(self):
+        from treemap.ecocache import get_cached_plot_count
+        from treemap.search import Filter
+        all_plots_filter = Filter('', '', self)
+        return get_cached_plot_count(all_plots_filter)
+
     def scope_model(self, model):
         qs = model.objects.filter(instance=self)
         return qs

--- a/opentreemap/treemap/views/tree.py
+++ b/opentreemap/treemap/views/tree.py
@@ -13,7 +13,7 @@ from django.db import transaction
 from django.http import HttpResponseRedirect
 
 from treemap.search import Filter
-from treemap.models import Plot, Tree
+from treemap.models import Tree
 from treemap.audit import Audit
 from treemap.ecobenefits import get_benefits_for_filter
 from treemap.ecobenefits import BenefitCategory
@@ -64,8 +64,7 @@ def search_tree_benefits(request, instance):
     hide_summary = hide_summary_text.lower() == 'true'
 
     filter = Filter(filter_str, display_str, instance)
-    total_plots = get_cached_plot_count(
-        filter, lambda: filter.get_object_count(Plot))
+    total_plots = get_cached_plot_count(filter)
 
     benefits, basis = get_benefits_for_filter(filter)
 


### PR DESCRIPTION
Removes the need to pass `compute_value` to get_cached_plot_count and
adds a helper method to Instance to get the total number of plots from the
cache.