### PR TITLE
Fix bug in formatting edit values for clashing custom field names.

### DIFF
--- a/opentreemap/treemap/audit.py
+++ b/opentreemap/treemap/audit.py
@@ -1268,11 +1268,14 @@ class Audit(models.Model):
                 udfd_pk = int(self.model[4:])
                 udf_def = next((udfd for udfd in udfds if udfd.pk == udfd_pk),
                                None)
-                datatype = udf_def.datatype_by_field[field_name]
+                if udf_def is not None:
+                    datatype = udf_def.datatype_by_field[field_name]
             else:
                 udf_def = next((udfd for udfd in udfds
-                                if udfd.name == field_name), None)
-                datatype = udf_def.datatype_dict
+                                if udfd.name == field_name
+                                and udfd.model_type == self.model), None)
+                if udf_def is not None:
+                    datatype = udf_def.datatype_dict
             if udf_def is not None:
                 return udf_def.clean_value(value, datatype)
             else:


### PR DESCRIPTION
Because we were not filtering by both model and field name, but just field
name, `UserDefinedFieldDefinition.clean_value` was being given the
`datatype_dict` of Bioswale.Perennial Plants for an edit on the
Perennial Plants field of a Rain Garden.

Connects to #2366