### PR TITLE
Conditionally disable collection UDF date search fields

### DIFF
--- a/opentreemap/treemap/js/src/udfcSearch.js
+++ b/opentreemap/treemap/js/src/udfcSearch.js
@@ -109,10 +109,10 @@ function resetType(widgetName, optionKey, state) {
     resetSelectWidget(widgetName, optionKey, state);
     var $el = $(widgets.type.selector),
         shouldEnable = !_.isNull(state.modelName);
-    enableDropdown($el, shouldEnable);
+    enableInput($el, shouldEnable);
 }
 
-function enableDropdown($el, shouldEnable) {
+function enableInput($el, shouldEnable) {
     $el.prop('disabled', shouldEnable ? false : 'disabled');
 }
 
@@ -142,7 +142,7 @@ function resetAction(state) {
             .filter(typeSelector)
             .appendTo($el);
     }
-    enableDropdown($el, shouldEnable);
+    enableInput($el, shouldEnable);
 
     $el = $(widgets.action.selector);
     if (!_.isNull(state.action)) {
@@ -158,15 +158,19 @@ function resetDateBox(widgetName, state) {
         $widget = $(widgets[widgetName].selector),
         longDate = moment(state[widgetName], DATETIME_FORMAT),
         shortDate = moment(state[widgetName], 'MM/DD/YYYY'),
+        shouldEnable = !_.isNull(state.modelName) && !_.isNull(state.type),
         val;
 
-    if (!_.isNull(longDate) && longDate.isValid()) {
-        val = longDate.format('MM/DD/YYYY');
-    } else if (!_.isNull(shortDate) && shortDate.isValid()) {
-        val = shortDate.format('MM/DD/YYYY');
-    } else {
-        val = '';
+    if (shouldEnable) {
+        if (!_.isNull(longDate) && longDate.isValid()) {
+            val = longDate.format('MM/DD/YYYY');
+        } else if (!_.isNull(shortDate) && shortDate.isValid()) {
+            val = shortDate.format('MM/DD/YYYY');
+        } else {
+            val = '';
+        }
     }
+    enableInput($widget, shouldEnable);
 
     $widget.attr('name', name);
     $widget.val(val);


### PR DESCRIPTION
The advanced search UI was allowing the selection of a date range for stewardship/alerts without selecting a type of either stewardship or alert. We don't support searching across collection UDF types, so this resulted in the code generating invalid filter query strings.

This commit addresses the issue by following the existing patterns in `udfcSearch.js` and disabling the date fields until both a model and a CUDF type have been selected.

##### Testing

The date fields at the end of the "Tree Care" section of the advanced search bar should be disabled until values have been selected from the first two dropdowns.

<img width="970" alt="screen shot 2016-02-12 at 11 38 28 am" src="https://cloud.githubusercontent.com/assets/17363/13016652/515b3808-d17d-11e5-8f77-2358aba9ba78.png">

<img width="971" alt="screen shot 2016-02-12 at 11 38 39 am" src="https://cloud.githubusercontent.com/assets/17363/13016663/5d20b8a2-d17d-11e5-892c-c866afcc97ec.png">


---

Connects to #2497 