### PR TITLE
Update python dependencies to the latest versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
   - flake8 --exclude migrations,opentreemap/settings/local_settings.py,*.pyc opentreemap
   - npm run check
   - testem ci -l Firefox
-  - cd opentreemap && coverage run --rcfile=../coveragerc --source=. manage.py test
+  - cd opentreemap && coverage run --rcfile=../.coveragerc --source=. manage.py test
 
 after_success:
   coveralls

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
 django-extensions==1.6.1
 six==1.10.0
-django-debug-toolbar==1.3.2
+django-debug-toolbar==1.4

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
 django-extensions==1.6.1
-six==1.4.1
+six==1.10.0
 django-debug-toolbar==1.3.2

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
-django-extensions==1.2.5
+django-extensions==1.6.1
 six==1.4.1
 django-debug-toolbar==1.3.2

--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -109,11 +109,11 @@ USE_TZ = True
 
 # Path to the Django Project root
 # Current file is in opentreemap/opentreemap/settings, so go up 3
-PROJECT_ROOT = os.path.abspath(
+BASE_DIR = os.path.abspath(
     os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 
 # Path to the location of SCSS files, used for on-the-fly compilation to CSS
-SCSS_ROOT = os.path.join(PROJECT_ROOT, 'treemap', 'css', 'sass')
+SCSS_ROOT = os.path.join(BASE_DIR, 'treemap', 'css', 'sass')
 
 # Entry point .scss file for on-the-fly compilation to CSS
 SCSS_ENTRY = 'main'
@@ -186,7 +186,7 @@ if ROLLBAR_ACCESS_TOKEN is not None:
     ROLLBAR = {
         'access_token': ROLLBAR_ACCESS_TOKEN,
         'environment': STACK_TYPE,
-        'root': PROJECT_ROOT
+        'root': BASE_DIR
     }
     MIDDLEWARE_CLASSES += (
         'rollbar.contrib.django.middleware.RollbarNotifierMiddleware',)

--- a/opentreemap/treemap/images.py
+++ b/opentreemap/treemap/images.py
@@ -19,9 +19,9 @@ def _rotate_image_based_on_exif(img):
         # According to PIL.ExifTags, 0x0112 is "Orientation"
         orientation = img._getexif()[0x0112]
         if orientation == 6:  # Right turn
-            img = img.rotate(-90)
+            img = img.rotate(-90, expand=True)
         elif orientation == 5:  # Left turn
-            img = img.rotate(90)
+            img = img.rotate(90, expand=True)
     except:
         pass
 
@@ -81,7 +81,7 @@ def save_uploaded_image(image_data, name_prefix, thumb_size=None,
         if degrees_to_rotate is None:
             image = _rotate_image_based_on_exif(image)
         else:
-            image = image.rotate(degrees_to_rotate)
+            image = image.rotate(degrees_to_rotate, expand=True)
 
         image_file = _get_file_for_image(image, name, format)
         thumb_file = None

--- a/opentreemap/treemap/tests/test_images.py
+++ b/opentreemap/treemap/tests/test_images.py
@@ -18,5 +18,5 @@ class SaveImageTest(LocalMediaTestCase):
 
         expected_width, expected_height = Image.open(sideways_file).size
         actual_width, actual_height = Image.open(img_file).size
-        self.assertEquals(expected_width, actual_height)
-        self.assertEquals(expected_height, actual_width)
+        self.assertAlmostEqual(expected_width, actual_height, delta=1)
+        self.assertAlmostEqual(expected_height, actual_width, delta=1)

--- a/opentreemap/treemap/tests/test_views.py
+++ b/opentreemap/treemap/tests/test_views.py
@@ -231,12 +231,15 @@ class TreePhotoRotationTest(TreePhotoTestCase):
         self.assertEqual(1, len(context['photos']))
         self.assertEqual(old_photo.pk, context['photos'][0]['id'])
 
-        self.assertEqual(
-            (old_photo.image.width, old_photo.image.height),
-            (rotated_photo.image.height, rotated_photo.image.width))
-        self.assertEqual(
-            (old_photo.thumbnail.width, old_photo.thumbnail.height),
-            (rotated_photo.thumbnail.height, rotated_photo.thumbnail.width))
+        self.assertAlmostEqual(old_photo.image.width,
+                               rotated_photo.image.height, delta=1)
+        self.assertAlmostEqual(old_photo.image.height,
+                               rotated_photo.image.width, delta=1)
+
+        self.assertAlmostEqual(old_photo.thumbnail.width,
+                               rotated_photo.thumbnail.height, delta=1),
+        self.assertAlmostEqual(old_photo.thumbnail.height,
+                               rotated_photo.thumbnail.width, delta=1)
 
 
 class ApproveOrRejectPhotoTest(TreePhotoTestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ django-celery-with-redis==3.0
 git+https://github.com/dahlia/libsass-python.git@4aa8fd3c2cef8c1
 # Django comments are no longer bundled with django in
 # 1.6 so we include them here
-django-contrib-comments==1.6.1
+django-contrib-comments==1.6.2
 django-threadedcomments==1.0b1
 django-apptemplates==0.0.1
 django-queryset-csv>=0.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto==2.38.0
 django-storages==1.1.8
 Django==1.8.8  # rq.filter: >=1.8,<1.9
-Pillow==2.3.1
+Pillow==3.1.0
 argparse==1.2.1
 gunicorn==19.3.0
 psycopg2==2.4.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ django-threadedcomments==1.0.1
 django-apptemplates==1.0
 django-queryset-csv==0.3.2
 python-dateutil==2.4.2
-pytz==2014.7
+pytz==2015.7
 django-tinsel==0.1.1
 django-url-tools==0.0.8
 django-redis==4.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ django-storages==1.1.8
 Django==1.8.8  # rq.filter: >=1.8,<1.9
 Pillow==3.1.0
 gunicorn==19.4.5
-psycopg2==2.4.6
+psycopg2==2.6.1
 django-hstore==1.4.0
 wsgiref==0.1.2
 pep8==1.4.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,6 @@ python-dateutil==2.4.2
 pytz==2015.7
 django-tinsel==0.1.1
 django-url-tools==0.0.8
-django-redis==4.2.0
+django-redis==4.3.0
 hiredis==0.2.0
 rollbar==0.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ git+https://github.com/dahlia/libsass-python.git@4aa8fd3c2cef8c1
 django-contrib-comments==1.6.2
 django-threadedcomments==1.0.1
 django-apptemplates==1.0
-django-queryset-csv>=0.3.2
+django-queryset-csv==0.3.2
 python-dateutil==2.2
 pytz==2014.7
 django-tinsel==0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,4 +28,4 @@ django-tinsel==0.1.1
 django-url-tools==0.0.8
 django-redis==4.3.0
 hiredis==0.2.0
-rollbar==0.11.0
+rollbar==0.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto==2.38.0
 django-storages==1.1.8
-Django==1.8.4
+Django==1.8.8  # rq.filter: >=1.8,<1.9
 Pillow==2.3.1
 argparse==1.2.1
 gunicorn==19.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Django==1.8.8  # rq.filter: >=1.8,<1.9
 Pillow==3.1.0
 gunicorn==19.4.5
 psycopg2==2.6.1
-django-hstore==1.4.0
+django-hstore==1.4.1
 wsgiref==0.1.2
 pep8==1.4.6
 flake8==2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ boto==2.38.0
 django-storages==1.1.8
 Django==1.8.8  # rq.filter: >=1.8,<1.9
 Pillow==3.1.0
-gunicorn==19.3.0
+gunicorn==19.4.5
 psycopg2==2.4.6
 django-hstore==1.4.0
 wsgiref==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ git+https://github.com/dahlia/libsass-python.git@4aa8fd3c2cef8c1
 # 1.6 so we include them here
 django-contrib-comments==1.6.2
 django-threadedcomments==1.0.1
-django-apptemplates==0.0.1
+django-apptemplates==1.0
 django-queryset-csv>=0.3.2
 python-dateutil==2.2
 pytz==2014.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@ gunicorn==19.4.5
 psycopg2==2.6.1
 django-hstore==1.4.1
 wsgiref==0.1.2
-pep8==1.4.6
-flake8==2.0
+pep8==1.4.6 # rq.filter: ==1.4.6
+flake8==2.0 # rq.filter: ==2.0
 python-omgeo==1.7.2
 django-registration-redux==1.2
 # Modgrammar-py2 has a 0.9.2 release on PyPi, but no artifacts for the release

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ django-contrib-comments==1.6.2
 django-threadedcomments==1.0.1
 django-apptemplates==1.0
 django-queryset-csv==0.3.2
-python-dateutil==2.2
+python-dateutil==2.4.2
 pytz==2014.7
 django-tinsel==0.1.1
 django-url-tools==0.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-boto==2.11.0
+boto==2.38.0
 django-storages==1.1.8
 Django==1.8.4
 Pillow==2.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ boto==2.38.0
 django-storages==1.1.8
 Django==1.8.8  # rq.filter: >=1.8,<1.9
 Pillow==3.1.0
-argparse==1.2.1
 gunicorn==19.3.0
 psycopg2==2.4.6
 django-hstore==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,8 @@ pep8==1.4.6
 flake8==2.0
 python-omgeo==1.7.2
 django-registration-redux==1.2
-modgrammar-py2==0.9.1
+# Modgrammar-py2 has a 0.9.2 release on PyPi, but no artifacts for the release
+modgrammar-py2==0.9.1 # rq.filter: !=0.9.2
 django-celery-with-redis==3.0
 # libsass==0.2.4
 # We need libsass version 3.0, which fixes libsass issue #54

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ django-hstore==1.4.1
 wsgiref==0.1.2
 pep8==1.4.6
 flake8==2.0
-python-omgeo==1.5
+python-omgeo==1.7.2
 django-registration-redux==1.2
 modgrammar-py2==0.9.1
 django-celery-with-redis==3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ git+https://github.com/dahlia/libsass-python.git@4aa8fd3c2cef8c1
 # Django comments are no longer bundled with django in
 # 1.6 so we include them here
 django-contrib-comments==1.6.2
-django-threadedcomments==1.0b1
+django-threadedcomments==1.0.1
 django-apptemplates==0.0.1
 django-queryset-csv>=0.3.2
 python-dateutil==2.2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
-PyVirtualDisplay==0.1.2
+PyVirtualDisplay==0.1.5
 selenium==2.48.0
 coverage==3.7

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 PyVirtualDisplay==0.1.5
 selenium==2.48.0
-coverage==3.7
+coverage==4.0.3

--- a/travis-requirements.txt
+++ b/travis-requirements.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 -r test-requirements.txt
 
-coveralls==0.4.4
+coveralls==1.1


### PR DESCRIPTION
The aim behind doing this is to take advantage of the requires.io service, which has been sending us pull requests whenever a new version of one of our dependencies has been updated.

I opted to defer some updates by using the special `rq.filter` comment recognized by requires.io.
 - I left updated Django to the latest 1.8 release, but used a filter to stay on 1.8 instead of the latest, which is 1.9
 - I kept us at our current versions of `pep8` and `flake8`, because the latest versions have new linting rules which our codebase does not follow.  We need to fix our code lint at the same time that we update these (see https://github.com/OpenTreeMap/otm-core/issues/2443).
 - I left `libsass` using a git version even though the release we are pinned to has been released on PyPi, because we need to update the Python `libsass` in conjunction with `node-sass` (see https://github.com/OpenTreeMap/otm-core/issues/2332).

Code changes were required for a few upgrades:
 - Django extensions wanted us to define the base directory of our project in `settings.py`, which we were already doing, but using the wrong name https://github.com/maurizi/otm-core/commit/10780ba8e9ab21c85e688bea784cd5e56702f26b
 - Pillow now requires an extra argument to the `rotate` method 703c8f4
 - There was a typo in our `.travis.yml` that was previously silently ignored by coverage.py that now is not - I fixed the typo