### PR TITLE
Include correct protocol in activation email template.

### DIFF
--- a/opentreemap/registration_backend/views.py
+++ b/opentreemap/registration_backend/views.py
@@ -135,7 +135,7 @@ class RegistrationView(DefaultRegistrationView):
 
         user = RegistrationProfile.objects.create_inactive_user(
             site, send_email=should_email, username=username,
-            email=email, password=password)
+            email=email, password=password, request=request)
 
         user.first_name = cleaned_data.get('first_name', '')
         user.last_name = cleaned_data.get('last_name', '')

--- a/opentreemap/treemap/templates/registration/activation_email.txt
+++ b/opentreemap/treemap/templates/registration/activation_email.txt
@@ -5,7 +5,11 @@ Hello,
 Thank you for creating a tree map account and joining our community. To activate your account, please click on the link below or copy and paste it into your web browser. The link is only valid for {{ expiration_days }} days.
 
 {% endblocktrans %}
-{{ site.domain }}{% url 'registration_activate' activation_key %}
+{% if request.is_secure %}
+https://{{ site.domain }}{% url 'registration_activate' activation_key %}
+{% else %}
+http://{{ site.domain }}{% url 'registration_activate' activation_key %}
+{% endif %}
 {% blocktrans %}
 
 You can use your OpenTreeMap account to sign in to the tree map you registered on as well as any other map in the OpenTreeMap system. We hope you enjoy exploring the urban forest!


### PR DESCRIPTION
Passes the request object into the activation email template, so it can
be used to template the activation link with either HTTP or HTTPS,
depending on whether the signup page was accessed over HTTPS.

Connects to https://github.com/OpenTreeMap/otm-cloud/issues/44