### PR TITLE
Support ESRI basemaps

### DIFF
--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -125,6 +125,7 @@ class Instance(models.Model):
     basemap_type = models.CharField(max_length=255,
                                     choices=(("google", "Google"),
                                              ("bing", "Bing"),
+                                             ("esri", "ESRI"),
                                              ("tms", "Tile Map Service")),
                                     default="google")
     basemap_data = models.CharField(max_length=255, null=True, blank=True)

--- a/opentreemap/treemap/js/src/boundarySelect.js
+++ b/opentreemap/treemap/js/src/boundarySelect.js
@@ -3,7 +3,8 @@
 var $ = require('jquery'),
     BU = require('treemap/baconUtils'),
     _ = require('lodash'),
-    L = require('leaflet');
+    L = require('leaflet'),
+    layersLib = require('treemap/layers');
 
 var boundaryUrlTemplate = _.template('<%= instanceUrl %>boundaries/<%= boundaryId %>/geojson/');
 var currentLayer = null;
@@ -23,9 +24,9 @@ function showBoundaryGeomOnMapLayerAndZoom(map, boundaryGeom) {
     // so our only choice is to set the z-index of the entire overlay pane.
     // That's not great since we might want other polygons on the map,
     // *above* the plot tiles.
-    // TODO: When we switch to Leaflet 0.8, make a separate pane to contain
+    // TODO: When we switch to Leaflet 1.0, make a separate pane to contain
     // the boundary polygon, with a permanent z-index.
-    map.getPanes().overlayPane.style.zIndex = -2;
+    map.getPanes().overlayPane.style.zIndex = layersLib.OVERLAY_PANE_Z_INDEX;
 
     currentLayer = boundaryGeom;
 

--- a/opentreemap/treemap/js/src/layers.js
+++ b/opentreemap/treemap/js/src/layers.js
@@ -9,7 +9,12 @@ var $ = require("jquery"),
 
     MAX_ZOOM_OPTION = exports.MAX_ZOOM_OPTION = {maxZoom: 21},
     // Min zoom level for detail layers
-    MIN_ZOOM_OPTION = exports.MIN_ZOOM_OPTION = {minZoom: 15};
+    MIN_ZOOM_OPTION = exports.MIN_ZOOM_OPTION = {minZoom: 15},
+
+    BASE_LAYER_OPTION = exports.BASE_LAYER_OPTION = {zIndex: 0},
+    BOUNDARY_LAYER_OPTION = {zIndex: 1},
+    OVERLAY_PANE_Z_INDEX = exports.OVERLAY_PANE_Z_INDEX = 2,
+    FEATURE_LAYER_OPTION = {zIndex: 3};
 
 ////////////////////////////////////////////////
 // public functions
@@ -20,17 +25,18 @@ exports.createBoundariesTileLayer = function (config) {
     // safe to use the same url permanently.
     var revToUrl = getUrlMaker(config, 'treemap_boundary', 'png'),
         url = revToUrl(config.instance.geoRevHash),
-        options = _.extend({}, MAX_ZOOM_OPTION, MIN_ZOOM_OPTION);
+        options = _.extend({}, MAX_ZOOM_OPTION, MIN_ZOOM_OPTION, BOUNDARY_LAYER_OPTION);
     return L.tileLayer(url, options);
 };
 
 exports.createPlotTileLayer = function (config) {
+    var options = _.extend({}, MAX_ZOOM_OPTION, FEATURE_LAYER_OPTION);
     return filterableLayer(
-        'treemap_mapfeature', 'png', config, MAX_ZOOM_OPTION);
+        'treemap_mapfeature', 'png', config, options);
 };
 
 exports.createPolygonTileLayer = function (config) {
-    var options = _.extend({}, MAX_ZOOM_OPTION, MIN_ZOOM_OPTION);
+    var options = _.extend({}, MAX_ZOOM_OPTION, MIN_ZOOM_OPTION, FEATURE_LAYER_OPTION);
     return filterableLayer(
         'stormwater_polygonalmapfeature', 'png', config, options);
 };
@@ -40,7 +46,7 @@ exports.createPlotUTFLayer = function (config) {
         revToUrl = getUrlMaker(
             config, 'treemap_mapfeature', 'grid.json'),
         url = revToUrl(config.instance.geoRevHash),
-        options = _.extend({resolution: 4}, MAX_ZOOM_OPTION);
+        options = _.extend({resolution: 4}, MAX_ZOOM_OPTION, FEATURE_LAYER_OPTION);
 
     // Need to use JSONP on on browsers that do not support CORS (IE9)
     // Only applies to plot layer because only UtfGrid is using XmlHttpRequest

--- a/opentreemap/treemap/migrations/0022_add_esri_basemap_type_choice.py
+++ b/opentreemap/treemap/migrations/0022_add_esri_basemap_type_choice.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0021_rename_bounds_obj_to_bounds'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='instance',
+            name='basemap_type',
+            field=models.CharField(default='google', max_length=255, choices=[('google', 'Google'), ('bing', 'Bing'), ('esri', 'ESRI'), ('tms', 'Tile Map Service')]),
+        ),
+    ]

--- a/opentreemap/treemap/migrations/0023_merge.py
+++ b/opentreemap/treemap/migrations/0023_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0022_remove_null_from_eco_rev'),
+        ('treemap', '0022_add_esri_basemap_type_choice'),
+    ]
+
+    operations = [
+    ]

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "baconjs": "~0.6",
     "console-browserify": "~1.0.1",
     "dragula": "^2.0.2",
+    "esri-leaflet": "~1.0.2",
     "leaflet-pip": "~0.1.1",
     "lodash": "2.4.x",
     "moment": "~2.2.1",


### PR DESCRIPTION
`esri-leaflet` makes it easy.

But note that including `esri-leaflet` increases our JS download by 56K (6%). Once we switch to Leaflet 1.0 we can reduce that greatly using https://github.com/esri/esri-leaflet-bundler to grab just the basemap layer code.

For the default basemap I chose ESRI "Topographic" because i thought it looked better for a treemap than "Streets".

Google:
![image](https://cloud.githubusercontent.com/assets/2162993/13115135/97f42244-d564-11e5-8650-65cabd4b99dd.png)

ESRI Streets:
![image](https://cloud.githubusercontent.com/assets/2162993/13115206/dc1a56e6-d564-11e5-9b02-96f83eb0096f.png)

ESRI Topographic:
![image](https://cloud.githubusercontent.com/assets/2162993/13115093/7194ca90-d564-11e5-8906-930b03361b52.png)

#### Testing

Change your favorite instance to use ESRI basemaps via the Django shell:
```
manage.py shell_plus
i = Instance.objects.get(url_name='...')
i.basemap_type = 'esri'
i.save()
```

Connects OpenTreeMap/otm-addons#1079