### PR TITLE
Fix error handling on the tree details quick edit

### DIFF
--- a/opentreemap/treemap/css/sass/partials/_error.scss
+++ b/opentreemap/treemap/css/sass/partials/_error.scss
@@ -65,3 +65,8 @@
         line-height: 1.6rem;
     }
 }
+
+// Hides error bubbles when there is no error message
+.alert:empty {
+    display: none !important;
+}

--- a/opentreemap/treemap/templates/treemap/partials/map_feature_accordion.html
+++ b/opentreemap/treemap/templates/treemap/partials/map_feature_accordion.html
@@ -6,6 +6,8 @@
 <form id="details-form" data-location-x="{{ plot.geom.x|unlocalize }}" data-location-y="{{ plot.geom.y|unlocalize }}"
       data-map-feature-type="{% if feature.is_plot %}plot{% else %}resource{% endif %}">
 
+    <div class="alert alert-danger text-danger" data-class="error" data-field="mapFeature.geom"></div>
+
     {% if feature.is_plot %}
     {% if tree %}
     {# The "edit-tree-species" label is used as an id prefix in "species_div.html" #}


### PR DESCRIPTION
 - Empty error boxes were appearing - fixed via CSS rule
 - Errors due to out of bounds plots were not appearing, fixed by adding
   an element to display mapFeature.geom errors.

Connects to #2393