### PR TITLE
Revert "Make the default email backend be console-based"

### DIFF
--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -10,8 +10,6 @@ USER_ACTIVATION_FUNCTION = None
 UITEST_CREATE_INSTANCE_FUNCTION = 'treemap.tests.make_instance'
 UITEST_SETUP_FUNCTION = None
 
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-
 # This email is shown in various contact/error pages
 # throughout the site
 SUPPORT_EMAIL_ADDRESS = 'support@yoursite.com'


### PR DESCRIPTION
This reverts commit 67a12d361da2631b7162df7d34c0c765bfeadab8.

Some existing deployment environments currently depend on the default value of `django.core.mail.backends.smtp.EmailBackend`