### PR TITLE
Clear typeaheads when switching out of add tree mode

### DIFF
--- a/opentreemap/treemap/js/src/addMapFeature.js
+++ b/opentreemap/treemap/js/src/addMapFeature.js
@@ -19,6 +19,7 @@ function init(options) {
         mapManager = options.mapManager,
         plotMarker = options.plotMarker,
         onClose = options.onClose || $.noop,
+        clearChildEditControls = options.clearEditControls || $.noop,
         sidebar = options.sidebar,
         $sidebar = $(sidebar),
         formSelector = options.formSelector,
@@ -83,7 +84,6 @@ function init(options) {
     deactivateBus.onValue(function () {
         // Hide/deactivate/clear everything
         plotMarker.hide();
-        $addressInput.val("");
         clearEditControls();
     });
 
@@ -119,7 +119,7 @@ function init(options) {
             displayedResults: sidebar + ' [data-class="geocode-result"]'
         });
 
-    otmTypeahead.create({
+    var addressTypeahead = otmTypeahead.create({
         input: addressInput,
         geocoder: true,
         geocoderBbox: config.instance.extent
@@ -316,6 +316,9 @@ function init(options) {
     }
 
     function clearEditControls() {
+        clearChildEditControls();
+
+        addressTypeahead.clear();
         $(editFields).find('input,select').each(function () {
             var $control = $(this),
                 type = $control.prop('type');

--- a/opentreemap/treemap/js/src/addTreeMode.js
+++ b/opentreemap/treemap/js/src/addTreeMode.js
@@ -14,13 +14,17 @@ var activateMode = _.identity,
     STEP_FINAL = 2;
 
 function init(options) {
-    var manager = addMapFeature.init(options),
-        plotMarker = options.plotMarker,
+    var plotMarker = options.plotMarker,
         $sidebar = $(options.sidebar),
         $speciesTypeahead = U.$find('#add-tree-species-typeahead', $sidebar),
         $speciesInput = U.$find('[data-typeahead-input="tree.species"]', $sidebar),
         $summaryHead = U.$find('.summaryHead', $sidebar),
-        $summarySubhead = U.$find('.summarySubhead', $sidebar);
+        $summarySubhead = U.$find('.summarySubhead', $sidebar),
+        typeahead = otmTypeahead.create(options.typeahead),
+        clearEditControls = function() {
+            typeahead.clear();
+        },
+        manager = addMapFeature.init(_.extend({clearEditControls: clearEditControls}, options));
 
     activateMode = function() {
         manager.activate();
@@ -29,9 +33,10 @@ function init(options) {
         plotMarker.enablePlacing();
     };
 
-    deactivateMode = manager.deactivate;
-
-    otmTypeahead.bulkCreate(options.typeaheads);
+    deactivateMode = function() {
+        typeahead.clear();
+        manager.deactivate();
+    };
 
     diameterCalculator({ formSelector: options.formSelector,
                          cancelStream: manager.deactivateStream,

--- a/opentreemap/treemap/js/src/otmTypeahead.js
+++ b/opentreemap/treemap/js/src/otmTypeahead.js
@@ -181,7 +181,7 @@ var create = exports.create = function(options) {
         backspaceOrDeleteStream = $input.asEventStream('keyup')
                                         .filter(BU.keyCodeIs([8, 46])),
 
-        editStream = selectStream.merge(backspaceOrDeleteStream.map(undefined)).skipDuplicates(),
+        editStream = selectStream.merge(backspaceOrDeleteStream.map(undefined)),
 
         idStream = selectStream.map(".id")
                                .merge(backspaceOrDeleteStream.map(""));
@@ -262,6 +262,19 @@ var create = exports.create = function(options) {
             }
         });
     }
+
+    return {
+        getDatum: function() {
+            return exports.getDatum($input);
+        },
+        clear: function() {
+            $input.typeahead('val', '');
+            $input.removeData('datum');
+            if (options.hidden) {
+                $hidden_input.val('');
+            }
+        }
+    };
 };
 
 exports.bulkCreate = function (typeaheads) {

--- a/opentreemap/treemap/js/src/treeMapModes.js
+++ b/opentreemap/treemap/js/src/treeMapModes.js
@@ -135,7 +135,7 @@ function init(config, mapManager, triggerSearchBus) {
         formSelector: '#add-tree-form',
         validationFields: '#add-tree-container [data-class="error"]',
         indexOfSetLocationStep: 0,
-        typeaheads: [getSpeciesTypeaheadOptions(config, "add-tree-species")],
+        typeahead: getSpeciesTypeaheadOptions(config, "add-tree-species"),
         addFeatureRadioOptions: 'addFeatureOptions',
         triggerSearchBus: triggerSearchBus
     });


### PR DESCRIPTION
Fixes an issue where when selecting a species or address after having
already added a tree, the only results shown would be for the tree
previously added.

By explicitly clearing the typeahead when deactivating add tree mode or
clearing edit controls, the problem is fixed.

Connects to #1025