### PR TITLE
Improve timestamp refreshing in object_caches.

### DIFF
--- a/opentreemap/treemap/lib/object_caches.py
+++ b/opentreemap/treemap/lib/object_caches.py
@@ -67,9 +67,11 @@ def increment_adjuncts_timestamp(instance):
     # Don't call save(), to avoid storing possibly-stale data in "instance".
     # Use a SQL increment, to prevent race conditions between servers.
     from treemap.models import Instance
-    Instance.objects.filter(pk=instance.id)\
-                    .update(adjuncts_timestamp=F('adjuncts_timestamp') + 1)
-    instance.refresh_from_db()
+    qs = Instance.objects.filter(pk=instance.id)
+    qs.update(adjuncts_timestamp=F('adjuncts_timestamp') + 1)
+
+    # Update timestamp from DB to prevent saving stale timestamps
+    instance.adjuncts_timestamp = qs[0].adjuncts_timestamp
 
 
 # ------------------------------------------------------------------------


### PR DESCRIPTION
Commit 6222295e fixed a problem with accidentally saving stale
adjuncts_timestamp values, but @RickMohr pointed out that it could cause
changes to be missed.  Only refreshing the timestamp but keeping other data in
the instance is a bit safer while still preventing the original problem.