### PR TITLE
Correctly use model display names on the Edits page.

### DIFF
--- a/opentreemap/treemap/lib/map_feature.py
+++ b/opentreemap/treemap/lib/map_feature.py
@@ -28,7 +28,7 @@ from stormwater.models import PolygonalMapFeature
 
 def _photo_upload_share_text(feature, has_tree=False):
     return (_("I added a photo of this %s!") %
-            feature.terminology(feature.instance)['singular'].lower())
+            feature.display_name(feature.instance).lower())
 
 
 def _map_feature_audits(user, instance, feature, filters=None,

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -697,7 +697,7 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
             else:
                 title = _("Empty Planting Site")
         else:
-            title = feature.terminology(self.instance)['singular']
+            title = feature.display_name(self.instance)
 
         return title
 
@@ -996,7 +996,7 @@ class Favorite(models.Model):
         unique_together = ('user', 'map_feature',)
 
 
-class MapFeaturePhoto(models.Model, PendingAuditable):
+class MapFeaturePhoto(models.Model, PendingAuditable, Convertible):
     map_feature = models.ForeignKey(MapFeature)
 
     image = models.ImageField(
@@ -1006,6 +1006,8 @@ class MapFeaturePhoto(models.Model, PendingAuditable):
 
     created_at = models.DateTimeField(auto_now_add=True)
     instance = models.ForeignKey(Instance)
+
+    _terminology = {'singular': _('Photo'), 'plural': _('Photos')}
 
     def __init__(self, *args, **kwargs):
         super(MapFeaturePhoto, self).__init__(*args, **kwargs)

--- a/opentreemap/treemap/tests/test_templatetags.py
+++ b/opentreemap/treemap/tests/test_templatetags.py
@@ -625,10 +625,7 @@ class PartialTagTest(OTMTestCase):
 
 class DisplayValueTagTest(OTMTestCase):
     def test_display_value_converts_string_plot(self):
-        self.assertEqual('Planting Site', display_name('plot'))
-
-    def test_display_value_passes_string_through(self):
-        self.assertEqual('FooBAR', display_name('FooBAR'))
+        self.assertEqual('Planting Site', display_name('Plot'))
 
     def test_display_value_converts_plot_model(self):
         self.assertEqual('Planting Site', display_name(Plot()))

--- a/opentreemap/treemap/units.py
+++ b/opentreemap/treemap/units.py
@@ -31,6 +31,10 @@ class Convertible(object):
                          .get(cls.__name__, {}))
         return terms
 
+    @classmethod
+    def display_name(cls, instance):
+        return cls.terminology(instance)['singular']
+
     def _mutate_convertable_fields(self, f):
         from treemap.util import to_object_name
         # note that `to_object_name` is a helper function we use


### PR DESCRIPTION
Also adds a helper method to get the singular terminology name more
easily, and improves the display_name template filter to take an
(optional) instance parameter to use to look up the display name.