### PR TITLE
Reusable components for filters on "list of items" pages

### DIFF
--- a/opentreemap/opentreemap/util.py
+++ b/opentreemap/opentreemap/util.py
@@ -8,7 +8,6 @@ import logging
 
 from rollbar.logger import RollbarHandler
 
-from django.core.urlresolvers import reverse
 from django.conf import settings
 
 
@@ -113,18 +112,6 @@ def get_ids_from_request(request):
         return [int(id) for id in ids_string.split(',')]
     else:
         return []
-
-
-class UrlParams(object):
-    def __init__(self, url_name, *url_args, **params):
-        self._url = reverse(url_name, args=url_args) + '?'
-        self._params = params
-
-    def params(self, *keys):
-        return '&'.join(['%s=%s' % (key, self._params[key]) for key in keys])
-
-    def url(self, *keys):
-        return self._url + self.params(*keys)
 
 
 def add_rollbar_handler(logger):

--- a/opentreemap/otm_comments/templates/otm_comments/partials/moderation.html
+++ b/opentreemap/otm_comments/templates/otm_comments/partials/moderation.html
@@ -9,28 +9,7 @@
       <h1>{% trans "Comments" %}</h1>
   </div>
   <div class="col-xs-4 text-right">
-      <div class="btn-group">
-        <button type="button" class="btn btn-sm btn-info dropdown-toggle" data-toggle="dropdown">
-          {{ comments_filter }} <span class="caret"></span>
-        </button>
-        <ul data-comments-filter class="dropdown-menu" role="menu">
-          {% if comments_filter == 'Active' %}
-          <li class="active"><a>{% trans "Active" %}</a></li>
-          {% else %}
-          <li><a href="{{ comments_url_for_filter }}&archived=False&removed=None">{% trans "Active" %}</a></li>
-          {% endif %}
-          {% if comments_filter == 'Hidden' %}
-          <li class="active"><a>{% trans "Hidden" %}</a></li>
-          {% else %}
-          <li><a href="{{ comments_url_for_filter }}&archived=None&removed=True">{% trans "Hidden" %}</a></li>
-          {% endif %}
-          {% if comments_filter == 'Archived' %}
-          <li class="active"><a>{% trans "Archived" %}</a></li>
-          {% else %}
-          <li><a href="{{ comments_url_for_filter }}&archived=True&removed=None">{% trans "Archived" %}</a></li>
-          {% endif %}
-        </ul>
-      </div>
+      {% include 'treemap/partials/filter_dropdown.html' with filter=comments_filter %}
       <button type="button" class="btn btn-sm" data-export-start-url="{% url 'comments-csv' request.instance.url_name %}?{{ comments_params }}"><i class="icon-export"></i>{% trans "Export All" %}</button>
   </div>
 </div> <!--END OF PAGE HEADER -->
@@ -84,7 +63,9 @@
 
     {% else %}
     <div class="alert alert-info">
-      {% blocktrans %}There are no {{ comments_filter_trans }} comments.{% endblocktrans %}
+      {% blocktrans with comments_filter.selected_option.label_lower as filtered %}
+          There are no {{ filtered }} comments.
+      {% endblocktrans %}
     </div>
     {% endif %}
   </div> <!--END OF COMMENT AREA -->

