### PR TITLE
Restore missing message

### DIFF
--- a/opentreemap/treemap/templates/treemap/partials/advanced_search/missing.html
+++ b/opentreemap/treemap/templates/treemap/partials/advanced_search/missing.html
@@ -7,6 +7,6 @@
 {% endblock %}
 
 {% block dropdown_content %}
-    <div class="field-group-message">Checking a field's box below overrides any other filter for that field</div>
+    <div class="field-group-message" style="display:block">Checking a field's box below overrides any other filter for that field</div>
     {{ block.super }}
 {% endblock %}


### PR DESCRIPTION
CSS class `field-group-message` has `display: none` because most such messages
are hidden by default. This one is always shown, so override with `display: block`.

Connects #2449