### PR TITLE
Support for tiler to render fewer plots on large maps

### DIFF
--- a/opentreemap/treemap/lib/hide_at_zoom.py
+++ b/opentreemap/treemap/lib/hide_at_zoom.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from math import floor
+
+from django.db import connection
+
+from treemap.models import MapFeature
+
+GRID_PIXELS = 2
+MAX_ZOOM = 14
+MIN_ZOOM = 0
+
+# When viewing a zoomed-out tree map, multiple plots in a local area are
+# rendered on top of one another. We set MapFeature.hide_at_zoom so the tiler
+# can render just one plot in such cases, speeding up tile creation for maps
+# with many plots.
+#
+# At each zoom level Z we find groups of plots located in the same cell of
+# a grid (cell size GRID_PIXELS), and set hide_at_zoom = Z for all but one
+# plot in each group.
+#
+# A larger cell size gives more speedup, but if it's too large the tree dots
+# start showing the grid pattern. GRID_PIXELS = 2 is the sweet spot for our
+# current tree dot size of 5 pixels.
+
+
+def recompute_hide_at_zoom(instance, verbose=False):
+    # TODO: skip if geo_rev hasn't changed
+    if verbose:
+        print('\nUpdating instance %s' % instance.url_name)
+
+    MapFeature.objects.all() \
+        .filter(instance=instance) \
+        .update(hide_at_zoom=None)
+
+    _print_summary(instance, MAX_ZOOM + 1, verbose)
+    for zoom in range(MAX_ZOOM, MIN_ZOOM - 1, -1):
+        grid_size_wm = _get_grid_size_wm(GRID_PIXELS, zoom)
+        with connection.cursor() as cursor:
+            cursor.execute(_SQL_RECOMPUTE, {
+                'instance_id': instance.id,
+                'grid_size': grid_size_wm,
+                'zoom': zoom
+            })
+        _print_summary(instance, zoom, verbose)
+
+    instance.update_geo_rev()
+
+
+def _print_summary(instance, zoom, verbose):
+    if verbose:
+        features = MapFeature.objects.filter(instance=instance,
+                                             hide_at_zoom=None)
+        print("{1:>2}  {0:>7}".format(features.count(), zoom))
+
+
+def _get_grid_size_wm(grid_pixels, zoom):
+    wm_world_width = 40075016.6856
+    tile_size = 256
+    wm_units_per_pixel = wm_world_width / (tile_size * pow(2, zoom))
+    grid_size_wm = grid_pixels * wm_units_per_pixel
+    return grid_size_wm
+
+
+# Notes:
+# 1) Ignore non-plots. They aren't numerous, and it simplifies
+#    both the tiler and opt-out of green infrastructure types.
+# 2) Not using ST_SnapToGrid because results were not consistent across runs.
+
+_SQL_RECOMPUTE = """
+    WITH featuresToHide AS (
+        WITH mapfeature AS (
+            /* Get all plots in instance with hide_at_zoom not set */
+             SELECT f.id, f.the_geom_webmercator
+             FROM treemap_mapfeature f
+             INNER JOIN treemap_instance i ON f.instance_id=i.id
+             WHERE i.id=%(instance_id)s
+               AND f.feature_type='Plot'
+               AND f.hide_at_zoom IS NULL
+        )
+        SELECT mapfeature.id FROM mapfeature
+        LEFT OUTER JOIN
+            /* Choose one feature from each grid cell */
+            (SELECT DISTINCT ON (geom)
+                id,
+                ST_MakePoint(floor(ST_X(the_geom_webmercator) / %(grid_size)s),
+                             floor(ST_Y(the_geom_webmercator) / %(grid_size)s))
+                    AS geom
+              FROM mapfeature
+            ) AS distinctRows
+            ON mapfeature.id = distinctRows.id
+        /* Now get the features NOT chosen */
+        WHERE distinctRows.id IS NULL
+    )
+    UPDATE treemap_mapfeature f
+    SET hide_at_zoom = %(zoom)s
+    FROM featuresToHide
+    WHERE f.id = featuresToHide.id;
+    """
+
+
+def update_hide_at_zoom_after_delete(feature):
+    if feature.feature_type == 'Plot':
+        _reveal_a_hidden_plot(
+            feature.instance, feature.geom, feature.hide_at_zoom)
+
+
+def update_hide_at_zoom_after_move(feature, user, point_old):
+    # For simplicity treat a move as an add and a delete.
+    # This means slightly more rendering than would be optimal, but
+    # plots aren't moved often and we'll re-optimize nightly.
+    # For the "add" we show the plot at all zoom levels (by clearing its
+    # hide_at_zoom). For the "delete" we reveal a plot hidden by the old
+    # position to prevent holes in the canopy.
+    if feature.feature_type == 'Plot':
+        hide_at_zoom_old = feature.hide_at_zoom
+        feature.hide_at_zoom = None
+        feature.save_with_user(user)
+
+        _reveal_a_hidden_plot(feature.instance, point_old, hide_at_zoom_old)
+
+
+def _reveal_a_hidden_plot(instance, point, hide_at_zoom):
+    min_zoom = MIN_ZOOM - 1 if hide_at_zoom is None else hide_at_zoom
+
+    for zoom in range(MAX_ZOOM, min_zoom, -1):
+        grid_size_wm = _get_grid_size_wm(GRID_PIXELS, zoom)
+        # Plot that disappeared was visible at this zoom level.
+        # Reveal a hidden plot if there's one in this cell.
+        with connection.cursor() as cursor:
+            cursor.execute(_SQL_REVEAL, {
+                'instance_id': instance.id,
+                'grid_size': grid_size_wm,
+                'zoom': zoom,
+                'hide_at_zoom': hide_at_zoom,
+                'cell_x': floor(point.x / grid_size_wm),
+                'cell_y': floor(point.y / grid_size_wm),
+            })
+            result = cursor.fetchone()
+            if result is not None:
+                # Found one. Its hide_at_zoom has been lowered so it will fill
+                # the hole left by the old plot.
+                return
+
+
+_SQL_REVEAL = """
+    UPDATE treemap_mapfeature f
+    SET hide_at_zoom = %(hide_at_zoom)s
+    FROM (
+         SELECT f.id
+         FROM treemap_mapfeature f
+         INNER JOIN treemap_instance i ON f.instance_id=i.id
+         WHERE i.id = %(instance_id)s
+           AND f.feature_type = 'Plot'
+           AND f.hide_at_zoom >= %(zoom)s
+           AND floor(ST_X(the_geom_webmercator) / %(grid_size)s) = %(cell_x)s
+           AND floor(ST_Y(the_geom_webmercator) / %(grid_size)s) = %(cell_y)s
+         LIMIT 1
+         ) feature_to_reveal
+    WHERE f.id = feature_to_reveal.id
+    RETURNING feature_to_reveal.id;
+    """

