### PR TITLE
Add support for emitting Celery metrics via signals

### DIFF
--- a/opentreemap/opentreemap/celery.py
+++ b/opentreemap/opentreemap/celery.py
@@ -7,6 +7,8 @@ import rollbar
 from celery import Celery
 from celery.signals import task_failure
 
+from django_statsd.celery import register_celery_events
+
 from django.conf import settings
 
 # set the default Django settings module for the 'celery' program.
@@ -19,6 +21,9 @@ app = Celery('opentreemap')
 # pickle the object when using Windows.
 app.config_from_object('django.conf:settings')
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+
+if getattr(settings, 'STATSD_CELERY_SIGNALS', False):
+    register_celery_events()
 
 rollbar_settings = getattr(settings, 'ROLLBAR', {})
 access_token = rollbar_settings.get('access_token')

--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -230,6 +230,12 @@ if ROLLBAR_ACCESS_TOKEN is not None:
     MIDDLEWARE_CLASSES += (
         'rollbar.contrib.django.middleware.RollbarNotifierMiddleware',)
 
+# Settings for StatsD metrics aggregation
+STATSD_CLIENT = 'django_statsd.clients.normal'
+STATSD_PREFIX = '{}.django'.format(STACK_TYPE.lower())
+STATSD_HOST = os.environ.get('OTM_STATSD_HOST', 'localhost')
+STATSD_CELERY_SIGNALS = True
+
 ROOT_URLCONF = 'opentreemap.urls'
 
 # Python dotted path to the WSGI application used by Django's runserver.

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,3 +29,4 @@ django-url-tools==0.0.8
 django-redis==4.3.0
 hiredis==0.2.0
 rollbar==0.11.1
+django-statsd-mozilla==0.3.16


### PR DESCRIPTION
Piggybacking on the existing Celery support, start emitting a variety of metrics for the following lifecycle events by registering with their signals:

- `on_task_sent` (counter)
- `on_task_prerun` (counter, timer)
- `on_task_postrun` (counter, timer)
- `on_task_failure` (counter)

See also: https://github.com/django-statsd/django-statsd/blob/0.3.16/django_statsd/celery.py

---

**Testing**

Provision the `app` virtual machine and then set the following two settings in `/etc/statsite/statsite.cfg`:

```
flush_interval = 10
stream_cmd = /usr/bin/logger
```

Finally, restart the `statsite` service and tail `syslog` for relevant metrics when performing some operation that exercises Celery:

```bash
vagrant@app:~$ sudo restart statsite
vagrant@app:~$ sudo tail -f /var/log/syslog | grep logger
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: counts.django.celery.exporter.tasks.async_csv_export.start|1.000000|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.sum|72.000000|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.sum_sq|5184.000000|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.mean|72.000000|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.lower|72.000000|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.upper|72.000000|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.count|1|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.stdev|0.000000|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.median|72.000000|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.p50|72.000000|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.p95|72.000000|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.p99|72.000000|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.rate|7.200000|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.sample_rate|0.100000|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.histogram.bin_<0.00|0|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.histogram.bin_0.00|0|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.histogram.bin_20.00|0|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.histogram.bin_40.00|0|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.histogram.bin_60.00|1|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.histogram.bin_80.00|0|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.histogram.bin_100.00|0|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.histogram.bin_120.00|0|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.histogram.bin_140.00|0|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.histogram.bin_160.00|0|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.histogram.bin_180.00|0|1455133734
Feb 10 19:48:54 vagrant-ubuntu-trusty-64 logger: timers.django.celery.exporter.tasks.async_csv_export.runtime.histogram.bin_>200.00|0|1455133734
```