### PR TITLE
Switch from 'help_text' to 'verbose_name' for field name defaults.

### DIFF
--- a/opentreemap/stormwater/migrations/0005_help_text_to_verbose_name.py
+++ b/opentreemap/stormwater/migrations/0005_help_text_to_verbose_name.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('stormwater', '0004_auto_20151021_1600'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='rainbarrel',
+            name='capacity',
+            field=models.FloatField(verbose_name='Capacity', error_messages={'invalid': 'Please enter a number.'}),
+        ),
+    ]

--- a/opentreemap/stormwater/models.py
+++ b/opentreemap/stormwater/models.py
@@ -131,7 +131,7 @@ class RainGarden(PolygonalMapFeature):
 class RainBarrel(MapFeature):
     objects = GeoHStoreUDFManager()
     capacity = models.FloatField(
-        help_text=_("Capacity"),
+        verbose_name=_("Capacity"),
         error_messages={'invalid': _("Please enter a number.")})
 
     _terminology = {

--- a/opentreemap/treemap/migrations/0012_help_text_to_verbose_name.py
+++ b/opentreemap/treemap/migrations/0012_help_text_to_verbose_name.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0011_instance_universal_rev'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='mapfeature',
+            name='address_city',
+            field=models.CharField(max_length=255, null=True, verbose_name='City', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='mapfeature',
+            name='address_street',
+            field=models.CharField(max_length=255, null=True, verbose_name='Address', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='mapfeature',
+            name='address_zip',
+            field=models.CharField(max_length=30, null=True, verbose_name='Postal Code', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='mapfeature',
+            name='updated_at',
+            field=models.DateTimeField(default=django.utils.timezone.now, verbose_name='Last Updated'),
+        ),
+        migrations.AlterField(
+            model_name='plot',
+            name='length',
+            field=models.FloatField(null=True, verbose_name='Planting Site Length', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='plot',
+            name='width',
+            field=models.FloatField(null=True, verbose_name='Planting Site Width', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='tree',
+            name='canopy_height',
+            field=models.FloatField(null=True, verbose_name='Canopy Height', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='tree',
+            name='date_planted',
+            field=models.DateField(null=True, verbose_name='Date Planted', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='tree',
+            name='date_removed',
+            field=models.DateField(null=True, verbose_name='Date Removed', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='tree',
+            name='diameter',
+            field=models.FloatField(null=True, verbose_name='Tree Diameter', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='tree',
+            name='height',
+            field=models.FloatField(null=True, verbose_name='Tree Height', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='tree',
+            name='species',
+            field=models.ForeignKey(verbose_name='Species', blank=True, to='treemap.Species', null=True),
+        ),
+    ]

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -528,11 +528,11 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
     geom = models.PointField(srid=3857, db_column='the_geom_webmercator')
 
     address_street = models.CharField(max_length=255, blank=True, null=True,
-                                      help_text=_("Address"))
+                                      verbose_name=_("Address"))
     address_city = models.CharField(max_length=255, blank=True, null=True,
-                                    help_text=_("City"))
+                                    verbose_name=_("City"))
     address_zip = models.CharField(max_length=30, blank=True, null=True,
-                                   help_text=_("Postal Code"))
+                                   verbose_name=_("Postal Code"))
 
     readonly = models.BooleanField(default=False)
 
@@ -540,7 +540,7 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
     # table, we store a "cached" value here to keep filtering easy and
     # efficient.
     updated_at = models.DateTimeField(default=timezone.now,
-                                      help_text=_("Last Updated"))
+                                      verbose_name=_("Last Updated"))
 
     # Tells the permission system that if any other field is writable,
     # updated_at is also writable
@@ -760,9 +760,9 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
 # authorizable and auditable, thus needs to be inherited first
 class Plot(MapFeature):
     width = models.FloatField(null=True, blank=True,
-                              help_text=_("Plot Width"))
+                              verbose_name=_("Planting Site Width"))
     length = models.FloatField(null=True, blank=True,
-                               help_text=_("Plot Length"))
+                               verbose_name=_("Planting Site Length"))
 
     owner_orig_id = models.CharField(max_length=255, null=True, blank=True)
 
@@ -858,19 +858,19 @@ class Tree(Convertible, UDFModel, PendingAuditable):
 
     plot = models.ForeignKey(Plot)
     species = models.ForeignKey(Species, null=True, blank=True,
-                                help_text=_("Species"))
+                                verbose_name=_("Species"))
 
     readonly = models.BooleanField(default=False)
     diameter = models.FloatField(null=True, blank=True,
-                                 help_text=_("Tree Diameter"))
+                                 verbose_name=_("Tree Diameter"))
     height = models.FloatField(null=True, blank=True,
-                               help_text=_("Tree Height"))
+                               verbose_name=_("Tree Height"))
     canopy_height = models.FloatField(null=True, blank=True,
-                                      help_text=_("Canopy Height"))
+                                      verbose_name=_("Canopy Height"))
     date_planted = models.DateField(null=True, blank=True,
-                                    help_text=_("Date Planted"))
+                                    verbose_name=_("Date Planted"))
     date_removed = models.DateField(null=True, blank=True,
-                                    help_text=_("Date Removed"))
+                                    verbose_name=_("Date Removed"))
 
     objects = GeoHStoreUDFManager()
 

--- a/opentreemap/treemap/templatetags/form_extras.py
+++ b/opentreemap/treemap/templatetags/form_extras.py
@@ -145,8 +145,8 @@ def inline_edit_tag(tag, Node):
     {% field "First" from "user.first_name" withtemplate "template.html" %}
 
     For simple use cases, the label can be omitted, in which case the
-    translated help_text property (for Django fields) or the name (for UDFs) of
-    the underlying field is provided as the label.
+    translated verbose_name property (for Django fields) or the name (for UDFs)
+    of the underlying field is provided as the label.
 
     {% field from "user.first_name" withtemplate "template.html" %}
     {% field from "user.first_name" for user withtemplate "template.html" %}
@@ -264,7 +264,7 @@ def field_type_label_choices(model, field_name, label,
             raise Exception('This template tag only supports %s not %s'
                             % (VALID_FIELD_KEYS,
                                field_type))
-        label = label if label else field.help_text
+        label = label if label else field.verbose_name
         choices = [{'value': choice[0], 'display_value': choice[1]}
                    for choice in field.choices]
         if choices and field.null:

--- a/opentreemap/treemap/tests/test_templatetags.py
+++ b/opentreemap/treemap/tests/test_templatetags.py
@@ -548,7 +548,7 @@ class InlineFieldTagTests(OTMTestCase):
     def test_labelless_sets_label_to_default(self):
         self.assert_plot_length_context_value(
             self.observer, 'field.label',
-            Plot._meta.get_field('length').help_text,
+            Plot._meta.get_field('length').verbose_name,
             self._form_template_labelless_with_request_user_for)
 
     def test_labelless_sets_identifier(self):
@@ -591,7 +591,7 @@ class InlineFieldTagTests(OTMTestCase):
     def test_search_gets_default_label_when_none_given(self):
         self.assert_search_context_value(
             self.observer, 'field.label',
-            unicode(Plot._meta.get_field('length').help_text),
+            unicode(Plot._meta.get_field('length').verbose_name),
             {'identifier': 'Plot.length', 'label': None})
 
     def test_search_fields_get_added_only_for_valid_json_matches(self):


### PR DESCRIPTION
`verbose_name` is the more correct Django-ism to use for a field name.

Also removes a few errant uses of Plot in favor of Planting Site