### PR TITLE
fix add-ons issue 946. highlight background color on new roles

### DIFF
--- a/opentreemap/treemap/css/sass/partials/pages/_admin.scss
+++ b/opentreemap/treemap/css/sass/partials/pages/_admin.scss
@@ -262,9 +262,14 @@
         table-layout: fixed;
         tr {
 
-            &.active {
+            &.active,
+            &.active:hover {
                 background-color: $warning-color;
                 background-color: rgba($warning-color, .75);
+
+                > td {
+                    background: none;
+                }
             }
             
             th {


### PR DESCRIPTION
Fix for https://github.com/OpenTreeMap/otm-addons/issues/946