### PR TITLE
Upgrade to selenium 2.48.0

### DIFF
--- a/opentreemap/otm_comments/uitests.py
+++ b/opentreemap/otm_comments/uitests.py
@@ -60,6 +60,9 @@ class CommentReviewUITest(CommentTestMixin, TreemapUITestCase):
     def go_to_page(self, page_num):
         page = str(page_num)
         page_link = self.find('.pagination').find_element_by_link_text(page)
+
+        self.driver.execute_script("return arguments[0].scrollIntoView();",
+                                   page_link)
         page_link.click()
 
         self.wait_until_on_page(page_num)

--- a/opentreemap/treemap/tests/ui/__init__.py
+++ b/opentreemap/treemap/tests/ui/__init__.py
@@ -57,13 +57,16 @@ def patch_broken_pipe_error():
 # output about "broken pipe" errors. Muzzle it.
 patch_broken_pipe_error()
 
+DISPLAY_WIDTH = 1280
+DISPLAY_HEIGHT = 1024
+
 
 class UITestCase(LiveServerTestCase):
     def use_xvfb(self):
         from pyvirtualdisplay import Display
         self.display = Display('xvfb',
                                visible=1,
-                               size=(1280, 1024))
+                               size=(DISPLAY_WIDTH, DISPLAY_HEIGHT))
         self.display.start()
         self.driver = WebDriver()
 
@@ -76,6 +79,8 @@ class UITestCase(LiveServerTestCase):
 
         if ui_is_not_available:
             self.use_xvfb()
+
+        self.driver.set_window_size(DISPLAY_WIDTH, DISPLAY_HEIGHT)
 
         self.driver.implicitly_wait(10)
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 PyVirtualDisplay==0.1.2
-selenium==2.46.0
+selenium==2.48.0
 coverage==3.7


### PR DESCRIPTION
Running UI tests with Firefox 43 (the latest version as of this commit) and selenium 2.46.0 generated errors on every test.

~~This resolved the errors on every test, but still results in failing tests.~~
43fce3a fixed the failing tests by making sure elements to be clicked are on screen

Connects to #2397 