### PR TITLE
Fix style issues caused when closing social media sharing modal

### DIFF
--- a/opentreemap/treemap/js/src/imageUploadPanel.js
+++ b/opentreemap/treemap/js/src/imageUploadPanel.js
@@ -66,7 +66,11 @@ module.exports.init = function(options) {
             }
 
             if (callback) {
-                callback(new Bacon.Next({event: e, data: data}));
+                // Downstream users will be opening modals, which leads to
+                // style errors if that is done before a modal closes
+                $panel.one('hidden.bs.modal', function() {
+                    callback(new Bacon.Next({event: e, data: data}));
+                });
             }
         },
         fail: function (e, data) {


### PR DESCRIPTION
There is an open issue in the version of Bootstrap we are using that causes
a 14-17px padding to be added to the body element, in an attempt to hide
the scrollbar of the page when modals are open.
https://github.com/twbs/bootstrap/issues/14040

As a side effect of this, opening a modal while another modal is still
closing (which is documented by Bootstrap as something to avoid) causes
this padding to remain in effect in even when the modal is closed.

I fixed that issue by ensuring that we wait until the upload modal has
closed before attempting to open the social media modal.

We may have to wait for a newer version of Bootstrap to fix the
main issue of unnecessarily adding padding when modals are open, or we may
be able to fix it with CSS rules.

Connects to #2427