--- a/opentreemap/treemap/management/commands/recompute_hide_at_zoom.py
+++ b/opentreemap/treemap/management/commands/recompute_hide_at_zoom.py
@@ -1,0 +1,42 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.core.exceptions import ObjectDoesNotExist
+from django.db.models import Count
+
+from treemap.instance import Instance
+from treemap.lib.hide_at_zoom import recompute_hide_at_zoom
+from treemap.models import MapFeature
+
+MIN_FEATURE_COUNT = 100
+
+
+class Command(BaseCommand):
+    args = '<[instance_url_name]>'
+    help = 'Recomputes hide_at_zoom for all instances or specified instance'
+
+    def handle(self, *args, **options):
+        if len(args) > 1:
+            raise CommandError('Command takes 0 or 1 argument')
+
+        elif len(args) == 0:
+            _update_all_instances()
+
+        else:
+            url_name = args[0]
+            try:
+                instance = Instance.objects.get(url_name=url_name)
+            except ObjectDoesNotExist:
+                raise CommandError('Instance "%s" not found' % url_name)
+
+            recompute_hide_at_zoom(instance, verbose=True)
+
+
+def _update_all_instances():
+    instance_ids = MapFeature.objects \
+        .values('instance_id') \
+        .annotate(n=Count('instance_id')) \
+        .filter(n__gt=MIN_FEATURE_COUNT) \
+        .values_list('instance_id', flat=True)
+
+    for id in instance_ids:
+        instance = Instance.objects.get(id=id)
+        recompute_hide_at_zoom(instance, verbose=True)

--- a/opentreemap/treemap/migrations/0013_mapfeature_hide_at_zoom.py
+++ b/opentreemap/treemap/migrations/0013_mapfeature_hide_at_zoom.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0012_help_text_to_verbose_name'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='mapfeature',
+            name='hide_at_zoom',
+            field=models.IntegerField(default=None, null=True, db_index=True, blank=True),
+        ),
+    ]

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -544,7 +544,7 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
 
     # Tells the permission system that if any other field is writable,
     # updated_at is also writable
-    joint_writable = {'updated_at'}
+    joint_writable = {'updated_at', 'hide_at_zoom'}
 
     objects = GeoHStoreUDFManager()
 
