### PR TITLE
Revert "Add coarse values to importer rate limiting"

### DIFF
--- a/opentreemap/importer/tasks.py
+++ b/opentreemap/importer/tasks.py
@@ -119,7 +119,7 @@ def run_import_event_validation(import_type, import_event_id, file_obj):
         return
 
 
-@task(rate_limit=settings.IMPORT_VALIDATION_RATE_LIMIT)
+@task()
 def _validate_rows(import_type, import_event_id, start_row_id):
     ie = _get_import_event(import_type, import_event_id)
     rows = ie.rows()[start_row_id:(start_row_id+settings.IMPORT_BATCH_SIZE)]

--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -342,8 +342,7 @@ DOUBLE_CLICK_INTERVAL = 300
 IMPORT_BATCH_SIZE = 85
 
 # The rate limit for how frequently batches of imports can happen per worker
-IMPORT_COMMIT_RATE_LIMIT = "5/m"
-IMPORT_VALIDATION_RATE_LIMIT = "10/m"
+IMPORT_COMMIT_RATE_LIMIT = "1/m"
 
 # We have... issues on IE9 right now
 # Disable it on production, but enable it in Debug mode


### PR DESCRIPTION
Reverts OpenTreeMap/otm-core#2483

We decided that it would be simpler to leave these new values off master until they've been tested against a production-like deployment stack. We also seek to create a release branch without these new values and reverting these commits makes this simpler.