### PR TITLE
Reduce transaction scope and heartbeat frequency

### DIFF
--- a/opentreemap/importer/models/species.py
+++ b/opentreemap/importer/models/species.py
@@ -312,7 +312,6 @@ class SpeciesImportRow(GenericImportRow):
             self.status = SpeciesImportRow.VERIFIED
 
         self.save()
-        self.import_event.update_progress_timestamp_and_save()
         return not fatal
 
     def _prepare_merge_data(self):
@@ -419,5 +418,4 @@ class SpeciesImportRow(GenericImportRow):
 
         self.species = species
         self.status = SpeciesImportRow.SUCCESS
-        self.import_event.update_progress_timestamp_and_save()
         self.save()

--- a/opentreemap/importer/models/trees.py
+++ b/opentreemap/importer/models/trees.py
@@ -101,7 +101,6 @@ class TreeImportRow(GenericImportRow):
     def model_fields(self):
         return fields.trees
 
-    @transaction.atomic
     def commit_row(self):
         is_valid = self.validate_row()
 
@@ -141,8 +140,11 @@ class TreeImportRow(GenericImportRow):
         else:
             plot = Plot(instance=self.import_event.instance)
 
-        self._commit_plot_data(data, plot)
+        self._commit_row(data, plot)
 
+    @transaction.atomic
+    def _commit_row(self, data, plot):
+        self._commit_plot_data(data, plot)
         # TREE_PRESENT handling:
         #   If True, create a tree
         #   If False, don't create a tree

--- a/opentreemap/importer/models/trees.py
+++ b/opentreemap/importer/models/trees.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ValidationError, MultipleObjectsReturned
 from django.contrib.gis.db import models
 from django.contrib.gis.geos import Point, Polygon
 from django.utils.translation import ugettext as _
+from django.db import transaction
 
 from treemap.models import Species, Plot, Tree, MapFeature
 from treemap.lib.object_caches import udf_defs
@@ -100,6 +101,7 @@ class TreeImportRow(GenericImportRow):
     def model_fields(self):
         return fields.trees
 
+    @transaction.atomic
     def commit_row(self):
         is_valid = self.validate_row()
 
@@ -159,7 +161,6 @@ class TreeImportRow(GenericImportRow):
         self.plot = plot
         self.status = TreeImportRow.SUCCESS
         self.save()
-        self.import_event.update_progress_timestamp_and_save()
 
     def _import_value_to_udf_value(self, udf_def, value):
         if udf_def.datatype_dict['type'] == 'multichoice':
@@ -421,5 +422,4 @@ class TreeImportRow(GenericImportRow):
             self.status = TreeImportRow.VERIFIED
 
         self.save()
-        self.import_event.update_progress_timestamp_and_save()
         return not fatal

--- a/opentreemap/importer/tasks.py
+++ b/opentreemap/importer/tasks.py
@@ -8,7 +8,6 @@ import json
 from celery import task, chord
 from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
-from django.db import transaction
 
 from importer.models.base import GenericImportEvent, GenericImportRow
 from importer.models.species import SpeciesImportEvent, SpeciesImportRow
@@ -125,6 +124,7 @@ def _validate_rows(import_type, import_event_id, start_row_id):
     rows = ie.rows()[start_row_id:(start_row_id+settings.IMPORT_BATCH_SIZE)]
     for row in rows:
         row.validate_row()
+    ie.update_progress_timestamp_and_save()
 
 
 @task()
@@ -158,12 +158,12 @@ def commit_import_event(import_type, import_event_id):
 
 
 @task(rate_limit=settings.IMPORT_COMMIT_RATE_LIMIT)
-@transaction.atomic
 def _commit_rows(import_type, import_event_id, i):
     ie = _get_import_event(import_type, import_event_id)
 
     for row in ie.rows()[i:(i + settings.IMPORT_BATCH_SIZE)]:
         row.commit_row()
+    ie.update_progress_timestamp_and_save()
 
 
 @task()


### PR DESCRIPTION
connects #2500 on github

These two features together lead to a large increase in task runtime in
cases where multiple tasks were running in parallel. This is because
each task would hold a transaction with edits to one import_event record
for the entire life of the task. The result is that each task would have
to wait until a sibling task finishes its transaction. We were seeing
queries in excess of ten seconds as a result. By scoping the transaction to just the
length of the row edits, queries from other tasks need only block as long as it takes a
task to edit each row.

Additionally, the heartbeat was being run once per row (85 times per
task) when once per task is perfectly adequate.

It is suspected, but not confirmed, that the heartbeat is the particular
aspect of the row edit that was causing the lock on import_event that
was blocking other tasks. It is possible that performing either one of
these two changes would have fixed this issue. However, they are both
improvements so there is little benefit to further investigation.

To test:
1) run an import job with rate limiting at its current setting of
1/m. Note the time per job.
2) change rate limiting value to something like 15/m.
3) run an import job. If this fix works, the tasks run more frequently
but with the same average runtime.