### PR TITLE
Add the unlocalize template filter to PKs used in Django templates.

### DIFF
--- a/opentreemap/treemap/templates/treemap/field/species_typeahead.html
+++ b/opentreemap/treemap/templates/treemap/field/species_typeahead.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load l10n %}
 {% load instance_config %}
 {% load species_thumbprint %}
 
@@ -6,7 +7,7 @@
        data-typeahead-hidden
        id="{{ field.label }}-hidden"
        name="{{ field.identifier }}"
-       value="{{ field.value.id }}"/>
+       value="{{ field.value.id|unlocalize }}"/>
 <input type="text"
        data-typeahead-input="{{ field.identifier }}"
        id="{{ field.label }}-typeahead"
@@ -15,7 +16,7 @@
        data-thumbprint="{{ request|species_thumbprint }}"
        value="{{ field.value.display_name }}"/>
 <input type="hidden"
-       value="{{ field.value.id }}"
+       value="{{ field.value.id|unlocalize }}"
        data-typeahead-restore="{{ field.identifier }}"
        data-datum="id" />
 <p>

--- a/opentreemap/treemap/templates/treemap/partials/collection_udf_row.html
+++ b/opentreemap/treemap/templates/treemap/partials/collection_udf_row.html
@@ -1,8 +1,9 @@
 {% load util %}
+{% load l10n %}
 
 <tr
    {% if perm_level == "write" %}
-   data-value-id="{{ value.pk }}"
+   data-value-id="{{ value.pk|unlocalize }}"
    {% endif %}
    >
   {% for field in udf.datatype_dict %}

--- a/opentreemap/treemap/templates/treemap/partials/map_feature_accordion.html
+++ b/opentreemap/treemap/templates/treemap/partials/map_feature_accordion.html
@@ -1,8 +1,9 @@
 {% load i18n %}
+{% load l10n %}
 {% load auth_extras %}
 {% load form_extras %}
 
-<form id="details-form" data-location-x="{{ plot.geom.x }}" data-location-y="{{ plot.geom.y }}"
+<form id="details-form" data-location-x="{{ plot.geom.x|unlocalize }}" data-location-y="{{ plot.geom.y|unlocalize }}"
       data-map-feature-type="{% if feature.is_plot %}plot{% else %}resource{% endif %}">
 
     {% if feature.is_plot %}

--- a/opentreemap/treemap/templates/treemap/partials/photo.html
+++ b/opentreemap/treemap/templates/treemap/partials/photo.html
@@ -1,10 +1,11 @@
 {% load i18n %}
+{% load l10n %}
 {% load util %}
 
 {% if photo %}
-<div class="photo-review-item" data-total-pages="{{ total_pages }}" data-photo>
+<div class="photo-review-item" data-total-pages="{{ total_pages|unlocalize }}" data-photo>
     <a class="thumbnail" href="{{ photo.image.url }}">
-      <img data-id="{{ photo.pk }}" src="{{ photo.thumbnail.url }}">
+      <img data-id="{{ photo.pk|unlocalize }}" src="{{ photo.thumbnail.url }}">
     </a>
     <div class="btn-group">
         <a class="action btn btn-sm" href="{% url "approve_or_reject_photo" instance_url_name=request.instance.url_name feature_id=photo.map_feature.pk photo_id=photo.pk action="approve" %}">{% trans "Approve" %}</a>

--- a/opentreemap/treemap/templates/treemap/recent_user_edits.html
+++ b/opentreemap/treemap/templates/treemap/recent_user_edits.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load l10n %}
 {% load util %}
 
 <table id="recent-user-edits" class="table table-hover table-bordered table-condensed">
@@ -13,7 +14,7 @@
     </thead>
     <tbody>
         {% for audit in audits %}
-        <tr data-id="{{audit.id}}">
+        <tr data-id="{{ audit.id|unlocalize }}">
             <td>{{ audit.display_action }}</td>
             <td>{{ audit|display_name }}</td>
             <td>{{ audit.field_display_name }}</td>

--- a/opentreemap/treemap/templates/treemap/resource_detail.html
+++ b/opentreemap/treemap/templates/treemap/resource_detail.html
@@ -117,7 +117,7 @@
 
       resource.init({
           ecoBenefits: '#ecobenefits',
-          featureId: {{ feature.id }},
+          featureId: {{ feature.id|unlocalize }},
           inlineEditForm: mapFeatureOptions.inlineEditForm,
           form: mapFeature.inlineEditForm,
           deleteControls: mapFeatureOptions.deleteControls,


### PR DESCRIPTION
I went through the source and grepped for `'(id|pk) ?}}'` and added an
`unlocalize` filter to everywhere it seemed appropriate.  I'm sure there
are other places where the template variables are named differently that
I've missed, but this should prevent a slew of bugs waiting to happen.