### PR TITLE
Update robots.txt

### DIFF
--- a/opentreemap/treemap/static/robots.txt
+++ b/opentreemap/treemap/static/robots.txt
@@ -1,1 +1,27 @@
+User-agent: *
 
+# Allow the home page to be indexed.
+Allow: /$
+
+# Allow marketing pages to be indexed.
+Allow: /map/$
+Allow: /engage/$
+Allow: /analyze/$
+Allow: /mobile/$
+Allow: /pricing/$
+
+# Allow user profile pages to be indexed. If the user makes their
+# profile private, the robot will see a 404.
+Allow: /user/
+
+# Allow instance map feature detail pages to be indexed.
+Allow: /*/features/
+
+# Allow instance custom pages to be indexed.
+Allow: /*/page/
+
+# Disallow indexing of everything by default. We only want a small
+# subset of the site's pages to be indexed. This is at the bottom so
+# that crawlers that process the file from the top down will still
+# crawl the explicitly allowed pages.
+Disallow: /


### PR DESCRIPTION
When robots.txt is empty, search crawlers request every linked page on the site. Only a small subset of pages on the site have content that would be useful in a general web search context:

- Map feature detail pages
- Public user profile pages
- Instance custom pages

It is important that the /instance/edits/ page is disallowed because it is a paginated list of every edit and can result in millions of crawler requests if the instance is large.

These URLs should be allowed:
/
/map/
/engage/
/analyze/
/mobile/
/pricing/
/instance/features/12345/
/instance/page/About/
/user/person/

These should be disallowed:
/instance/
/instance/map/
/instance/edits/
/instance/management/
/instance/management/a-management-sub-page/

--- 

##### Testing

The Googlebot testing tool allows you to paste in the content of robots.txt and verify individual addresses
https://www.google.com/webmasters/tools/robots-testing-tool

Note: You need to log in with the Google account that controls analytics for the domain to use the test tool.

<img width="803" alt="screen shot 2016-03-08 at 10 37 06 am" src="https://cloud.githubusercontent.com/assets/17363/13610233/e9db077a-e519-11e5-8bbb-9bc8da5d3c98.png">

I also ran the Yandex tester, which allows testing in bulk
https://webmaster.yandex.com/robots.xml

<img width="714" alt="screen shot 2016-03-08 at 9 18 38 am" src="https://cloud.githubusercontent.com/assets/17363/13610279/18c1b9f8-e51a-11e5-9242-c6e9689ea880.png">

---

Connects to #1445 