### PR TITLE
Include the instance map feature types in eco etags.

### DIFF
--- a/opentreemap/treemap/views/tree.py
+++ b/opentreemap/treemap/views/tree.py
@@ -118,6 +118,8 @@ def search_hash(request, instance):
     else:
         eco_str = 'none'
 
-    string_to_hash = audit_id_str + ":" + eco_str
+    map_features = ','.join(instance.map_feature_types)
+
+    string_to_hash = audit_id_str + ":" + eco_str + ":" + map_features
 
     return hashlib.md5(string_to_hash).hexdigest()


### PR DESCRIPTION
This ensures that changing the map features for the instance invalidates
the browser cached resource counts.

Connects to #2303