### PR TITLE
 Rename 'TILE_HOST' -> 'TILER_HOST'

### DIFF
--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -66,7 +66,7 @@ OMGEO_SETTINGS = [[
     'omgeo.services.EsriWGS', {}
 ]]
 
-# Set TILE_HOST to None if the tiler is running on the same host
+# Set TILER_HOST to None if the tiler is running on the same host
 # as this app. Otherwise, provide a Leaflet url template as described
 # at http://leafletjs.com/reference.html#url-template
 #
@@ -74,7 +74,7 @@ OMGEO_SETTINGS = [[
 #
 #   //host/tile/
 #
-TILE_HOST = None
+TILER_HOST = None
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name

--- a/opentreemap/treemap/js/src/MapManager.js
+++ b/opentreemap/treemap/js/src/MapManager.js
@@ -287,7 +287,7 @@ function getPolygonLayerURL(config, extension) {
 function getLayerURL(config, layer, extension) {
     return format(
         '%s/tile/%s/database/otm/table/%s/{z}/{x}/{y}.%s%s',
-        config.tileHost || '', config.instance.rev, layer, extension,
+        config.tilerHost || '', config.instance.rev, layer, extension,
         urlLib.format({query: {
             'instance_id': config.instance.id,
             'restrict': JSON.stringify(config.instance.mapFeatureTypes)

--- a/opentreemap/treemap/templates/treemap/settings.js
+++ b/opentreemap/treemap/templates/treemap/settings.js
@@ -17,8 +17,8 @@ otm.settings.urls = {
     'displayQueryArgumentName': 'show'
 }
 
-{% if not settings.TILE_HOST = None %}
-    otm.settings.tileHost = "{{ settings.TILE_HOST }}";
+{% if not settings.TILER_HOST = None %}
+    otm.settings.tilerHost = "{{ settings.TILER_HOST }}";
 {% endif %}
 
 {% if request.user.is_authenticated %}

--- a/opentreemap/treemap/tests/test_views.py
+++ b/opentreemap/treemap/tests/test_views.py
@@ -1690,14 +1690,14 @@ class SettingsJsViewTests(ViewTestCase):
         self.req.session = MockSession()
         self.get_response = lambda: root_settings_js(self.req)
 
-    @override_settings(TILE_HOST=None)
-    def test_none_tile_hosts_omits_tilehosts_setting(self):
-        self.assertNotInResponse('otm.settings.tileHosts',
+    @override_settings(TILER_HOST=None)
+    def test_none_tiler_hosts_omits_tilerhosts_setting(self):
+        self.assertNotInResponse('otm.settings.tilerHosts',
                                  self.get_response())
 
-    @override_settings(TILE_HOST='{s}.a')
-    def test_single_tile_host_in_tilehosts_setting(self):
-        self.assertInResponse('otm.settings.tileHost = "{s}.a";',
+    @override_settings(TILER_HOST='{s}.a')
+    def test_single_tiler_host_in_tilerhosts_setting(self):
+        self.assertInResponse('otm.settings.tilerHost = "{s}.a";',
                               self.get_response())
 
 

--- a/opentreemap/treemap/tests/ui/uitest_map.py
+++ b/opentreemap/treemap/tests/ui/uitest_map.py
@@ -163,7 +163,7 @@ class MapTest(TreemapUITestCase):
 
         ui_test_urls.testing_id = tree.plot.pk
 
-        with self.settings(TILE_HOST=self.live_server_url):
+        with self.settings(TILER_HOST=self.live_server_url):
 
             # Reload the page
             self.go_to_map_page()
@@ -211,7 +211,7 @@ class ModeChangeTest(TreemapUITestCase):
 
     def test_locked_add_tree_in_edit_mode(self):
 
-        with self.settings(TILE_HOST=self.live_server_url):
+        with self.settings(TILER_HOST=self.live_server_url):
             self.login_and_go_to_map_page()
 
             self.start_add_tree(20, 20)


### PR DESCRIPTION
'Tiler' is more conventional than 'Tile' and more consistent with other uses.