### PR TITLE
Make batch moderation selector more specific

### DIFF
--- a/opentreemap/otm_comments/templates/otm_comments/partials/moderation_row.html
+++ b/opentreemap/otm_comments/templates/otm_comments/partials/moderation_row.html
@@ -36,19 +36,19 @@
     <td data-single-action>
       {# Moderators don't see flag, only unflag.  The "|" is inside the if for that reason #}
       {% if comment.visible_flag_count > 0 %}
-      <a href="{% url 'hide-comment-flags' request.instance.url_name %}?{{ comments_params }}">Unflag</a>
+      <a class="action" href="{% url 'hide-comment-flags' request.instance.url_name %}?{{ comments_params }}">Unflag</a>
       |
       {% endif %}
       {% if comment.is_removed %}
-      <a href="{% url 'show-comments' request.instance.url_name %}?{{ comments_params }}">Unhide</a>
+      <a class="action" href="{% url 'show-comments' request.instance.url_name %}?{{ comments_params }}">Unhide</a>
       {% else %}
-      <a href="{% url 'hide-comments' request.instance.url_name %}?{{ comments_params }}">Hide</a>
+      <a class="action" href="{% url 'hide-comments' request.instance.url_name %}?{{ comments_params }}">Hide</a>
       {% endif %}
       |
       {% if comment.is_archived %}
-      <a href="{% url 'unarchive-comments' request.instance.url_name %}?{{ comments_params }}">Unarchive</a>
+      <a class="action" href="{% url 'unarchive-comments' request.instance.url_name %}?{{ comments_params }}">Unarchive</a>
       {% else %}
-      <a href="{% url 'archive-comments' request.instance.url_name %}?{{ comments_params }}">Archive</a>
+      <a class="action" href="{% url 'archive-comments' request.instance.url_name %}?{{ comments_params }}">Archive</a>
       {% endif %}
     </td>
     {% endspaceless %}

--- a/opentreemap/treemap/js/src/batchModeration.js
+++ b/opentreemap/treemap/js/src/batchModeration.js
@@ -12,7 +12,7 @@ $.ajaxSetup(csrf.jqueryAjaxSetupOptions);
 module.exports = function(container) {
     var $container = $(container),
 
-        singleActionStream = $container.asEventStream('click', '[data-single-action] a'),
+        singleActionStream = $container.asEventStream('click', '[data-single-action] a.action'),
         batchActionStream = $container.asEventStream('click', '[data-batch-action] a'),
         toggleAllEventStream = $container.asEventStream('click', '[data-toggle-all]'),
 


### PR DESCRIPTION
[This is a new version of #2440 targeted at `develop`]

The single action selector was including the anchor tag for "View Details" on the photo moderation page, which should be a plan request rather than an AJAX request that replaces the content of the page with the response.

The links on the photo moderation page already had a class attribute set correctly. I added `class="action"` to the links on the comment moderation page so that they would still trigger AJAX requests when clicked.

##### Testing

Add a bunch of photos and comments then make sure all the moderation action links work correctly. "View Detail" should be the only anchor that works like a normal link, the rest should make AJAX calls.

----

Connects to OpenTreeMap/otm-addons#1030