### PR TITLE
Faster species export

### DIFF
--- a/opentreemap/importer/models/species.py
+++ b/opentreemap/importer/models/species.py
@@ -4,6 +4,9 @@ from __future__ import unicode_literals
 from __future__ import division
 
 import itertools
+
+from collections import OrderedDict
+
 from django.contrib.gis.db import models
 from django.db import transaction
 from django.utils.translation import ugettext as _
@@ -56,25 +59,25 @@ class SpeciesImportEvent(GenericImportEvent):
 
 class SpeciesImportRow(GenericImportRow):
 
-    SPECIES_MAP = {
-        'genus': fields.species.GENUS,
-        'species': fields.species.SPECIES,
-        'cultivar': fields.species.CULTIVAR,
-        'other_part_of_name': fields.species.OTHER_PART_OF_NAME,
-        'common_name': fields.species.COMMON_NAME,
-        'is_native': fields.species.IS_NATIVE,
-        'flowering_period': fields.species.FLOWERING_PERIOD,
-        'fruit_or_nut_period': fields.species.FRUIT_OR_NUT_PERIOD,
-        'fall_conspicuous': fields.species.FALL_CONSPICUOUS,
-        'flower_conspicuous': fields.species.FLOWER_CONSPICUOUS,
-        'palatable_human': fields.species.PALATABLE_HUMAN,
-        'has_wildlife_value': fields.species.HAS_WILDLIFE_VALUE,
-        'fact_sheet_url': fields.species.FACT_SHEET_URL,
-        'plant_guide_url': fields.species.PLANT_GUIDE_URL,
-        'max_diameter': fields.species.MAX_DIAMETER,
-        'max_height': fields.species.MAX_HEIGHT,
-        'id': fields.species.ID
-    }
+    SPECIES_MAP = OrderedDict((
+        ('genus', fields.species.GENUS),
+        ('species', fields.species.SPECIES),
+        ('cultivar', fields.species.CULTIVAR),
+        ('other_part_of_name', fields.species.OTHER_PART_OF_NAME),
+        ('common_name', fields.species.COMMON_NAME),
+        ('is_native', fields.species.IS_NATIVE),
+        ('flowering_period', fields.species.FLOWERING_PERIOD),
+        ('fruit_or_nut_period', fields.species.FRUIT_OR_NUT_PERIOD),
+        ('fall_conspicuous', fields.species.FALL_CONSPICUOUS),
+        ('flower_conspicuous', fields.species.FLOWER_CONSPICUOUS),
+        ('palatable_human', fields.species.PALATABLE_HUMAN),
+        ('has_wildlife_value', fields.species.HAS_WILDLIFE_VALUE),
+        ('fact_sheet_url', fields.species.FACT_SHEET_URL),
+        ('plant_guide_url', fields.species.PLANT_GUIDE_URL),
+        ('max_diameter', fields.species.MAX_DIAMETER),
+        ('max_height', fields.species.MAX_HEIGHT),
+        ('id', fields.species.ID)
+    ))
 
     # Species reference
     species = models.ForeignKey(Species, null=True, blank=True)

--- a/opentreemap/importer/tasks.py
+++ b/opentreemap/importer/tasks.py
@@ -10,12 +10,10 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
 from django.db import transaction
 
-from treemap.models import Species
-
 from importer.models.base import GenericImportEvent, GenericImportRow
 from importer.models.species import SpeciesImportEvent, SpeciesImportRow
 from importer.models.trees import TreeImportEvent, TreeImportRow
-from importer import errors, fields
+from importer import errors
 from importer.util import (clean_row_data, clean_field_name,
                            utf8_file_to_csv_dictreader)
 
@@ -207,25 +205,6 @@ def _get_waiting_row_count(ie):
     return ie.rows()\
              .filter(status=GenericImportRow.WAITING)\
              .count()
-
-
-def _species_export_builder(model):
-    model_dict = model.as_dict()
-    obj = {}
-
-    for k, v in SpeciesImportRow.SPECIES_MAP.iteritems():
-        if v in fields.species.ALL:
-            if k in model_dict:
-                val = model_dict[k]
-                if not val is None:
-                    obj[v] = val
-    return obj
-
-
-@task
-def get_all_species_export(instance_id):
-    return [_species_export_builder(species) for species
-            in Species.objects.filter(instance_id=instance_id)]
 
 
 @task

--- a/opentreemap/importer/views.py
+++ b/opentreemap/importer/views.py
@@ -21,14 +21,14 @@ from treemap.units import (storage_to_instance_units_factor,
                            get_value_display_attr)
 from treemap.plugin import get_tree_limit
 
-from exporter.decorators import task_output_as_csv
+from exporter.decorators import task_output_as_csv, queryset_as_exported_csv
 
 from importer.models.base import GenericImportEvent, GenericImportRow
 from importer.models.trees import TreeImportEvent, TreeImportRow
 from importer.models.species import SpeciesImportEvent, SpeciesImportRow
 from importer.tasks import (run_import_event_validation, commit_import_event,
                             get_import_event_model, get_import_row_model,
-                            get_all_species_export, get_import_export)
+                            get_import_export)
 from importer import errors, fields
 
 TABLE_ACTIVE_TREES = 'activeTrees'
@@ -686,10 +686,11 @@ def cancel(request, instance, import_type, import_event_id):
     return list_imports(request, instance)
 
 
-@task_output_as_csv
+@queryset_as_exported_csv
 def export_all_species(request, instance):
-    return ("all_species.csv", get_all_species_export, (instance.pk,),
-            fields.species.ALL)
+    fields = SpeciesImportRow.SPECIES_MAP.keys()
+    fields.remove('id')
+    return Species.objects.filter(instance_id=instance.id).values(*fields)
 
 
 @task_output_as_csv


### PR DESCRIPTION
It was slow because:
* It used a large `Species.objects.` query
* `Species` subclasses `Auditable`, so its constructor calls `populate_previous_state`, which fetches UDFs
* That hits the object cache, which requires `instance.adjunct_timestamp`
* So `species.instance` was fetched from the database
* `select_related` and `prefetch_related` didn't help

At @maurizi's suggestion I rewrote it to use a values queryset, which was easy because
* Changing `SpeciesImportRow.SPECIES_MAP` to an `OrderedDict` made it easy to get the right field order
* The header row comes out right because `django-queryset-csv` removes underscores
