### PR TITLE
Create celery queues for each stack color

### DIFF
--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -236,6 +236,10 @@ STATSD_PREFIX = '{}.django'.format(STACK_TYPE.lower())
 STATSD_HOST = os.environ.get('OTM_STATSD_HOST', 'localhost')
 STATSD_CELERY_SIGNALS = True
 
+STACK_COLOR = os.environ.get('OTM_STACK_COLOR', 'Black')
+CELERY_DEFAULT_QUEUE = STACK_COLOR
+CELERY_DEFAULT_ROUTING_KEY = "task.%s" % STACK_COLOR
+
 ROOT_URLCONF = 'opentreemap.urls'
 
 # Python dotted path to the WSGI application used by Django's runserver.


### PR DESCRIPTION
Intended to allow tasks that originate with one stack to be completed by that
stack, to make background tasks more resilient to code changes.

Connects to OpenTreeMap/otm-cloud#177

To test, I applied this diff to the `otm-cloud` Vagrantfile to create separate VMs each with their own celery worker.
```diff
diff --git a/Vagrantfile b/Vagrantfile
index 0b52b75..357cf2e 100644
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ if ["up", "provision", "status"].include?(ARGV.first)
 end

 ANSIBLE_GROUPS = {
-  "app-servers" => [ "app" ],
+  "app-servers" => [ "app", "appcopy" ],
   "services" => [ "services" ],
   "modeling" => [ "modeling" ],
   "monitoring-servers" => [ "services" ],
@@ -138,6 +138,33 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end

+  config.vm.define "appcopy" do |app|
+    app.vm.hostname = "appcopy"
+    app.vm.network "private_network", ip: ENV.fetch("OTM_APP_IP", "33.33.34.40")
+
+    app.vm.synced_folder ".", "/vagrant", disabled: true
+    app.vm.synced_folder "src/otm-core", "/opt/app/core/"
+    app.vm.synced_folder "src/otm-addons/", "/opt/app/otm-addons/"
+    app.vm.synced_folder "src/otm-ecoservice/", "/opt/ecoservice/"
+    app.vm.synced_folder "src/otm-website/", "/opt/website/"
+
+    # Django via Nginx/Gunicorn
+    app.vm.network "forwarded_port", {
+      guest: 80,
+      host: 9090
+    }.merge(VAGRANT_NETWORK_OPTIONS)
+
+    app.vm.provider "virtualbox" do |v|
+      v.memory = 1536
+    end
+
+    app.vm.provision "ansible" do |ansible|
+      ansible.playbook = "deployment/ansible/app-servers.yml"
+      ansible.groups = ANSIBLE_GROUPS.merge(ANSIBLE_ENV_GROUPS)
+      ansible.raw_arguments = ["--timeout=60"]
+    end
+  end
+
   config.vm.define "tiler" do |tiler|
     tiler.vm.hostname = "tiler"
     tiler.vm.network "private_network", ip: ENV.fetch("OTM_LOCAL_TILER_IP", "33.33.34.35")
```

I then SSHed to each machine and modified the ~~`OTM_STACK_TYPE`~~ `OTM_STACK_COLOR` environment variable to be different on each machine.

After that, importing a tree CSV on `localhost:6060` should create tasks only on the `app` Celery worker, and importing a CSV on `localhost:9090` should create tasks only on the `appcopy` Celery worker.

You can inspect the reserved Celery tasks for both workers by running the following command on either machine:
```
cd /opt/app/core/opentreemap
envdir /etc/otm.d/env celery -A "opentreemap.celery:app" -b "redis://33.33.34.30:6379/2" inspect reserved
```