### PR TITLE
Feature/move instance bounds to separate model

### DIFF
--- a/opentreemap/api/tests.py
+++ b/opentreemap/api/tests.py
@@ -1264,8 +1264,17 @@ class InstancesClosestToPoint(OTMTestCase):
 
         instance_infos = instances_closest_to_point(request, 0, 0)
         self.assertEqual(2, len(instance_infos))
+        self.assertEqual(2, len(instance_infos['nearby']))
         self.assertEqual(self.i1.pk, instance_infos['nearby'][0]['id'])
         self.assertEqual(self.i3.pk, instance_infos['nearby'][1]['id'])
+
+        i5 = make_instance(is_public=True, point=Point(200, 200))
+
+        instance_infos = instances_closest_to_point(request, 0, 0)
+        self.assertEqual(3, len(instance_infos['nearby']))
+        self.assertEqual(self.i1.pk, instance_infos['nearby'][0]['id'])
+        self.assertEqual(i5.pk, instance_infos['nearby'][1]['id'])
+        self.assertEqual(self.i3.pk, instance_infos['nearby'][2]['id'])
 
         self.assertEqual(0, len(instance_infos['personal']))
 

--- a/opentreemap/importer/models/trees.py
+++ b/opentreemap/importer/models/trees.py
@@ -240,7 +240,7 @@ class TreeImportRow(GenericImportRow):
         p = Point(x, y, srid=4326)
         p.transform(3857)
 
-        if self.import_event.instance.bounds.contains(p):
+        if self.import_event.instance.bounds_obj.geom.contains(p):
             self.cleaned[fields.trees.POINT] = p
         else:
             self.append_error(errors.GEOM_OUT_OF_BOUNDS,

--- a/opentreemap/importer/tests.py
+++ b/opentreemap/importer/tests.py
@@ -25,7 +25,7 @@ from api.test_utils import setupTreemapEnv, mkPlot
 from treemap.json_field import set_attr_on_json_field
 from treemap.models import (Species, Plot, Tree, ITreeCodeOverride,
                             ITreeRegion, User)
-from treemap.instance import Instance
+from treemap.instance import Instance, InstanceBounds
 from treemap.tests import (make_admin_user, make_instance, login,
                            ecoservice_not_running)
 from treemap.udf import UserDefinedFieldDefinition
@@ -1049,7 +1049,8 @@ class TreeIntegrationTests(IntegrationTests):
                           (6000000, 6000000),
                           (6000000, -6000000),
                           (-6000000, -6000000)))
-        self.instance.bounds = MultiPolygon(square)
+        self.instance.bounds_obj = InstanceBounds.objects.create(
+            geom=MultiPolygon(square))
         self.instance.save()
 
         settings.DBH_TO_INCHES_FACTOR = 1.0

--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -158,7 +158,6 @@ class Instance(models.Model):
         'BenefitCurrencyConversion', null=True, blank=True)
 
     """ Center of the map when loading the instance """
-    bounds = models.MultiPolygonField(srid=3857)
     bounds_obj = models.OneToOneField(InstanceBounds,
                                       on_delete=models.CASCADE,
                                       null=True, blank=True)
@@ -272,7 +271,7 @@ class Instance(models.Model):
 
     @property
     def extent_as_json(self):
