### PR TITLE
Mobile apps shouldn't show a blank choice for search fields

### DIFF
--- a/opentreemap/treemap/search_fields.py
+++ b/opentreemap/treemap/search_fields.py
@@ -171,8 +171,8 @@ def advanced_search_fields(instance, user):
 
 
 def mobile_search_fields(instance):
-    from treemap.templatetags.form_extras import field_type_label_choices
-
+    from treemap.templatetags.form_extras import (field_type_label_choices,
+                                                  ADD_BLANK_NEVER)
     search_fields = copy.deepcopy(instance.mobile_search_fields)
     for field in search_fields['standard']:
         identifier = field['identifier']
@@ -184,7 +184,7 @@ def mobile_search_fields(instance):
         Model, field_name = _parse_field_info(instance, field)
         set_search_field_label(instance, field)
         field_type, __, choices = field_type_label_choices(
-            Model, field_name, treat_multichoice_as_choice=True)
+            Model, field_name, add_blank=ADD_BLANK_NEVER)
 
         if identifier == 'species.id':
             field['search_type'] = 'SPECIES'

--- a/opentreemap/treemap/tests/test_search_fields.py
+++ b/opentreemap/treemap/tests/test_search_fields.py
@@ -149,8 +149,7 @@ class InstanceMobileSearch(OTMTestCase):
                 'label': 'Planting Site Choice',
                 'identifier': 'plot.udf:Choice',
                 'search_type': 'CHOICE',
-                'choices': [{'display_value': '', 'value': ''},
-                            {'display_value': 'a', 'value': 'a'},
+                'choices': [{'display_value': 'a', 'value': 'a'},
                             {'display_value': 'b', 'value': 'b'},
                             {'display_value': 'c', 'value': 'c'}]
             }
@@ -174,8 +173,7 @@ class InstanceMobileSearch(OTMTestCase):
                 'label': 'Tree MultiChoice',
                 'identifier': 'tree.udf:MultiChoice',
                 'search_type': 'MULTICHOICE',
-                'choices': [{'display_value': '', 'value': ''},
-                            {'display_value': 'a', 'value': 'a'},
+                'choices': [{'display_value': 'a', 'value': 'a'},
                             {'display_value': 'b', 'value': 'b'},
                             {'display_value': 'c', 'value': 'c'}]
             }


### PR DESCRIPTION
We now have 3 cases for whether a choice/multichoice field should offer a blank choice:
* Always -- search fields on the web
* Never -- search fields on mobile
* Choice fields but not multichoice fields -- detail page fields

Connects #2506

Testing: verify that the 3 cases above work as expected