### PR TITLE
Fix species importer i-Tree override tests

### DIFF
--- a/opentreemap/treemap/tests/__init__.py
+++ b/opentreemap/treemap/tests/__init__.py
@@ -336,8 +336,13 @@ def media_dir(f):
 
 
 def ecoservice_not_running():
-    return subprocess.call(
-        ["sudo", "service", settings.ECOSERVICE_NAME, "start"]) != 0
+    """Returns True if the ecoservice is not running"""
+    try:
+        status = subprocess.check_output(
+            ["sudo", "service", settings.ECOSERVICE_NAME, "status"])
+        return status.find('start/running') < 0
+    except subprocess.CalledProcessError:
+        return True
 
 
 class LocalMediaTestCase(OTMTestCase):


### PR DESCRIPTION
`ecoservice_not_running` was always reporting that the eco-service was not running, so tests using it never ran.

* Fix `ecoservice_not_running`
* Fix `ITreeCommitTest._assert_overrides` so that species with merge conflicts are committed

Connects #2395