### PR TITLE
Refresh Instances after incrementing the adjuncts_timestamp

### DIFF
--- a/opentreemap/treemap/lib/object_caches.py
+++ b/opentreemap/treemap/lib/object_caches.py
@@ -69,6 +69,7 @@ def increment_adjuncts_timestamp(instance):
     from treemap.models import Instance
     Instance.objects.filter(pk=instance.id)\
                     .update(adjuncts_timestamp=F('adjuncts_timestamp') + 1)
+    instance.refresh_from_db()
 
 
 # ------------------------------------------------------------------------


### PR DESCRIPTION
Prevents caching issues where related objects were saved before the Instance
object was saved, causing the adjuncts_timestamp to be reverted back to the old
value.

As an example of what this prevents, consider the following code snippet:

```
role = Role.objects.all()[0]  # role.instance.adjuncts_timestamp is 1

role.perm_level = 2
role.save()  # This triggers `increment_adjuncts_timestamp`, increasing it to 2

role.instance.save()  # This reverts the `adjuncts_timestamp` to 1
```

By refreshing the `Instance` object whenever its `adjuncts_timestamp` is updated, we can avoid most of the accidental reversions to the timestamp.

Connects to https://github.com/OpenTreeMap/otm-addons/issues/891
Connects to https://github.com/OpenTreeMap/otm-addons/issues/890