### PR TITLE
Rename instance.bounds_obj

### DIFF
--- a/opentreemap/api/instance.py
+++ b/opentreemap/api/instance.py
@@ -125,7 +125,7 @@ def instances_closest_to_point(request, lat, lng):
         results = []
         for instance in instances:
             instance_info = _instance_info_dict(instance)
-            d = D(m=point.distance(instance.bounds_obj.geom)).km
+            d = D(m=point.distance(instance.bounds.geom)).km
             instance_info['distance'] = d
             results.append(instance_info)
         return sorted(results, key=itemgetter('distance'))
@@ -134,7 +134,7 @@ def instances_closest_to_point(request, lat, lng):
         'nearby': get_annotated_contexts(
             instances
             .filter(is_public=True)
-            .filter(bounds_obj__geom__distance_lte=(
+            .filter(bounds__geom__distance_lte=(
                 point, D(m=distance)))
             .exclude(personal_predicate)
             [0:max_instances]),
@@ -273,7 +273,7 @@ def _contextify_instances(instances):
 def _instance_info_dict(instance):
     center = instance.center
     center.transform(4326)
-    bounds = instance.bounds_obj.geom
+    bounds = instance.bounds.geom
     bounds.transform(4326)
     extent = bounds.extent
     p1 = Point(float(extent[0]), float(extent[1]), srid=4326)

--- a/opentreemap/importer/models/trees.py
+++ b/opentreemap/importer/models/trees.py
@@ -241,7 +241,7 @@ class TreeImportRow(GenericImportRow):
         p = Point(x, y, srid=4326)
         p.transform(3857)
 
-        if self.import_event.instance.bounds_obj.geom.contains(p):
+        if self.import_event.instance.bounds.geom.contains(p):
             self.cleaned[fields.trees.POINT] = p
         else:
             self.append_error(errors.GEOM_OUT_OF_BOUNDS,

--- a/opentreemap/importer/tests.py
+++ b/opentreemap/importer/tests.py
@@ -1048,7 +1048,7 @@ class TreeIntegrationTests(IntegrationTests):
                           (6000000, 6000000),
                           (6000000, -6000000),
                           (-6000000, -6000000)))
-        self.instance.bounds_obj = InstanceBounds.objects.create(
+        self.instance.bounds = InstanceBounds.objects.create(
             geom=MultiPolygon(square))
         self.instance.save()
 

--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -158,9 +158,9 @@ class Instance(models.Model):
         'BenefitCurrencyConversion', null=True, blank=True)
 
     """ Center of the map when loading the instance """
-    bounds_obj = models.OneToOneField(InstanceBounds,
-                                      on_delete=models.CASCADE,
-                                      null=True, blank=True)
+    bounds = models.OneToOneField(InstanceBounds,
+                                  on_delete=models.CASCADE,
+                                  null=True, blank=True)
 
     """
     Override the center location (which is, by default,
@@ -271,7 +271,7 @@ class Instance(models.Model):
 
     @property
     def extent_as_json(self):
-        boundary = self.bounds_obj.geom.boundary
+        boundary = self.bounds.geom.boundary
         xmin, ymin, xmax, ymax = boundary.extent
 
         return json.dumps({'xmin': xmin, 'ymin': ymin,
@@ -279,13 +279,13 @@ class Instance(models.Model):
 
     @property
     def bounds_as_geojson(self):
-        boundary = self.bounds_obj.geom
+        boundary = self.bounds.geom
         boundary.transform(4326)
         return boundary.json
 
     @property
     def center(self):
-        return self.center_override or self.bounds_obj.geom.centroid
+        return self.center_override or self.bounds.geom.centroid
 
     @property
     def geo_rev_hash(self):
@@ -442,7 +442,7 @@ class Instance(models.Model):
     def itree_regions(self, **extra_query):
         from treemap.models import ITreeRegion, ITreeRegionInMemory
 
-        query = {'geometry__intersects': self.bounds_obj.geom}
+        query = {'geometry__intersects': self.bounds.geom}
         query.update(extra_query)
 
         if self.itree_region_default:

--- a/opentreemap/treemap/management/commands/create_instance.py
+++ b/opentreemap/treemap/management/commands/create_instance.py
@@ -94,7 +94,7 @@ class Command(BaseCommand):
         instance = Instance(
             config={},
             name=name,
-            bounds_obj=InstanceBounds.objects.create(geom=bounds),
+            bounds=InstanceBounds.objects.create(geom=bounds),
             is_public=True,
             url_name=url_name)
 

--- a/opentreemap/treemap/migrations/0020_remove_instance_bounds.py
+++ b/opentreemap/treemap/migrations/0020_remove_instance_bounds.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0019_merge'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='instance',
+            name='bounds',
+        ),
+    ]

--- a/opentreemap/treemap/migrations/0021_rename_bounds_obj_to_bounds.py
+++ b/opentreemap/treemap/migrations/0021_rename_bounds_obj_to_bounds.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0020_remove_instance_bounds'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='instance',
+            old_name='bounds_obj',
+            new_name='bounds',
+        ),
+    ]

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -616,7 +616,7 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
     def clean(self):
         super(MapFeature, self).clean()
 
-        if not self.instance.bounds_obj.geom.contains(self.geom):
+        if not self.instance.bounds.geom.contains(self.geom):
             raise ValidationError({
                 "geom": [
                     _(

--- a/opentreemap/treemap/tests/__init__.py
+++ b/opentreemap/treemap/tests/__init__.py
@@ -276,7 +276,7 @@ def make_instance(name=None, is_public=False, url_name=None, point=None,
                       (p1.x + d, p1.y + d),
                       (p1.x + d, p1.y - d),
                       (p1.x - d, p1.y - d)))
-    instance.bounds_obj = InstanceBounds.objects.create(
+    instance.bounds = InstanceBounds.objects.create(
         geom=MultiPolygon((square,)))
     instance.save()
 


### PR DESCRIPTION
As part of a multiple commit, blue-green safe migration, instance.bounds
has been replaced with a one-to-one foreign key, bounds_obj, which is
now being renamed to bounds. Effectively, this "moves" instance.bounds
to another table.

See the commits on
https://github.com/OpenTreeMap/otm-core/commit/600f163eb0963e45cf0513515bb0d98e45077082
for more details.