### PR TITLE
Expose inlineEditForm functions

### DIFF
--- a/opentreemap/treemap/js/src/inlineEditForm.js
+++ b/opentreemap/treemap/js/src/inlineEditForm.js
@@ -272,6 +272,7 @@ exports.init = function(options) {
         inEditModeProperty: inEditModeProperty,
         showGlobalErrors: showGlobalErrors,
         showValidationErrorsInline: showValidationErrorsInline,
+        getDataToSave: getDataToSave,
         setUpdateUrl: function (url) { updateUrl = url; }
     };
 };

--- a/opentreemap/treemap/js/src/inlineEditForm.js
+++ b/opentreemap/treemap/js/src/inlineEditForm.js
@@ -142,6 +142,7 @@ exports.init = function(options) {
 
             if ($globalErrorSection.length > 0) {
                 $globalErrorSection.html(errors.join(','));
+                $globalErrorSection.show();
             } else {
                 console.log('Global error returned from server, ' +
                             'but no dom element bound from client.',
@@ -158,6 +159,7 @@ exports.init = function(options) {
 
                 if ($field.length > 0) {
                     $field.html(errorList.join(','));
+                    $field.show();
                 } else {
                     console.log('Field error returned from server, ' +
                                 'but no dom element bound from client.',
@@ -268,6 +270,8 @@ exports.init = function(options) {
         saveOkStream: saveOkStream,
         cancelStream: cancelStream,
         inEditModeProperty: inEditModeProperty,
+        showGlobalErrors: showGlobalErrors,
+        showValidationErrorsInline: showValidationErrorsInline,
         setUpdateUrl: function (url) { updateUrl = url; }
     };
 };


### PR DESCRIPTION
This allows code outside the context of the inlineEditForm
to serialize the state of the inlineEditForm and push validation errors into the inlineEditForm for display. 

The use case driving this change is wanting to "preview" the results of a change, which could return the same server-side validation errors that the actual save operation would generate.

Another potential use case would be adding client side validations that could make use of the existing error display plumbing.