### PR TITLE
Include empty plots in tree exports

### DIFF
--- a/opentreemap/treemap/js/src/export.js
+++ b/opentreemap/treemap/js/src/export.js
@@ -34,7 +34,11 @@ var $ = require('jquery'),
 ////////////////////////////////////////
 
 function getQueryStringObject () {
-    return {q: url.parse(window.location.href, true).query.q || '' };
+    var query = url.parse(window.location.href, true).query;
+    return {
+        q: query.q || '',
+        show: query.show || ''
+    };
 }
 
 function isComplete (resp) { return resp.status === 'COMPLETE'; }

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ git+https://github.com/dahlia/libsass-python.git@4aa8fd3c2cef8c1
 django-contrib-comments==1.6.1
 django-threadedcomments==1.0b1
 django-apptemplates==0.0.1
-django-queryset-csv>=0.3.0
+django-queryset-csv>=0.3.2
 python-dateutil==2.2
 pytz==2014.7
 django-tinsel==0.1.1


### PR DESCRIPTION
* Query `Plot` instead of `Tree`
* Adjust CSV headers to remain tree-centric instead of becoming plot-centric
* Use latest version of `django-queryset-csv` for necessary bug fix

Also fixes a longstanding bug where exports ignored "Display Filters"

Connects #1990