### PR TITLE
Add coarse values to importer rate limiting

### DIFF
--- a/opentreemap/importer/tasks.py
+++ b/opentreemap/importer/tasks.py
@@ -119,7 +119,7 @@ def run_import_event_validation(import_type, import_event_id, file_obj):
         return
 
 
-@task()
+@task(rate_limit=settings.IMPORT_VALIDATION_RATE_LIMIT)
 def _validate_rows(import_type, import_event_id, start_row_id):
     ie = _get_import_event(import_type, import_event_id)
     rows = ie.rows()[start_row_id:(start_row_id+settings.IMPORT_BATCH_SIZE)]

--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -342,7 +342,8 @@ DOUBLE_CLICK_INTERVAL = 300
 IMPORT_BATCH_SIZE = 85
 
 # The rate limit for how frequently batches of imports can happen per worker
-IMPORT_COMMIT_RATE_LIMIT = "1/m"
+IMPORT_COMMIT_RATE_LIMIT = "5/m"
+IMPORT_VALIDATION_RATE_LIMIT = "10/m"
 
 # We have... issues on IE9 right now
 # Disable it on production, but enable it in Debug mode


### PR DESCRIPTION
addresses #2451 on github

This changeset introduces rate limiting for validation and provides a coarse starting point for rate limiting values we will want to use in production. These values will be revisited after testing in our staging environment.