--- a/opentreemap/treemap/lib/page_of_items.py
+++ b/opentreemap/treemap/lib/page_of_items.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django.core.urlresolvers import reverse
+
+
+class UrlParams(object):
+    def __init__(self, url_name, *url_args, **params):
+        self._url = reverse(url_name, args=url_args) + '?'
+        self._params = params
+
+    def params(self, *keys):
+        return self._param_string(keys, self._params)
+
+    def url(self, *keys, **overrides):
+        params = self._params
+        if overrides:
+            keys += tuple(overrides.keys())
+            params = dict(params.items() + overrides.items())
+        return self._url + self._param_string(keys, params)
+
+    @staticmethod
+    def _param_string(keys, params):
+        return '&'.join(['%s=%s' % (key, params[key]) for key in keys])
+
+
+def make_filter_context(urlizer, filter_value, option_data):
+    # Set up context for the treemap/partials/filter_dropdown.html template.
+    # "option_data" is a list of tuples specifying filter options; each tuple
+    # is fed directly to make_filter_option().
+
+    def make_filter_option(label, label_lower, param_dict):
+        # "param_dict" contains key=value pairs defining this filter option.
+        # The values become part of the option's URL query string, and are
+        # also compared to the "filter_value" to determine if this is the
+        # currently-selected option.
+        url = urlizer.url('sort', **param_dict)
+        return {
+            'label': label,
+            'label_lower': label_lower,
+            'url': url,
+            'selected': (param_dict == filter_value)
+        }
+
+    options = [make_filter_option(*data) for data in option_data]
+
+    selected_options = [option for option in options if option['selected']]
+    selected_option = selected_options[0] if selected_options else None
+
+    return {
+        'options': options,
+        'selected_option': selected_option,
+    }

--- a/opentreemap/treemap/templates/treemap/partials/filter_dropdown.html
+++ b/opentreemap/treemap/templates/treemap/partials/filter_dropdown.html
@@ -1,0 +1,14 @@
+<div class="btn-group">
+    <button type="button" class="btn btn-sm btn-info dropdown-toggle" data-toggle="dropdown">
+        {{ filter.selected_option.label }} <span class="caret"></span>
+    </button>
+    <ul {{ filter.container_attr }} class="dropdown-menu dropdown-menu-right" role="menu">
+        {% for option in filter.options %}
+            {% if option.selected %}
+                <li class="active"><a>{{ option.label }}</a></li>
+            {% else %}
+                <li><a href="{{ option.url }}">{{ option.label }}</a></li>
+            {% endif %}
+        {% endfor %}
+    </ul>
+</div>

--- a/opentreemap/treemap/templates/treemap/partials/photo_review.html
+++ b/opentreemap/treemap/templates/treemap/partials/photo_review.html
@@ -9,24 +9,7 @@
         <h1>{% trans "Photos" %}</h1>
     </div>
     <div class="col-xs-4 text-right">
-        <div class="btn-group">
-            <button type="button" class="btn btn-sm btn-info dropdown-toggle" data-toggle="dropdown">
-                {{ is_archived_text }}
-                <span class="caret"></span>
-            </button>
-            <ul data-photo-filter class="dropdown-menu dropdown-menu-right" role="menu">
-                {% if not is_archived %}
-                <li class="active"><a>{% trans "Active" %}</a></li>
-                {% else %}
-                <li><a href="{{ url_for_filter }}&amp;archived=False">{% trans "Active" %}</a></li>
-                {% endif %}
-                {% if is_archived %}
-                <li class="active"><a>{% trans "Archived" %}</a></li>
-                {% else %}
-                <li><a href="{{ url_for_filter }}&amp;archived=True">{% trans "Archived" %}</a></li>
-                {% endif %}
-            </ul>
-        </div>
+        {% include 'treemap/partials/filter_dropdown.html' with filter=archived_filter %}
     </div>
 </div>
 
@@ -83,7 +66,11 @@
         </div>
         {% include 'treemap/partials/paging_controls.html' with paging=photos url=url_for_pagination %}
         {% else %}
-        <div class="alert alert-info">{% blocktrans %}There are no {{ is_archived_text_lower }} photos.{% endblocktrans%}</div>
+            <div class="alert alert-info">
+                {% blocktrans with archived_filter.selected_option.label_lower as filtered %}
+                    There are no {{ filtered }} photos.
+                {% endblocktrans %}
+            </div>
         {% endif %}
     </div>
 </div>


### PR DESCRIPTION
* Template `treemap/partials/filter_dropdown.html` creates a filter dropdown
* Helper `treemap/lib/page_of_items/make_filter_context` sets up context for the template
* Enhance `UrlParms.url()` to take optional param overrides, allowing easy creation of a URL for each filter option.
* Change the comment and photo moderation pages to use the new scheme.