### PR TITLE
Eliminate `fields.W340` warnings

### DIFF
--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -220,10 +220,9 @@ class Instance(models.Model):
 
     default_role = models.ForeignKey('Role', related_name='default_role')
 
-    users = models.ManyToManyField('User', through='InstanceUser',
-                                   null=True, blank=True)
+    users = models.ManyToManyField('User', through='InstanceUser')
 
-    boundaries = models.ManyToManyField('Boundary', null=True, blank=True)
+    boundaries = models.ManyToManyField('Boundary')
 
     """
     Config contains a bunch of config variables for a given instance

--- a/opentreemap/treemap/migrations/0010_eliminate_warnings_fields_w340.py
+++ b/opentreemap/treemap/migrations/0010_eliminate_warnings_fields_w340.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0009_restructure_replaceable_terms'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='instance',
+            name='boundaries',
+            field=models.ManyToManyField(to='treemap.Boundary'),
+        ),
+        migrations.AlterField(
+            model_name='instance',
+            name='users',
+            field=models.ManyToManyField(to=settings.AUTH_USER_MODEL, through='treemap.InstanceUser'),
+        ),
+    ]


### PR DESCRIPTION
No need for `null=True` on many-to-many fields `Instance.users` and `Instance.boundaries`

Connects #2142