### PR TITLE
Revert change to tile URL in 0c56150.

### DIFF
--- a/opentreemap/treemap/js/src/layers.js
+++ b/opentreemap/treemap/js/src/layers.js
@@ -80,7 +80,7 @@ exports.createPlotUTFLayer = function (config) {
 function getUrlMaker(config, table, extension) {
     return function revToUrl(rev) {
         return format(
-            '%s/tile/%s/table/%s/{z}/{x}/{y}.%s%s',
+            '%s/tile/%s/database/otm/table/%s/{z}/{x}/{y}.%s%s',
             config.tileHost || '', rev, table, extension,
             urlLib.format({query: {
                 'instance_id': config.instance.id,


### PR DESCRIPTION
This change was reverted in otm-tiler to support legacy clients, and
needs to be reflected here as well.

Connects to https://github.com/OpenTreeMap/otm-tiler/issues/96