### PR TITLE
fixed bottom padding on admin page overflows

### DIFF
--- a/opentreemap/treemap/css/sass/partials/pages/_admin.scss
+++ b/opentreemap/treemap/css/sass/partials/pages/_admin.scss
@@ -209,6 +209,14 @@
                 overflow-y: auto;
                 padding: 16px;
                 margin-bottom: 40px;
+
+                &:after {
+                    content: '';
+                    position: relative;
+                    display: block;
+                    width: 100%;
+                    height: 16px;
+                }
             }
         }
     }

--- a/opentreemap/treemap/css/sass/partials/pages/_admin.scss
+++ b/opentreemap/treemap/css/sass/partials/pages/_admin.scss
@@ -207,7 +207,7 @@
                 right: 0;
                 bottom: 0;
                 overflow-y: auto;
-                padding: 16px;
+                padding: 16px 16px 0;
                 margin-bottom: 40px;
 
                 &:after {


### PR DESCRIPTION
Fixes issue reported on add-ons repo https://github.com/OpenTreeMap/otm-addons/issues/843

Firefox now has correct padding-bottom. Every other browser will have slightly bigger padding-bottom due to this *fix*. It still looks good though