-        boundary = self.bounds.boundary
+        boundary = self.bounds_obj.geom.boundary
         xmin, ymin, xmax, ymax = boundary.extent
 
         return json.dumps({'xmin': xmin, 'ymin': ymin,
@@ -280,13 +279,13 @@ class Instance(models.Model):
 
     @property
     def bounds_as_geojson(self):
-        boundary = self.bounds
+        boundary = self.bounds_obj.geom
         boundary.transform(4326)
         return boundary.json
 
     @property
     def center(self):
-        return self.center_override or self.bounds.centroid
+        return self.center_override or self.bounds_obj.geom.centroid
 
     @property
     def geo_rev_hash(self):
@@ -443,7 +442,7 @@ class Instance(models.Model):
     def itree_regions(self, **extra_query):
         from treemap.models import ITreeRegion, ITreeRegionInMemory
 
-        query = {'geometry__intersects': self.bounds}
+        query = {'geometry__intersects': self.bounds_obj.geom}
         query.update(extra_query)
 
         if self.itree_region_default:

--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -89,6 +89,15 @@ def add_species_to_instance(instance):
     Species.objects.bulk_create(instance_species_list)
 
 
+class InstanceBounds(models.Model):
+    """ Center of the map when loading the instance """
+    geom = models.MultiPolygonField(srid=3857)
+    objects = models.GeoManager()
+
+    def __str__(self):
+        return "instance_id: %s" % self.instance.id
+
+
 class Instance(models.Model):
     """
     Each "Tree Map" is a single instance
@@ -150,6 +159,9 @@ class Instance(models.Model):
 
     """ Center of the map when loading the instance """
     bounds = models.MultiPolygonField(srid=3857)
+    bounds_obj = models.OneToOneField(InstanceBounds,
+                                      on_delete=models.CASCADE,
+                                      null=True, blank=True)
 
     """
     Override the center location (which is, by default,

--- a/opentreemap/treemap/management/commands/create_instance.py
+++ b/opentreemap/treemap/management/commands/create_instance.py
@@ -11,7 +11,8 @@ from django.db import transaction
 
 from django.contrib.gis.geos import MultiPolygon, Polygon, GEOSGeometry, Point
 
-from treemap.instance import (Instance, create_stewardship_udfs,
+from treemap.instance import (Instance, InstanceBounds,
+                              create_stewardship_udfs,
                               add_species_to_instance)
 from treemap.models import (Boundary, InstanceUser, User,
                             BenefitCurrencyConversion)
@@ -93,7 +94,7 @@ class Command(BaseCommand):
         instance = Instance(
             config={},
             name=name,
-            bounds=bounds,
+            bounds_obj=InstanceBounds.objects.create(geom=bounds),
             is_public=True,
             url_name=url_name)
 

--- a/opentreemap/treemap/migrations/0015_add_separate_instance_bounds_model.py
+++ b/opentreemap/treemap/migrations/0015_add_separate_instance_bounds_model.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.contrib.gis.db.models.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0014_change_empty_multichoice_values'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='InstanceBounds',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('geom', django.contrib.gis.db.models.fields.MultiPolygonField(srid=3857)),
+            ],
+        ),
+        migrations.AddField(
+            model_name='instance',
+            name='bounds_obj',
+            field=models.OneToOneField(null=True, blank=True, to='treemap.InstanceBounds'),
+        ),
+    ]

--- a/opentreemap/treemap/migrations/0016_make_bounds_nullable.py
+++ b/opentreemap/treemap/migrations/0016_make_bounds_nullable.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.contrib.gis.db.models.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0015_add_separate_instance_bounds_model'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='instance',
+            name='bounds',
+            field=django.contrib.gis.db.models.fields.MultiPolygonField(srid=3857, null=True, blank=True),
+        ),
+    ]

--- a/opentreemap/treemap/migrations/0017_copy_bounds_to_separate_model.py
+++ b/opentreemap/treemap/migrations/0017_copy_bounds_to_separate_model.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+def copy_bounds_to_separate_model(apps, schema_editor):
+    Instance = apps.get_model('treemap', 'Instance')
+    InstanceBounds = apps.get_model('treemap', 'InstanceBounds')
+
+    for instance in Instance.objects.all():
+        ib = InstanceBounds(geom=instance.bounds)
+        ib.save()
+        instance.bounds_obj = ib
+        instance.save()
+
+
+def copy_separate_model_to_bounds(apps, schema_editor):
+    Instance = apps.get_model('treemap', 'Instance')
+
+    for instance in Instance.objects.all():
+        ib = instance.bounds_obj
+        instance.bounds = ib.geom
+        instance.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0016_make_bounds_nullable'),
+    ]
+
+    operations = [
+        migrations.RunPython(copy_bounds_to_separate_model,
+                             reverse_code=copy_separate_model_to_bounds)
+    ]

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -610,7 +610,7 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
     def clean(self):
         super(MapFeature, self).clean()
 
-        if not self.instance.bounds.contains(self.geom):
+        if not self.instance.bounds_obj.geom.contains(self.geom):
             raise ValidationError({
                 "geom": [
                     _(

--- a/opentreemap/treemap/tests/__init__.py
+++ b/opentreemap/treemap/tests/__init__.py
@@ -23,7 +23,8 @@ from django.contrib.gis.geos import Point, Polygon, MultiPolygon
 from django.contrib.auth.models import AnonymousUser
 
 from treemap.models import (User, InstanceUser, Boundary, FieldPermission,
-                            Role, Instance)
+                            Role)
+from treemap.instance import Instance, InstanceBounds
 from treemap.audit import Authorizable, add_default_permissions
 from treemap.util import leaf_models_of_class
 from treemap.tests.base import OTMTestCase
@@ -275,7 +276,8 @@ def make_instance(name=None, is_public=False, url_name=None, point=None,
                       (p1.x + d, p1.y + d),
                       (p1.x + d, p1.y - d),
                       (p1.x - d, p1.y - d)))
-    instance.bounds = MultiPolygon((square,))
+    instance.bounds_obj = InstanceBounds.objects.create(
+        geom=MultiPolygon((square,)))
     instance.save()
 
     new_role = Role.objects.create(


### PR DESCRIPTION
connects #2399 on github

This changeset detaches bounds, which may be large, complicated geometries, from instances. This means that bounds objects will only be loaded when actually used. This results in a large importer speedup (~60%) for instances with complicated bounds. The speedup should affect most pages on the site, but may only be noticeable on large instances, if at all.

In order to test this PR, attempt to create a try and attempt the normal bounds operations for it: placing a tree out of bounds, finding nearby instances, etc.

These migrations are meant to gracefully support blue/green deployments. There will be a companion PR, one per repo, that makes another change, cumulatively completing the non-backward compatible change across two releases. When this PR is merged the other PR will be opened. When this PR is released, the other PR will then be merged to develop.