### PR TITLE
Make Street View show what you want to see

### DIFF
--- a/opentreemap/treemap/js/src/streetView.js
+++ b/opentreemap/treemap/js/src/streetView.js
@@ -31,15 +31,23 @@ exports.create = function(options) {
             if (status == google.maps.StreetViewStatus.OK) {
                 if (panorama === null) {
                     panorama = new google.maps.StreetViewPanorama(div, {
-                        position:pos,
+                        position: pos,
                         addressControl: showAddress,
                         panControl: false,
                     });
                 } else {
                     panorama.setPosition(pos);
                 }
-            }
-            else {
+                if (data !== null) {
+                    // Show specified location ("pos") in the view by computing
+                    // the angle ("heading") of a line from the camera location to "pos".
+                    var cameraPos = data.location.latLng,
+                        heading = google.maps.geometry.spherical.computeHeading(cameraPos, pos),
+                        pov = panorama.getPov();
+                    pov.heading = heading;
+                    panorama.setPov(pov);
+                }
+            } else {
                 panorama = null;
                 $(div).html(options.noStreetViewText || '');
             }


### PR DESCRIPTION
Using camera location of Street View image along with tree location, set panorama heading so you're looking at the tree.

To test:
* Find a place you're familiar with, that has trees, on some tree map
* Select a tree and "View All Details" -- Street View should be pointing at the tree
* Click another nearby tree -- Street View should point to it

Or:
* Find a place you're familiar with, that has trees, on some tree map
* Click "Add a Tree"
* Place the marker (Street View appears)
* Move the marker to different places on the street -- Street View should point to it