@@ -567,6 +567,7 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
             self.feature_type = self.map_feature_type
         self._do_not_track.add('feature_type')
         self._do_not_track.add('mapfeature_ptr')
+        self._do_not_track.add('hide_at_zoom')
         self.populate_previous_state()
 
     @property

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -558,6 +558,9 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
 
     feature_type = models.CharField(max_length=255)
 
+    hide_at_zoom = models.IntegerField(
+        null=True, blank=True, default=None, db_index=True)
+
     def __init__(self, *args, **kwargs):
         super(MapFeature, self).__init__(*args, **kwargs)
         if self.feature_type == '':

--- a/opentreemap/treemap/tests/test_hide_at_zoom.py
+++ b/opentreemap/treemap/tests/test_hide_at_zoom.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django.contrib.gis.geos import Point
+from django.db.models import Count
+
+from treemap.models import Plot
+from treemap.lib.hide_at_zoom import (recompute_hide_at_zoom,
+                                      update_hide_at_zoom_after_delete,
+                                      update_hide_at_zoom_after_move)
+from treemap.tests import make_instance, make_commander_user
+from treemap.tests.base import OTMTestCase
+
+
+class HideAtZoomTests(OTMTestCase):
+    def setUp(self):
+        self.instance = make_instance(edge_length=1000)
+        self.user = make_commander_user(self.instance)
+        self.make_plots([
+            (0, 100), (0, 101), (0, 200), (0, 201)
+        ])
+        recompute_hide_at_zoom(self.instance)
+        # Two plots have hide_at_zoom == 14
+        # One plot has hide_at_zoom == 10
+        # One plot has hide_at_zoom == None
+        self.assert_counts({14: 2, 10: 1})
+
+    def make_plots(self, points):
+        for p in points:
+            plot = Plot(instance=self.instance, geom=Point(*p))
+            plot.save_with_user(self.user)
+
+    def assert_counts(self, expected_count_dict):
+        # Count occurrences of each hide_at_zoom value
+        counts = Plot.objects.values('hide_at_zoom') \
+            .annotate(count=Count('hide_at_zoom'))
+        # Put counts into a dict.
+        # Skip "None" values because they aren't counted correctly.
+        # (The assert is still strong because an unexpected number of "None"
+        # values would be matched by an unexpected number of some other value.)
+        count_dict = {c['hide_at_zoom']: c['count'] for c in counts
+                      if c['hide_at_zoom'] is not None}
+        self.assertEqual(count_dict, expected_count_dict)
+
+    def delete_and_assert_counts(self, plot, expected_count_dict):
+        plot.delete_with_user(self.user)
+        update_hide_at_zoom_after_delete(plot)
+        self.assert_counts(expected_count_dict)
+
+    def move_and_assert_counts(self, plot, new_point, expected_count_dict):
+        old_point = plot.geom
+        plot.geom = Point(*new_point)
+        plot.save_with_user(self.user)
+        update_hide_at_zoom_after_move(plot, self.user, old_point)
+        self.assert_counts(expected_count_dict)
+
+    def test_delete_1(self):
+        plot = Plot.objects.get(hide_at_zoom=None)
+        self.delete_and_assert_counts(plot, {14: 1, 10: 1})
+
+    def test_delete_2(self):
+        plot = Plot.objects.get(hide_at_zoom=10)
+        self.delete_and_assert_counts(plot, {14: 1, 10: 1})
+
+    def test_move_1(self):
+        plot = Plot.objects.get(hide_at_zoom=None)
+        point = (1, plot.geom.y)
+        self.move_and_assert_counts(plot, point, {14: 1, 10: 1})
+
+    def test_move_2(self):
+        plot = Plot.objects.get(hide_at_zoom=10)
+        point = (1, plot.geom.y)
+        self.move_and_assert_counts(plot, point, {14: 1, 10: 1})


### PR DESCRIPTION
When viewing a zoomed-out tree map, multiple plots in a local area are rendered on top of one another. We set `MapFeature.hide_at_zoom` so the tiler can render just one plot in such cases, speeding up tile creation for maps with many plots.

The plan is to recompute `hide_at_zoom` nightly. After a large tree import, tiling could be somewhat slower until the next day.

To test:

1. Run migrations
2. Run management command to set `hide_at_zoom` for all plots in a large instance, e.g. `manage.py recompute_hide_at_zoom latreemap`. (It takes several minutes to complete.)
3. Load the tree map (with dev tools open to disable cacheing) and click around
4. To compare performance, do an advanced search of "Last Updated" from 5 years ago to now. (When a filter is passed to the tiler the optimizations aren't used.)

Requires OpenTreeMap/otm-tiler#93
Connects #2374 