### PR TITLE
Handle import parsing of UDF dates and multichoice

### DIFF
--- a/opentreemap/importer/util.py
+++ b/opentreemap/importer/util.py
@@ -43,5 +43,9 @@ def _guess_dialect_and_reset_read_pointer(f):
 
 def utf8_file_to_csv_dictreader(f):
     dialect = _guess_dialect_and_reset_read_pointer(f)
+    # csv.Sniffer does not automatically detect when a file uses the
+    # CSV standard "" to escape a double quote. Excel and LibreOffice
+    # use this escape by default when saving as CSV.
+    dialect.doublequote = True
     return csv.DictReader(_as_utf8(f),
                           dialect=dialect)


### PR DESCRIPTION
When importing a tree CSV with date and/or multichoice UDF columns, data in an invalid format would trigger the throwing of an `ValueError` which crashed the celery validation task. In this commit I continue the pattern of other UDF validations by catching the `ValueError` and converting it to a `ValidationError`, which is caught and logged by thevalidation task.
 
I wanted to add some UDF validation tests, but the TreeValidationTest class was already relatively long. I split the setUp and helper function into a base class that could be shared with multiple tree validation test classes.

Connects to #2380
Connects to #2383