### PR TITLE
Hide address and panning controls on street view.

### DIFF
--- a/opentreemap/treemap/css/sass/partials/pages/_treedetails.scss
+++ b/opentreemap/treemap/css/sass/partials/pages/_treedetails.scss
@@ -98,10 +98,14 @@
     border-radius: 9px;
 }
 
-// Needed because bootstrap breaks street view on firefox
-// by setting max-width: 100% on all <img> tags
-.street-view-small img {
-    max-width: none;
+.street-view-small {
+    height: 440px;
+
+    // Needed because bootstrap breaks street view on firefox
+    // by setting max-width: 100% on all <img> tags
+    .street-view-small img {
+        max-width: none;
+    }
 }
 
 #sidebar {

--- a/opentreemap/treemap/js/src/addMapFeature.js
+++ b/opentreemap/treemap/js/src/addMapFeature.js
@@ -151,8 +151,8 @@ function init(options) {
                 container = streetView.create({
                     streetViewElem: $streetViewContainer[0],
                     noStreetViewText: options.config.trans.noStreetViewText,
-                    hideAddress: true,
-                    location: latlng
+                    location: latlng,
+                    hideAddress: true
                 });
             }
 

--- a/opentreemap/treemap/js/src/streetView.js
+++ b/opentreemap/treemap/js/src/streetView.js
@@ -32,7 +32,8 @@ exports.create = function(options) {
                 if (panorama === null) {
                     panorama = new google.maps.StreetViewPanorama(div, {
                         position:pos,
-                        addressControl: showAddress
+                        addressControl: showAddress,
+                        panControl: false,
                     });
                 } else {
                     panorama.setPosition(pos);


### PR DESCRIPTION
I attempted to hide the full screen button but as far as I can tell
there is no option to do so.

There is also no way to minimize the address info box, only hide it or
change its position, so I opted to always hide it.

Connects to #2364