### PR TITLE
Make advanced search work with config from DB

### DIFF
--- a/opentreemap/treemap/templatetags/form_extras.py
+++ b/opentreemap/treemap/templatetags/form_extras.py
@@ -241,14 +241,13 @@ def _is_udf(model, udf_field_name):
 
 
 def _udf_dict(model, field_name):
-            matches = [field.datatype_dict
-                       for field
-                       in model.get_user_defined_fields()
-                       if field.name == field_name.replace('udf:', '')]
-            if matches:
-                return matches[0]
-            else:
-                raise Exception("Datatype for field %s not found" % field_name)
+    matches = [field.datatype_dict
+               for field in model.get_user_defined_fields()
+               if field.name == field_name.replace('udf:', '')]
+    if matches:
+        return matches[0]
+    else:
+        raise Exception("Datatype for field %s not found" % field_name)
 
 
 def field_type_label_choices(model, field_name, label,

--- a/opentreemap/treemap/tests/test_models.py
+++ b/opentreemap/treemap/tests/test_models.py
@@ -365,8 +365,46 @@ class InstanceTest(OTMTestCase):
 
         self.assertEqual(instance.has_itree_region(), True)
 
-    @override_settings(FEATURE_BACKEND_FUNCTION='treemap.plugin.always_false')
-    def test_advanced_search_fields(self):
-        instance = make_instance()
-        self.assertEqual(instance.advanced_search_fields,
-                         {'standard': [], 'missing': [], 'display': []})
+
+class InstanceAdvancedSearch(OTMTestCase):
+    def setUp(self):
+        self.instance = make_instance()
+
+    def assert_search_present(self, **groups):
+        search = self.instance.advanced_search_fields
+        for group_name, field in groups.iteritems():
+            self.assertIn(group_name, search)
+            search_group = search[group_name]
+
+            field_info = search_group[0]
+            if 'label' in field_info:
+                field_info['label'] = unicode(field_info['label'])
+            del field_info['id']
+
+            self.assertEquals(field_info, field)
+
+    def test_missing_filters(self):
+        self.instance.search_config = {
+            'standard': [],
+            'missing': [{'identifier': 'mapFeaturePhoto.id'}]
+        }
+        self.assert_search_present(
+            missing={
+                'label': 'Show missing photos',
+                'identifier': 'mapFeaturePhoto.id',
+                'search_type': 'ISNULL',
+                'value': 'true'
+            }
+        )
+        self.instance.search_config = {
+            'standard': [],
+            'missing': [{'identifier': 'tree.id'}]
+        }
+        self.assert_search_present(
+            missing={
+                'label': 'Show missing trees',
+                'identifier': 'tree.id',
+                'search_type': 'ISNULL',
+                'value': 'true'
+            }
+        )

--- a/opentreemap/treemap/util.py
+++ b/opentreemap/treemap/util.py
@@ -46,6 +46,15 @@ def safe_get_model_class(model_string):
             _('invalid model type: "%s"') % model_string)
 
 
+def get_model_for_instance(object_name, instance=None):
+    Model = safe_get_model_class(to_model_name(object_name))
+
+    if instance and hasattr(Model, 'instance'):
+        return Model(instance=instance)
+    else:
+        return Model()
+
+
 def add_visited_instance(request, instance):
     if not (hasattr(request, 'session') and request.session):
         return


### PR DESCRIPTION
 - Removes search_type from the advanced search configuration dict
Instead, the search_type is inferred based on the underlying field type when
displaying fields.