### PR TITLE
Revise eco error message logging

### DIFF
--- a/opentreemap/opentreemap/util.py
+++ b/opentreemap/opentreemap/util.py
@@ -114,8 +114,8 @@ def get_ids_from_request(request):
         return []
 
 
-def add_rollbar_handler(logger):
+def add_rollbar_handler(logger, level=logging.WARNING):
     if settings.ROLLBAR_ACCESS_TOKEN is not None:
         rollbar_handler = RollbarHandler()
-        rollbar_handler.setLevel(logging.WARNING)
+        rollbar_handler.setLevel(level)
         logger.addHandler(rollbar_handler)

--- a/opentreemap/treemap/lib/map_feature.py
+++ b/opentreemap/treemap/lib/map_feature.py
@@ -15,7 +15,7 @@ from django.utils.translation import ugettext as _
 from django.db.models import Q
 
 from treemap.audit import Audit
-from treemap.ecobackend import ECOBENEFIT_ERRORS
+from treemap.ecobackend import ECOBENEFIT_FAILURE_CODES_AND_PATTERNS
 from treemap.lib import execute_sql
 from treemap.models import Tree, MapFeature, User, Favorite
 
@@ -79,12 +79,12 @@ def _map_feature_audits(user, instance, feature, filters=None,
 def _add_eco_benefits_to_context_dict(instance, feature, context):
     FeatureClass = feature.__class__
 
-    benefits, basis, error = FeatureClass.benefits\
-                                         .benefits_for_object(
-                                             instance, feature)
+    benefits, basis, failure_code = FeatureClass.benefits\
+                                                .benefits_for_object(
+                                                    instance, feature)
 
-    if error in ECOBENEFIT_ERRORS:
-        context[error] = True
+    if failure_code in ECOBENEFIT_FAILURE_CODES_AND_PATTERNS:
+        context[failure_code] = True
     elif benefits:
         context.update(format_benefits(instance, benefits, basis))
 

--- a/opentreemap/treemap/templates/treemap/partials/plot_eco.html
+++ b/opentreemap/treemap/templates/treemap/partials/plot_eco.html
@@ -6,7 +6,7 @@
       <p>Ecosystem benefits cannot be calculated for this species of tree in this location.</p>
       <p>The tree's location falls within a climate region that does not support benefit calculations for this species.</p>
       {% endblocktrans %}
-  {% elif unknown_ecobenefit_error %}
+  {% elif incomplete_eco_data or unknown_eco_failure %}
       {% blocktrans %}
       <!-- TODO: When the ecoservice returns structured errors, replace this with real conditions -->
       <!-- Or, maybe always leave this to avoid 500s -->


### PR DESCRIPTION
Failing to calculate the ecobenefits for a tree for reasons like the species not having a i-Tree code defined for a given i-Tree region is a regular occurrence in production. This commit attempts to makes it easier for a log aggregator to combine similar failures and reduces the severity level of commonplace failures to "info" so they do not drown out more concerning warning and error messages.

Unexpected failures not related to the species and region configuration are now logged as errors because we want to see and address those issues quickly.

##### Testing

When looking at Rollbar, make sure you turn on all event types and sources so that info messages from the development environment appear in the list

<img width="637" alt="screen shot 2016-02-16 at 11 26 59 am" src="https://cloud.githubusercontent.com/assets/17363/13086410/593eb754-d4a0-11e5-8d55-b634ef2f4391.png">

Because this feature is all about how the text messages returned from the ecoservice are converted into log messages, the best way to test this is to mock the responses. Apply this diff to `ecobackend.py` to test how the different message types are logged.

```diff
diff --git a/opentreemap/treemap/ecobackend.py b/opentreemap/treemap/ecobackend.py
index 37b8471..7a5ba6b 100644
--- a/opentreemap/treemap/ecobackend.py
+++ b/opentreemap/treemap/ecobackend.py
@@ -119,7 +119,23 @@ def json_benefits_call(endpoint, params, post=False, convert_params=True):
     general_unhandled_struct = (None, UNKNOWN_ECO_FAILURE)
 
     try:
-        return (json.loads(urllib2.urlopen(req).read()), None)
+        class MockFP():
+            def __init__(self, msg):
+                self.readline = ''
+                self.msg = msg
+
+            def read(self):
+                return self.msg
+
+        message = 'iTree code not found for otmcode ABCD in region NMtnPrFNL\n'
+        # message = 'There are overrides defined for instance 999999 in the TESTRegion region but not for species ID 9999999'
+        # message = 'Species data not found for the TESTRegion region'
+        # message = 'There are overrides defined for the instance, but not for the TESTRegion region'
+        # message = 'Missing or invalid FOO parameter'
+        raise urllib2.HTTPError('http://example.com', 500, '', {},
+                                MockFP(message))
+
+        #return (json.loads(urllib2.urlopen(req).read()), None)
     except urllib2.HTTPError as e:
         error_body = e.fp.read()
         for code, patterns in ECOBENEFIT_FAILURE_CODES_AND_PATTERNS.items():
```

---

Connects to #2496 