### PR TITLE
Improvements to inline edit forms

### DIFF
--- a/opentreemap/treemap/css/sass/partials/pages/_admin.scss
+++ b/opentreemap/treemap/css/sass/partials/pages/_admin.scss
@@ -193,6 +193,10 @@
                     font-size: 16px;
                     font-weight: 100;
                 }
+
+                .spinner {
+                    padding-right: 5px;
+                }
             }
 
             .content {

--- a/opentreemap/treemap/templates/treemap/partials/form_buttons.html
+++ b/opentreemap/treemap/templates/treemap/partials/form_buttons.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+
+<div class="col-xs-4 text-right">
+    <img class="spinner" src="{{ STATIC_URL }}img/spinner.gif" style="display: none;">
+    <button data-class="display" class="btn btn-info editBtn">
+        {% trans "Edit" %}
+    </button>
+    <button data-class="edit" class="btn btn-primary saveBtn" style="display: none;">
+        {% trans "Save" %}
+    </button>
+    <button data-class="edit" class="btn cancelBtn" style="display: none;">
+        {% trans "Cancel" %}
+    </button>
+</div>


### PR DESCRIPTION
* Clicking "Save" disables "Save" and "Cancel" and shows spinner (if present)
* Pages configuring an inline edit form may omit options by following conventions
* New template partial allows DRY buttons