### PR TITLE
Importer bug fixes

### DIFF
--- a/opentreemap/importer/templates/importer/partials/import_table.html
+++ b/opentreemap/importer/templates/importer/partials/import_table.html
@@ -27,10 +27,12 @@
                 {% endif %}
             </td>
             <td>
-              <a class="js-view"
-                 href="{% url 'importer:status' import_type=ie.import_type import_event_id=ie.pk instance_url_name=request.instance.url_name %}">
-                {%trans "View" %}
-              </a>
+              {% if ie.is_running or ie.is_finished %}
+                <a class="js-view"
+                   href="{% url 'importer:status' import_type=ie.import_type import_event_id=ie.pk instance_url_name=request.instance.url_name %}">
+                  {%trans "View" %}
+                </a>
+              {% endif %}
             </td>
             <td>
               {% if ie.can_export %}

--- a/opentreemap/importer/views.py
+++ b/opentreemap/importer/views.py
@@ -615,7 +615,7 @@ def solve(request, instance, import_event_id, row_index):
     target_species = request.GET['species']
 
     # Strip off merge errors
-    #TODO: Json handling is terrible.
+    # TODO: Json handling is terrible.
     row.errors = json.dumps(row.errors_array_without_merge_errors())
     row.datadict.update(data)
     row.datadict = row.datadict  # invoke setter to update row.data
@@ -681,7 +681,11 @@ def cancel(request, instance, import_type, import_event_id):
 
     # If verifications tasks are still scheduled, we need to revoke them
     if ie.task_id:
-        GroupResult.restore(ie.task_id).revoke()
+        result = GroupResult.restore(ie.task_id)
+        if result:
+            result.revoke()
+
+    # If we couldn't get the task, it is already effectively cancelled
 
     return list_imports(request, instance)
 


### PR DESCRIPTION
 -  Always set importer status to canceled when calling the cancel endpoint
    On some occasions we cannot get the Celery task when attempting to call
    `GroupResult.restore()`, which caused attempts to call `.revoke()` to fail,
    which caused the change to the Import status to be rolled back.

    We explicitly check the return of `.restore()` before attempting to call
    `revoke()`, which prevents the transaction rollback from reverting the changed
    status.

 - Do not show the importer view link until it has started verification …

Connects to OpenTreeMap/otm-addons#990
Connects to OpenTreeMap/otm-addons#991