### PR TITLE
Fix error validation for species columns with numeric values.

### DIFF
--- a/opentreemap/importer/js/src/status.js
+++ b/opentreemap/importer/js/src/status.js
@@ -107,7 +107,7 @@ function updateRow($container, $el) {
 function updateSpeciesRow($container, $el) {
     var rowData = getRowData($container, $el);
     if (R.every(R.not(_.isEmpty), [rowData.fieldName, rowData.updatedValue])) {
-        $container.load(rowData.url, rowData.data, popover.activateAll);
+        $container.load(rowData.url, {species_id: rowData.updatedValue}, popover.activateAll);
     } else {
         toastr.error("Cannot save empty species");
     }

--- a/opentreemap/importer/views.py
+++ b/opentreemap/importer/views.py
@@ -210,6 +210,21 @@ def update_row(request, instance, import_type, row_id):
 
     basedata = row.datadict
 
+    # Minor workaround for updating species columns in tree imports
+    # The client sends up a species_id field, which does not match any of the
+    # columns in the ImportRow. If it is present, we look up the species in the
+    # DB and fill in the appropriate species fields in the ImportRow
+    if 'species_id' in request.POST:
+        # this round tripped from the server, so it should always have a match.
+        species = Species.objects.get(pk=request.POST['species_id'])
+        basedata.update({
+            fields.trees.GENUS: species.genus,
+            fields.trees.SPECIES: species.species,
+            fields.trees.CULTIVAR: species.cultivar,
+            fields.trees.OTHER_PART_OF_NAME: species.other_part_of_name,
+            fields.trees.COMMON_NAME: species.common_name
+        })
+
     for k, v in request.POST.iteritems():
         if k in basedata:
             basedata[k] = v


### PR DESCRIPTION
There was a "hack" in place to support changing the species values in a
tree import to an existing species. When updating a species, the 'species'
column was updated to reflect the PK of a species in the database, and
then later during validation the species related fields (including the one
which held the PK) would be overwritten with the correct info from the
database if the 'species' field was a number

Because it piggybacked the species id in the species name column of the
ImportRow object, there were conflicts when a number was uploaded as the
value for the species column in the original CSV, and no error would be
reported to the user.

I cleaned up the work-around significantly, by sending the species id in
a different field name, and fetching the species information from the DB
as part of the view function, so that there is no need for validation to
be concerned with it.