### PR TITLE
Support for super admin instance details

### DIFF
--- a/opentreemap/treemap/js/src/editableForm.js
+++ b/opentreemap/treemap/js/src/editableForm.js
@@ -100,7 +100,7 @@ exports.init = function(options) {
                     if ($(display).is('[data-value]')) {
                         $input = FH.getSerializableField($(editFields), field);
                         if ($input.is('[type="checkbox"]')) {
-                            value = $input.is(':checked') ? "True" : "False";
+                            value = $input.is(':checked') ? "Yes" : "No";
                         } else if ($input.is('[data-date-format]')) {
                             value = FH.getTimestampFromDatepicker($input);
                         } else if ($input.is('select[multiple]')) {

--- a/opentreemap/treemap/migrations/0015_instanceuser_last_seen.py
+++ b/opentreemap/treemap/migrations/0015_instanceuser_last_seen.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0014_change_empty_multichoice_values'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='instanceuser',
+            name='last_seen',
+            field=models.DateField(null=True, blank=True),
+        ),
+    ]

--- a/opentreemap/treemap/migrations/0018_merge.py
+++ b/opentreemap/treemap/migrations/0018_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0017_copy_bounds_to_separate_model'),
+        ('treemap', '0015_instanceuser_last_seen'),
+    ]
+
+    operations = [
+    ]

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -507,6 +507,11 @@ class InstanceUser(Auditable, models.Model):
     role = models.ForeignKey(Role)
     reputation = models.IntegerField(default=0)
     admin = models.BooleanField(default=False)
+    last_seen = models.DateField(null=True, blank=True)
+
+    def __init__(self, *args, **kwargs):
+        super(InstanceUser, self).__init__(*args, **kwargs)
+        self._do_not_track.add('last_seen')
 
     class Meta:
         unique_together = ('instance', 'user',)

--- a/opentreemap/treemap/templates/treemap/field/readonly.html
+++ b/opentreemap/treemap/templates/treemap/field/readonly.html
@@ -1,0 +1,6 @@
+<div class="form-group">
+    <label>{{ label }}</label>
+    <div class="field-view">
+        {{ value }}
+    </div>
+</div>

--- a/opentreemap/treemap/templatetags/form_extras.py
+++ b/opentreemap/treemap/templatetags/form_extras.py
@@ -393,6 +393,10 @@ class AbstractNode(template.Node):
             # there's no meaningful intermediate value to send
             # without rendering the same markup server-side.
             display_val = None
+        elif choices:
+            display_vals = [choice['display_value'] for choice in choices
+                            if choice['value'] == field_value]
+            display_val = display_vals[0] if display_vals else field_value
         else:
             display_val = unicode(field_value)
 

--- a/opentreemap/treemap/templatetags/form_extras.py
+++ b/opentreemap/treemap/templatetags/form_extras.py
@@ -377,12 +377,10 @@ class AbstractNode(template.Node):
 
         if field_value is None:
             display_val = None
-        elif data_type == 'date' and model.instance:
-            display_val = dateformat.format(field_value,
-                                            model.instance.short_date_format)
-        elif data_type == 'date':
-            display_val = dateformat.format(field_value,
-                                            settings.SHORT_DATE_FORMAT)
+        elif data_type in ['date', 'datetime']:
+            fmt = (model.instance.short_date_format if model.instance
+                   else settings.SHORT_DATE_FORMAT)
+            display_val = dateformat.format(field_value, fmt)
         elif is_convertible_or_formattable(object_name, field_name):
             display_val = format_value(
                 model.instance, object_name, field_name, field_value)


### PR DESCRIPTION
* Add and maintain `InstanceUser.last_seen` date
* Add template for showing read-only fields in an inline edit form
* Simplify code in `form_extras.py`
* Use "Yes/No" instead of "True/False" for default boolean display value
  This matches the server-side display values used in `form_extras.py`
* Make the display value of a choice field the choice's display value

Connects OpenTreeMap/otm-addons#1035