### PR TITLE
Implement Photo review redesign

### DIFF
--- a/opentreemap/opentreemap/util.py
+++ b/opentreemap/opentreemap/util.py
@@ -5,6 +5,8 @@ from __future__ import division
 
 import json
 
+from django.core.urlresolvers import reverse
+
 
 def json_from_request(request):
     body = request.body
@@ -99,3 +101,15 @@ def force_obj_to_pk(obj):
         return obj.id
     else:
         return obj
+
+
+class UrlParams(object):
+    def __init__(self, url_name, *url_args, **params):
+        self._url = reverse(url_name, args=url_args) + '?'
+        self._params = params
+
+    def params(self, *keys):
+        return '&'.join(['%s=%s' % (key, self._params[key]) for key in keys])
+
+    def url(self, *keys):
+        return self._url + self.params(*keys)

--- a/opentreemap/otm_comments/js/src/moderation.js
+++ b/opentreemap/otm_comments/js/src/moderation.js
@@ -74,7 +74,7 @@ module.exports = function(options) {
         $text.toggleClass('less');
     });
 
-    BU.reloadContainerOnClick(
+    BU.reloadContainerOnClickAndRecordUrl(
         $container, dom.pagingButtons, dom.filterButtons, dom.columnHeaders);
 
     toggleAllEventStream

--- a/opentreemap/treemap/css/sass/partials/pages/_admin.scss
+++ b/opentreemap/treemap/css/sass/partials/pages/_admin.scss
@@ -310,15 +310,29 @@
 
     #photo-review-container {
         .photo-review-item {
-            float: left;
-            position: relative;
             min-height: 1px;
             padding-right: 15px;
             padding-left: 15px;
 
-            .thumbnail img {
-                width: 240px;
-                height: 240px;
+            .thumbnail {
+                display: inline-block;
+                margin-bottom: 0;
+                width: 150px;
+                height: 150px;
+                position: relative;
+
+                img {
+                    width: auto;
+                    height: auto;
+                    max-width: 140px;
+                    max-height: 140px;
+                    margin: auto;
+                    position: absolute;
+                    left: 0;
+                    right: 0;
+                    top: 0;
+                    bottom: 0;
+                }
             }
         }
     }

--- a/opentreemap/treemap/js/src/baconUtils.js
+++ b/opentreemap/treemap/js/src/baconUtils.js
@@ -2,6 +2,8 @@
 
 var Bacon = require('baconjs'),
     $ = require('jquery'),
+    url = require('url'),
+    History = require('history'),
     R = require('ramda'),
     _ = require('lodash');
 
@@ -181,8 +183,17 @@ exports.reloadContainerOnClick = function ($container /*, selector1, selector2, 
         .filter(isDefinedNonEmpty) // ignore empty hrefs
         .onValue(function (url) {
             $container.load(url, function () {
-                htmlLoadedBus.push();
+                htmlLoadedBus.push(url);
             });
         });
     return htmlLoadedBus.toEventStream();  // in case further handling is desired
+};
+
+exports.reloadContainerOnClickAndRecordUrl = function() {
+    var stream = exports.reloadContainerOnClick.apply(this, arguments);
+    stream.onValue(function(partialUrl) {
+        var params = url.parse(partialUrl).query;
+        History.replaceState(null, document.title, '?' + params + window.location.hash);
+    });
+    return stream;
 };

--- a/opentreemap/treemap/js/src/photoReview.js
+++ b/opentreemap/treemap/js/src/photoReview.js
@@ -31,7 +31,7 @@ exports.init = function(options) {
             return stream;
         });
 
-    BU.reloadContainerOnClick($container, dom.pagingButtons);
+    BU.reloadContainerOnClickAndRecordUrl($container, dom.pagingButtons);
 
     return photoUpdateStream;
 };

--- a/opentreemap/treemap/js/src/photoReview.js
+++ b/opentreemap/treemap/js/src/photoReview.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var $ = require('jquery'),
+    url = require('url'),
     U = require('treemap/utility'),
     Bacon = require('baconjs'),
     BU = require('treemap/baconUtils'),
@@ -9,32 +10,12 @@ var $ = require('jquery'),
 var csrf = require('treemap/csrf');
 $.ajaxSetup(csrf.jqueryAjaxSetupOptions);
 
+var dom = {
+    pagingButtons: '.pagination li a'
+};
+
 exports.init = function(options) {
-    var updatePageFromUrl = new Bacon.Bus(),
-        url = options.url,
-        nextPhotoUrl = options.nextPhotoUrl,
-        $container = $(options.container),
-        initialPageStream = updatePageFromUrl
-            .map(U.parseQueryString)
-            .map('.n')
-            .filter(BU.id);
-
-    window.addEventListener('popstate', function(event) {
-        updatePageFromUrl.push();
-    }, false);
-
-    function showErrorMessage(msg) {
-        $container.find('.errors').html(msg);
-    }
-
-    function getReviewMarkupForNextPhoto() {
-        var n = U.parseQueryString.n || 1;
-        return BU.jsonRequest('GET', nextPhotoUrl)({n: n});
-    }
-
-    function nextPageExists() {
-        return !!$container.find('.pagination li:last-child [data-page]').attr('data-page');
-    }
+    var $container = $(options.container);
 
     var photoUpdateStream = $container.asEventStream('click', '.action')
         .doAction('.preventDefault')
@@ -43,50 +24,14 @@ exports.init = function(options) {
                 $photo = $elem.closest('[data-photo]'),
                 stream = BU.jsonRequest('POST', $elem.attr('href'))();
 
-            stream.onValue(function() {
-                $photo.remove();
+            stream.onValue(function(html) {
+                $container.html(html);
             });
 
             return stream;
         });
 
-    photoUpdateStream.onValue(function() {
-        if (nextPageExists()) {
-            getReviewMarkupForNextPhoto()
-                .map($)
-                .onValue($container.find('[data-photo-container]'), 'append');
-        }
-    });
-
-    function createPageUpdateStream(initialPageStream) {
-        var pageStream = $container.find('.pagination li')
-                .asEventStream('click')
-                .map('.target')
-                .map($)
-                .map('.data', 'page')
-                .filter(BU.isDefinedNonEmpty);
-
-        pageStream
-            .map(function(n) { return '?n=' + n + window.location.hash; })
-            .onValue(function (url) {
-                History.pushState(null, document.title, url);
-            });
-
-        var pageUpdateStream = pageStream
-                .merge(initialPageStream)
-                .map(function(n) { return {'n': n}; })
-                .flatMap(BU.jsonRequest('GET', url));
-
-        pageUpdateStream
-            .onValue($container, 'html');
-
-        pageUpdateStream
-            .onValue(createPageUpdateStream, initialPageStream);
-
-        return pageUpdateStream;
-    }
-
-    createPageUpdateStream(initialPageStream);
+    BU.reloadContainerOnClick($container, dom.pagingButtons);
 
     return photoUpdateStream;
 };

--- a/opentreemap/treemap/js/src/photoReview.js
+++ b/opentreemap/treemap/js/src/photoReview.js
@@ -11,7 +11,8 @@ var csrf = require('treemap/csrf');
 $.ajaxSetup(csrf.jqueryAjaxSetupOptions);
 
 var dom = {
-    pagingButtons: '.pagination li a'
+    pagingButtons: '.pagination li a',
+    sortHeader: '[data-photo-sort] a'
 };
 
 exports.init = function(options) {
@@ -31,7 +32,7 @@ exports.init = function(options) {
             return stream;
         });
 
-    BU.reloadContainerOnClickAndRecordUrl($container, dom.pagingButtons);
+    BU.reloadContainerOnClickAndRecordUrl($container, dom.pagingButtons, dom.sortHeader);
 
     return photoUpdateStream;
 };

--- a/opentreemap/treemap/routes.py
+++ b/opentreemap/treemap/routes.py
@@ -257,13 +257,8 @@ photo_review_partial = do(
     render_template('treemap/partials/photo_review.html'),
     photo_views.photo_review)
 
-next_photo = do(
-    require_http_method("GET"),
-    admin_instance_request,
-    render_template('treemap/partials/photo.html'),
-    photo_views.next_photo)
-
 approve_or_reject_photo = do(
     require_http_method("POST"),
     admin_instance_request,
+    render_template('treemap/partials/photo_review.html'),
     photo_views.approve_or_reject_photo)

--- a/opentreemap/treemap/templates/treemap/partials/photo.html
+++ b/opentreemap/treemap/templates/treemap/partials/photo.html
@@ -12,8 +12,8 @@
         </a>
     </td>
     <td>
-        <a class="action" href="{% url "approve_or_reject_photo" instance_url_name=request.instance.url_name feature_id=photo.map_feature.pk photo_id=photo.pk action="approve" %}">{% trans "Approve" %}</a> |
-        <a class="action" href="{% url "approve_or_reject_photo" instance_url_name=request.instance.url_name feature_id=photo.map_feature.pk photo_id=photo.pk action="reject" %}">{% trans "Reject" %}</a> |
+        <a class="action" href="{% url "approve_or_reject_photo" instance_url_name=request.instance.url_name feature_id=photo.map_feature.pk photo_id=photo.pk action="approve" %}?{{ full_params }}">{% trans "Approve" %}</a> |
+        <a class="action" href="{% url "approve_or_reject_photo" instance_url_name=request.instance.url_name feature_id=photo.map_feature.pk photo_id=photo.pk action="reject" %}?{{ full_params }}">{% trans "Reject" %}</a> |
         <a href="{{ photo|detail_link }}">{% trans "View Detail" %}</a>
     </td>
     <td>{{ photo.created_at|naturaltime }}</td>

--- a/opentreemap/treemap/templates/treemap/partials/photo.html
+++ b/opentreemap/treemap/templates/treemap/partials/photo.html
@@ -1,16 +1,21 @@
 {% load i18n %}
 {% load l10n %}
 {% load util %}
+{% load humanize %}
 
 {% if photo %}
-<div class="photo-review-item" data-total-pages="{{ total_pages|unlocalize }}" data-photo>
-    <a class="thumbnail" href="{{ photo.image.url }}">
-      <img data-id="{{ photo.pk|unlocalize }}" src="{{ photo.thumbnail.url }}">
-    </a>
-    <div class="btn-group">
-        <a class="action btn btn-sm" href="{% url "approve_or_reject_photo" instance_url_name=request.instance.url_name feature_id=photo.map_feature.pk photo_id=photo.pk action="approve" %}">{% trans "Approve" %}</a>
-        <a class="action btn btn-sm" href="{% url "approve_or_reject_photo" instance_url_name=request.instance.url_name feature_id=photo.map_feature.pk photo_id=photo.pk action="reject" %}">{% trans "Reject" %}</a>
-        <a class="btn btn-sm" href="{{ photo|detail_link }}">{% trans "View Detail" %}</a>
-    </div>
-</div>
+<tr class="photo-review-item" data-total-pages="{{ total_pages|unlocalize }}" data-photo>
+    <td>{{ photo.pk }}</td>
+    <td>
+        <a class="thumbnail" href="{{ photo.image.url }}">
+          <img data-id="{{ photo.pk|unlocalize }}" src="{{ photo.thumbnail.url }}">
+        </a>
+    </td>
+    <td>
+        <a class="action" href="{% url "approve_or_reject_photo" instance_url_name=request.instance.url_name feature_id=photo.map_feature.pk photo_id=photo.pk action="approve" %}">{% trans "Approve" %}</a> |
+        <a class="action" href="{% url "approve_or_reject_photo" instance_url_name=request.instance.url_name feature_id=photo.map_feature.pk photo_id=photo.pk action="reject" %}">{% trans "Reject" %}</a> |
+        <a href="{{ photo|detail_link }}">{% trans "View Detail" %}</a>
+    </td>
+    <td>{{ photo.created_at|naturaltime }}</td>
+</tr>
 {% endif %}

--- a/opentreemap/treemap/templates/treemap/partials/photo_review.html
+++ b/opentreemap/treemap/templates/treemap/partials/photo_review.html
@@ -30,16 +30,4 @@
     </div>
 </div>
 
-<div class="text-center">
-<ul class="pagination pagination-sm">
-    <li class="{% if not prev_page %}disabled{% endif %}">
-        <a data-page="{{ prev_page|default_if_none:"" }}">&laquo;</a>
-    </li>
-    {% for page in pages %}
-    <li class="{% if cur_page == page %}active{% endif %}"><a data-page="{{ page }}">{{ page }}</a></li>
-    {% endfor %}
-    <li class="{% if not next_page %}disabled{% endif %}">
-        <a data-page="{{ next_page|default_if_none:""}}">&raquo;</a>
-    </li>
-</ul>
-</div>
+{% include 'treemap/partials/paging_controls.html' with paging=photos url=url_for_pagination %}

--- a/opentreemap/treemap/templates/treemap/partials/photo_review.html
+++ b/opentreemap/treemap/templates/treemap/partials/photo_review.html
@@ -15,8 +15,8 @@
                     <th class="actions">
                         {% trans "Actions" %}
                     </th>
-                    <th>
-                        <a href="">{% trans "Date" %}</a>
+                    <th data-photo-sort>
+                        <a href="{{ url_for_sort }}&sort={{ 'created_at'|reverse_if_current:sort_order }}">{% trans "Date" %}</a>
                     </th>
                 </tr>
             </thead>

--- a/opentreemap/treemap/templates/treemap/partials/photo_review.html
+++ b/opentreemap/treemap/templates/treemap/partials/photo_review.html
@@ -1,10 +1,33 @@
 {% load i18n %}
+{% load sort %}
 
-{# JS stuffs the next photo into [data-photo-container], so it should be the container around each photo.html #}
-<div class="row" data-photo-container>
-  {% for photo in photos %}
-  {% include "treemap/partials/photo.html" %}
-  {% endfor %}
+<div class="row comment-table">
+    <div class="col-lg-12">
+        <table class="table table-hover admin-table">
+            <thead>
+                <tr>
+                    <th>
+                        {% trans "Id" %}
+                    </th>
+                    <th>
+                        {% trans "Photo" %}
+                    </th>
+                    <th class="actions">
+                        {% trans "Actions" %}
+                    </th>
+                    <th>
+                        <a href="">{% trans "Date" %}</a>
+                    </th>
+                </tr>
+            </thead>
+            {# JS stuffs the next photo into [data-photo-container], so it should be the container around each photo.html #}
+            <tbody data-photo-container>
+              {% for photo in photos %}
+              {% include "treemap/partials/photo.html" %}
+              {% endfor %}
+            </tbody>
+        </table>
+    </div>
 </div>
 
 <div class="text-center">

--- a/opentreemap/treemap/urls.py
+++ b/opentreemap/treemap/urls.py
@@ -26,7 +26,6 @@ urlpatterns = patterns(
     url(r'^photo_review_full/$', routes.photo_review),
     url(r'^photo_review/$', routes.photo_review_partial,
         name='photo_review'),
-    url(r'^photo_review/next$', routes.next_photo, name='photo_review_next'),
     url('^features/(?P<feature_id>\d+)/photo/(?P<photo_id>\d+)/'
         '(?P<action>(approve)|(reject))$',
         routes.approve_or_reject_photo, name='approve_or_reject_photo'),

--- a/opentreemap/treemap/views/photo.py
+++ b/opentreemap/treemap/views/photo.py
@@ -3,110 +3,60 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-import math
-
-from django.http import HttpResponse, Http404
-from django.utils.translation import ugettext as _
+from django.core.paginator import Paginator, EmptyPage
 from django.db import transaction
+from django.http import Http404
+
+from opentreemap.util import UrlParams
 
 from treemap.audit import (Audit, approve_or_reject_existing_edit,
                            approve_or_reject_audits_and_apply)
 from treemap.models import MapFeaturePhoto
 
 
-_PHOTO_PAGE_SIZE = 12
+_PHOTO_PAGE_SIZE = 5
 
 
-def photo_audits(instance):
+def get_photos(instance):
     unverified_actions = {Audit.Type.Insert,
                           Audit.Type.Delete,
                           Audit.Type.Update}
 
-    # Only return audits for photos that haven't been deleted
-    photo_ids = MapFeaturePhoto.objects.filter(instance=instance)\
-                                       .values_list('id', flat=True)
+    audit_model_ids = Audit.objects \
+        .filter(
+            instance=instance,
+            model__in=['TreePhoto', 'MapFeaturePhoto'],
+            field='image',
+            ref__isnull=True,
+            action__in=unverified_actions) \
+        .values_list('model_id', flat=True)
 
-    audits = Audit.objects.filter(instance=instance,
-                                  model__in=['TreePhoto', 'MapFeaturePhoto'],
-                                  field='image',
-                                  ref__isnull=True,
-                                  action__in=unverified_actions,
-                                  model_id__in=photo_ids)\
-                          .order_by('-created')
+    photos = MapFeaturePhoto.objects.filter(
+        instance=instance,
+        id__in=audit_model_ids,
+        map_feature__feature_type__in=instance.map_feature_types)
 
-    return audits
-
-
-def _process_page_number(request, total):
-    page = int(request.REQUEST.get('n', '1'))
-
-    # For some reason, despite importing division from the future
-    # total / PHOTO_PAGE_SIZE does integer division
-    total_pages = int(math.ceil(float(total) / _PHOTO_PAGE_SIZE))
-
-    startidx = (page-1) * _PHOTO_PAGE_SIZE
-    endidx = startidx + _PHOTO_PAGE_SIZE
-
-    return (page, total_pages, startidx, endidx)
-
-
-def next_photo(request, instance):
-    audits = photo_audits(instance)
-
-    total = audits.count()
-    page, total_pages, startidx, endidx = _process_page_number(request, total)
-
-    # We're done!
-    if total == 0 or total < _PHOTO_PAGE_SIZE:
-        photo = None
-    else:
-        try:
-            photo_id = audits[endidx].model_id
-        except IndexError:
-            # We may have finished an entire page
-            # in that case, simply return the last image
-            photo_id = audits[total-1].model_id
-
-        photo = (MapFeaturePhoto.objects
-                 .select_related('treephoto')
-                 .get(pk=photo_id))
-
-    return {
-        'photo': photo,
-        'total_pages': total_pages
-    }
+    return photos
 
 
 def photo_review(request, instance):
-    audits = photo_audits(instance)
+    photos = get_photos(instance)
+    page_number = int(request.REQUEST.get('page', '1'))
 
-    total = audits.count()
-    page, total_pages, startidx, endidx = _process_page_number(request, total)
+    paginator = Paginator(photos, _PHOTO_PAGE_SIZE)
 
-    audits = audits[startidx:endidx]
+    try:
+        paged_photos = paginator.page(page_number)
+    except EmptyPage:
+        # If the page number is out of bounds, return the last page
+        paged_photos = paginator.page(paginator.num_pages)
 
-    prev_page = page - 1
-    if prev_page <= 0:
-        prev_page = None
-
-    next_page = page + 1
-    if next_page > total_pages:
-        next_page = None
-
-    pages = range(1, total_pages+1)
-    if len(pages) > 10:
-        pages = pages[0:8] + [pages[-1]]
+    urlizer = UrlParams('photo_review', instance.url_name, page=page_number)
 
     return {
-        'photos': [(MapFeaturePhoto.objects
-                    .select_related('treephoto')
-                    .get(pk=audit.model_id))
-                   for audit in audits],
-        'pages': pages,
-        'total_pages': total_pages,
-        'cur_page': page,
-        'next_page': next_page,
-        'prev_page': prev_page
+        'photos': paged_photos,
+        'url_for_pagination': urlizer.url(),
+        'full_params': urlizer.params('page')
     }
 
 
@@ -115,13 +65,6 @@ def approve_or_reject_photo(
         request, instance, feature_id, photo_id, action):
 
     approved = action == 'approve'
-
-    if approved:
-        msg = _('Approved')
-    else:
-        msg = _('Rejected')
-
-    resp = HttpResponse(msg)
 
     try:
         photo = (MapFeaturePhoto.objects
@@ -145,7 +88,7 @@ def approve_or_reject_photo(
             approve_or_reject_audits_and_apply(
                 pending_audits, request.user, approved)
 
-            return resp
+            return photo_review(request, instance)
         else:
             # Error - no pending or regular
             raise Http404('Photo Not Found')
@@ -162,4 +105,4 @@ def approve_or_reject_photo(
         approve_or_reject_existing_edit(
             audit, request.user, approved)
 
-    return resp
+    return photo_review(request, instance)


### PR DESCRIPTION
~~Based on top of https://github.com/OpenTreeMap/otm-core/pull/2334, so commits  8f6bd7b and 799041d are from that PR.~~

 - Redesigns the styling and layout of the photo review page.  The page is now in a table layout instead of a grid layout, matching the comment moderation page.
 - Refactors photo review pagination to work similarly to comment moderation
 - Fixes a few bugs related to photo review, since the code causing them was refactored
 - Records query parameters on comment and photo moderation pages when pagination/filter buttons are clicked.

Connects to OpenTreeMap/otm-addons#541
Connects to OpenTreeMap/otm-addons#828
Connects to #2156