### PR TITLE
Move universal_rev_hash from APIv4 to APIv5

### DIFF
--- a/opentreemap/api/instance.py
+++ b/opentreemap/api/instance.py
@@ -34,6 +34,7 @@ def transform_instance_info_response(instance_view_fn):
 
     v3 - Collection UDFs added
     v4 - Multiselect fields added
+    v5 - universalRev added
     """
     @wraps(instance_view_fn)
     def wrapper(request, *args, **kwargs):
@@ -46,10 +47,6 @@ def transform_instance_info_response(instance_view_fn):
                  if 'collection_udf_keys' not in field_group]
 
         if request.api_version < 4:
-            instance_info_dict['geoRevHash'] = (
-                instance_info_dict['universalRevHash'])
-            del instance_info_dict['universalRevHash']
-
             multichoice_fields = {
                 field for field, info
                 in instance_info_dict['fields'].iteritems()
@@ -66,6 +63,11 @@ def transform_instance_info_response(instance_view_fn):
                 if 'field_keys' in group:
                     group['field_keys'] = [key for key in group['field_keys']
                                            if key not in multichoice_fields]
+
+        if request.api_version < 5:
+            instance_info_dict['geoRevHash'] = (
+                instance_info_dict['universalRevHash'])
+            del instance_info_dict['universalRevHash']
 
         return instance_info_dict
 

--- a/opentreemap/api/plots.py
+++ b/opentreemap/api/plots.py
@@ -20,11 +20,16 @@ from treemap.models import Plot
 
 
 def transform_plot_update_dict(plot_update_fn):
+    """
+    Removes some information from the plot response for older APIs
+
+    v5 - universalRev added
+    """
     @wraps(plot_update_fn)
     def wrapper(request, *args, **kwargs):
         plot_dict = plot_update_fn(request, *args, **kwargs)
 
-        if request.api_version < 4:
+        if request.api_version < 5:
             plot_dict['geoRevHash'] = plot_dict['universalRevHash']
             del plot_dict['universalRevHash']
         return plot_dict


### PR DESCRIPTION
We are adding support to the mobile apps for multichoice fields, but are not
yet adding support for universal_rev_hash, so I am leaving multichoice fields
available in v4 but moving universal_rev_hash to only be supported in v5 and
above.