### PR TITLE
Handle non-ASCII characters in text and choice UDF fields

### DIFF
--- a/opentreemap/treemap/ecobackend.py
+++ b/opentreemap/treemap/ecobackend.py
@@ -73,7 +73,7 @@ def json_benefits_call(endpoint, params, post=False, convert_params=True):
 
                     v = "ST_GeomFromEWKT('%s')" % GEOSGeometry(hexstring).ewkt
                 else:
-                    v = str(v)
+                    v = v if isinstance(v, unicode) else str(v)
 
                 if k == "param":
                     if k in paramdata:

--- a/opentreemap/treemap/ecobackend.py
+++ b/opentreemap/treemap/ecobackend.py
@@ -72,8 +72,8 @@ def json_benefits_call(endpoint, params, post=False, convert_params=True):
                     hexstring = ''.join('%02X' % ord(x) for x in bytestring)
 
                     v = "ST_GeomFromEWKT('%s')" % GEOSGeometry(hexstring).ewkt
-                else:
-                    v = v if isinstance(v, unicode) else str(v)
+                elif not isinstance(v, unicode):
+                    v = str(v)
 
                 if k == "param":
                     if k in paramdata:

--- a/opentreemap/treemap/ecobenefits.py
+++ b/opentreemap/treemap/ecobenefits.py
@@ -100,7 +100,10 @@ class TreeBenefitsCalculator(BenefitCalculator):
     def _make_sql_from_query(self, query):
         sql, params = query.sql_with_params()
         cursor = connection.cursor()
-        return cursor.mogrify(sql, params)
+        # Returning a unicode SQL string ensures that any string
+        # replacements done to query string will not raise
+        # UnicodeDecodeError
+        return unicode(cursor.mogrify(sql, params), 'utf-8')
 
     def benefits_for_filter(self, instance, item_filter):
         from treemap.models import Plot, Tree

--- a/opentreemap/treemap/ecocache.py
+++ b/opentreemap/treemap/ecocache.py
@@ -67,7 +67,10 @@ def _get_key(prefix, filter):
         version = filter.instance.universal_rev
 
     filter_key = '%s/%s' % (filter.filterstr, filter.displaystr)
-    filter_hash = hashlib.md5(filter_key).hexdigest()
+    # Explecitly calling `encode()` ensures that the presence of a
+    # unicode symbol in the filter string will not raise a
+    # UnicodeEncodeError exception when calling `md5()`
+    filter_hash = hashlib.md5(filter_key.encode('utf-8')).hexdigest()
     key = "%s/%s/%s/%s" % (prefix,
                            filter.instance.url_name,
                            version,

--- a/opentreemap/treemap/ecocache.py
+++ b/opentreemap/treemap/ecocache.py
@@ -67,7 +67,7 @@ def _get_key(prefix, filter):
         version = filter.instance.universal_rev
 
     filter_key = '%s/%s' % (filter.filterstr, filter.displaystr)
-    # Explecitly calling `encode()` ensures that the presence of a
+    # Explicitly calling `encode()` ensures that the presence of a
     # unicode symbol in the filter string will not raise a
     # UnicodeEncodeError exception when calling `md5()`
     filter_hash = hashlib.md5(filter_key.encode('utf-8')).hexdigest()

--- a/opentreemap/treemap/udf.py
+++ b/opentreemap/treemap/udf.py
@@ -737,7 +737,7 @@ class UserDefinedFieldDefinition(models.Model):
             else:
                 value = None  # so "missing data" searches will work
         if value:
-            return str(value)
+            return value if isinstance(value, unicode) else str(value)
         else:
             return None
 

--- a/opentreemap/treemap/udf.py
+++ b/opentreemap/treemap/udf.py
@@ -733,7 +733,7 @@ class UserDefinedFieldDefinition(models.Model):
                 value = str(value.pk)
         elif self.datatype_dict['type'] == 'multichoice':
             if value and len(value) > 0:
-                value = json.dumps(value)
+                value = json.dumps(value, ensure_ascii=False)
             else:
                 value = None  # so "missing data" searches will work
         if value:


### PR DESCRIPTION
An exception was being thrown when setting the value of a text or choice UDF if the value contained non-ASCII characters. This was caused by indiscriminately using `str()` to coerce values to strings.

Advanced searches that included non-ASCII characters in text or choice fields were also raising exceptions. The changes in this PR ensure that values are always encoded and decoded properly.

##### Testing

Use a test instance with the customization module enabled.

Add a text UDF and a choice UDF to the test instance. Ensure that the choice UDF has choices that contain non-ASCII characters like ≥. Add these fields to the search configuration so that they are available for advanced searching.

Add trees to instance and set UDF values that contain non-ASCII characters. Verify that the non-ASCII characters are saves and display correctly on the tree detail page.

Verify that advanced searches with non-ASCII values correctly return results.

---

Connects to #2458