### PR TITLE
Switch from thumbnail to full-size image for user profile photo.

### DIFF
--- a/opentreemap/treemap/templates/treemap/user.html
+++ b/opentreemap/treemap/templates/treemap/user.html
@@ -35,8 +35,8 @@ active
         <div class="col-md-3">
             <div class="account-info">
                 <div class="user-photo-container">
-                    {% if user.thumbnail %}
-                      <img class="user-photo" id="user-photo" src="{{ user.thumbnail.url }}">
+                    {% if user.photo %}
+                      <img class="user-photo" id="user-photo" src="{{ user.photo.url }}">
                     {% else %}
                       <img class="user-photo" id="user-photo" src="{{STATIC_URL}}img/profile.png">
                     {% endif %}


### PR DESCRIPTION
We create a compresseed 85x85 pixel thumbnail for uploaded user photos,
which is intended to be used for the small profile photo in the header.

This is too small and shows compression artifacts when used on the user
profile page in a 195x195 pixel image.

Switching to the full size image for the user profile page fixes the issue.

Connects to OpenTreeMap/otm-addons#876