### PR TITLE
Configure missing data search fields

### DIFF
--- a/opentreemap/api/tests.py
+++ b/opentreemap/api/tests.py
@@ -1081,7 +1081,7 @@ class UpdatePlotAndTree(OTMTestCase):
         self.assertEqual(200, response.status_code)
 
         response_json = loads(response.content)
-        self.assertEqual([], response_json['plot']['udf:multi'])
+        self.assertEqual(None, response_json['plot']['udf:multi'])
 
         test_plot.udfs['multi'] = ['b', 'c']
         test_plot.save_with_user(self.user)

--- a/opentreemap/importer/models/trees.py
+++ b/opentreemap/importer/models/trees.py
@@ -165,7 +165,10 @@ class TreeImportRow(GenericImportRow):
             # multichoice fields are represented in the import file as
             # a string, but the `udfs` attribute on the model expects
             # an actual list.
-            return json.loads(value)
+            if value:
+                return json.loads(value)
+            else:
+                return None
         else:
             return value
 

--- a/opentreemap/importer/tests.py
+++ b/opentreemap/importer/tests.py
@@ -454,6 +454,16 @@ class TreeUdfValidationTest(TreeValidationTestBase):
         i.validate_row()
         self.assertNotHasError(i, errors.INVALID_UDF_VALUE)
 
+        row['plot: test multichoice'] = None
+        i = self.mkrow(row)
+        i.validate_row()
+        self.assertNotHasError(i, errors.INVALID_UDF_VALUE)
+
+        row['plot: test multichoice'] = '[]'
+        i = self.mkrow(row)
+        i.validate_row()
+        self.assertNotHasError(i, errors.INVALID_UDF_VALUE)
+
         ## INVALID
 
         # This is an error because the JSON parser requires that

--- a/opentreemap/treemap/migrations/0014_change_empty_multichoice_values.py
+++ b/opentreemap/treemap/migrations/0014_change_empty_multichoice_values.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from treemap.udf import UDFDictionary
+
+
+def set_empty_multichoice_values_to_none(apps, schema_editor):
+    UserDefinedFieldDefinition = apps.get_model(
+        'treemap', 'UserDefinedFieldDefinition')
+    udfds = (UserDefinedFieldDefinition.objects
+             .filter(datatype__contains='multichoice'))
+    print()
+    for udfd in udfds:
+        type = udfd.model_type
+        if type in ('Bioswale', 'RainGarden', 'RainBarrel'):
+            Model = apps.get_model('stormwater', type)
+        else:
+            Model = apps.get_model('treemap', type)
+        objs = (Model.objects
+                .filter(instance=udfd.instance)
+                .filter(udfs__contains={udfd.name: '[]'})
+                )
+        for obj in objs:
+            # Note: this is doing
+            #     obj.udfs[udfd.name] = None
+            # in a migration-safe way
+            super(UDFDictionary, obj.udfs).__setitem__(udfd.name, None)
+            obj.save_base()
+        if len(objs) > 0:
+            print('Updated %s empty multichoice values for %s udf "%s" (%s)'
+                  % (len(objs), udfd.model_type, udfd.name,
+                     udfd.instance.url_name))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0013_mapfeature_hide_at_zoom'),
+    ]
+
+    # Note: reverse migration unnecessary since NULL is already a valid value
+    # for a multichoice field
+    operations = [
+        migrations.RunPython(set_empty_multichoice_values_to_none,
+                             migrations.RunPython.noop)
+    ]

--- a/opentreemap/treemap/templates/treemap/field/inputs.html
+++ b/opentreemap/treemap/templates/treemap/field/inputs.html
@@ -1,6 +1,15 @@
 {% load l10n %}
 {% load dateformat %}
-{% if field.choices %}
+{% if field.data_type == 'bool' or field.search_type == 'ISNULL' %}
+    <input name="{{ field.identifier }}"
+          {% if field.value %}
+           checked="checked"
+          {% endif %}
+           type="checkbox"
+           class="{{ class|default_if_none:"" }}"
+           value="{{ field.value }}"
+           {{ extra|default:"" }} />
+{% elif field.choices %}
     <select name="{{ field.identifier }}" {{ extra|default_if_none:"" }}
             {% if field.data_type == 'multichoice' %}multiple="multiple"{% endif %}
             class="{{ class|default_if_none:"" }} form-control">
@@ -14,15 +23,6 @@
                     >{{option.display_value}}</option>
         {% endfor %}
     </select>
-{% elif field.data_type == 'bool' or field.search_type == 'ISNULL' %}
-    <input name="{{ field.identifier }}"
-          {% if field.value %}
-           checked="checked"
-          {% endif %}
-           type="checkbox"
-           class="{{ class|default_if_none:"" }}"
-           value="{{ field.value }}"
-           {{ extra|default:"" }} />
 {% elif field.data_type == 'date' or field.data_type == 'datetime' %}
     <input name="{{ field.identifier }}"
            type="text"

--- a/opentreemap/treemap/tests/test_udfs.py
+++ b/opentreemap/treemap/tests/test_udfs.py
@@ -861,8 +861,8 @@ class ScalarUDFTest(OTMTestCase):
         self.plot = Plot.objects.get(pk=self.plot.pk)
         audit = self.plot.audits().filter(field='udf:Test multichoice')
 
-        self.assertEqual(self.plot.udfs['Test multichoice'], [])
-        self.assertEqual(json.loads(audit[0].current_value), [])
+        self.assertEqual(self.plot.udfs['Test multichoice'], None)
+        self.assertEqual(json.loads(audit[0].current_value), None)
 
         choice = UserDefinedFieldDefinition.objects.get(
             pk=self.multichoice_udfd.pk)


### PR DESCRIPTION
* Fields from all models are shown in the "Missing Data" category, so prefix the label with the model name.
* In the `field/inputs.html` template, move the test for checkbox fields to the top. Otherwise the advanced search "Missing" category shows dropdowns for "choice" fields instead of check boxes.
* When creating ID's for advanced search fields, convert spaces to underscores

See #2406 for discussion