### PR TITLE
Unify CSV columns

### DIFF
--- a/opentreemap/exporter/tasks.py
+++ b/opentreemap/exporter/tasks.py
@@ -211,8 +211,8 @@ def _csv_field_header_map(field_names):
     map = OrderedDict()
     # TODO: make this conditional based on whether or not
     # we are performing a complete export or an "importable" export
-    omit = {'readonly', 'udf:Stewardship',
-            'tree__readonly', 'tree__udf:Stewardship',
+    omit = {'readonly',
+            'tree__readonly',
             'tree__species', 'tree__id',
             'tree__species__fact_sheet_url',
             'tree__species__fall_conspicuous',

--- a/opentreemap/exporter/tasks.py
+++ b/opentreemap/exporter/tasks.py
@@ -239,14 +239,14 @@ def _csv_field_header_map(field_names):
 
     for name, header in fields.trees.EXPORTER_PAIRS:
         if name in field_names:
-            map[name] = header
+            map[name] = header.title()
             field_names.remove(name)
 
     for name in sorted(field_names):
         if name.startswith('udf:'):
-            header = 'planting site: ' + name[4:]
+            header = 'Planting Site: ' + name[4:]
         elif name.startswith('tree__udf:'):
-            header = 'tree: ' + name[10:]
+            header = 'Tree: ' + name[10:]
         else:
             logger.warn('Unrecognized export field name',
                         extra={'extra_data': {'field_name': name}})

--- a/opentreemap/exporter/tasks.py
+++ b/opentreemap/exporter/tasks.py
@@ -169,6 +169,10 @@ def async_csv_export(job, model, query, display_filters):
             values_plot = [f for f in values_plot if f != 'geom']
             values_plot += ['geom__x', 'geom__y']
 
+        if values_tree:
+            select['tree_present'] = "treemap_tree.id is not null"
+            values_plot += ['tree_present']
+
         get_ll = 'ST_Transform(treemap_mapfeature.the_geom_webmercator, 4326)'
         select['geom__x'] = 'ST_X(%s)' % get_ll
         select['geom__y'] = 'ST_Y(%s)' % get_ll

--- a/opentreemap/exporter/tasks.py
+++ b/opentreemap/exporter/tasks.py
@@ -48,7 +48,7 @@ def _job_transaction(fn):
     return wrapper
 
 
-def values_for_model(
+def _values_for_model(
         instance, job, table, model,
         select, select_params, prefix=None):
     if prefix:
@@ -132,8 +132,8 @@ def async_csv_export(job, model, query, display_filters):
     if model == 'species':
         initial_qs = (Species.objects.
                       filter(instance=instance))
-        values = values_for_model(instance, job, 'treemap_species',
-                                  'Species', select, select_params)
+        values = _values_for_model(instance, job, 'treemap_species',
+                                   'Species', select, select_params)
         ordered_fields = values + select.keys()
         limited_qs = (initial_qs
                       .extra(select=select,
@@ -151,14 +151,14 @@ def async_csv_export(job, model, query, display_filters):
         initial_qs = Filter(query, display_filters, instance)\
             .get_objects(Plot)
 
-        values_tree = values_for_model(
+        values_tree = _values_for_model(
             instance, job, 'treemap_tree', 'Tree',
             select, select_params,
             prefix='tree')
-        values_plot = values_for_model(
+        values_plot = _values_for_model(
             instance, job, 'treemap_mapfeature', 'Plot',
             select, select_params)
-        values_sp = values_for_model(
+        values_sp = _values_for_model(
             instance, job, 'treemap_species', 'Species',
             select, select_params,
             prefix='tree__species')

--- a/opentreemap/exporter/tasks.py
+++ b/opentreemap/exporter/tasks.py
@@ -244,6 +244,9 @@ def _csv_field_header_map(field_names):
         elif name.startswith('tree__udf:'):
             header = 'tree: ' + name[10:]
         else:
+            # TODO: log that we have an uncaught field that may be
+            # making re-imports impossible. This is better than crashing
+            # an export that is otherwise usable.
             continue
         map[name] = header
     return map

--- a/opentreemap/exporter/tasks.py
+++ b/opentreemap/exporter/tasks.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from __future__ import division
 
 import csv
+import logging
 
 from contextlib import contextmanager
 from functools import wraps
@@ -23,12 +24,18 @@ from treemap.udf import UserDefinedCollectionValue
 from treemap.lib.object_caches import udf_defs
 
 from djqscsv import write_csv, generate_filename
-from exporter.models import ExportJob
 
+from opentreemap.util import add_rollbar_handler
+
+from exporter.models import ExportJob
 from exporter.user import write_users
 from exporter.util import sanitize_unicode_record
 
 from importer import fields
+
+
+logger = logging.getLogger(__name__)
+add_rollbar_handler(logger, level=logging.INFO)
 
 
 @contextmanager
@@ -241,9 +248,8 @@ def _csv_field_header_map(field_names):
         elif name.startswith('tree__udf:'):
             header = 'tree: ' + name[10:]
         else:
-            # TODO: log that we have an uncaught field that may be
-            # making re-imports impossible. This is better than crashing
-            # an export that is otherwise usable.
+            logger.warn('Unrecognized export field name',
+                        extra={'extra_data': {'field_name': name}})
             continue
         map[name] = header
     return map

--- a/opentreemap/exporter/tasks.py
+++ b/opentreemap/exporter/tasks.py
@@ -211,7 +211,7 @@ def _csv_field_header_map(field_names):
     map = OrderedDict()
     # TODO: make this conditional based on whether or not
     # we are performing a complete export or an "importable" export
-    omit = {'readonly', 'udf:Stewardship', 'id',
+    omit = {'readonly', 'udf:Stewardship',
             'tree__readonly', 'tree__udf:Stewardship',
             'tree__species', 'tree__id',
             'tree__species__fact_sheet_url',

--- a/opentreemap/exporter/tests.py
+++ b/opentreemap/exporter/tests.py
@@ -134,8 +134,8 @@ class ExportTreeTaskTest(AsyncCSVTestCase):
     def test_tree_task_unit(self):
         self.assertTaskProducesCSV(
             self.user, 'tree', {'diameter': '2.0',
-                                'udf:Test int': '4',
-                                'plot__udf:Test choice': 'a'})
+                                'tree: Test int': '4',
+                                'planting site: Test choice': 'a'})
 
     @media_dir
     @override_settings(FEATURE_BACKEND_FUNCTION=None)

--- a/opentreemap/exporter/tests.py
+++ b/opentreemap/exporter/tests.py
@@ -133,9 +133,9 @@ class ExportTreeTaskTest(AsyncCSVTestCase):
     @media_dir
     def test_tree_task_unit(self):
         self.assertTaskProducesCSV(
-            self.user, 'tree', {'diameter': '2.0',
-                                'tree: Test int': '4',
-                                'planting site: Test choice': 'a'})
+            self.user, 'tree', {'Diameter': '2.0',
+                                'Tree: Test int': '4',
+                                'Planting Site: Test choice': 'a'})
 
     @media_dir
     @override_settings(FEATURE_BACKEND_FUNCTION=None)
@@ -150,7 +150,7 @@ class ExportTreeTaskTest(AsyncCSVTestCase):
     @media_dir
     @override_settings(FEATURE_BACKEND_FUNCTION=None)
     def test_psuedo_async_tree_export(self):
-        self.assertPsuedoAsyncTaskWorks('tree', self.user, 'diameter', '2.0',
+        self.assertPsuedoAsyncTaskWorks('tree', self.user, 'Diameter', '2.0',
                                         '.*tree_export(_\d+)?\.csv')
 
 
@@ -165,12 +165,12 @@ class ExportSpeciesTaskTest(AsyncCSVTestCase):
     @media_dir
     def test_species_task_unit(self):
         self.assertTaskProducesCSV(
-            self.user, 'species', {'common name': 'foo'})
+            self.user, 'species', {'Common Name': 'foo'})
 
     @media_dir
     @override_settings(FEATURE_BACKEND_FUNCTION=None)
     def test_psuedo_async_species_export(self):
-        self.assertPsuedoAsyncTaskWorks('species', self.user, 'common name',
+        self.assertPsuedoAsyncTaskWorks('species', self.user, 'Common Name',
                                         'foo', '.*species_export(_\d+)?\.csv')
 
 

--- a/opentreemap/importer/fields.py
+++ b/opentreemap/importer/fields.py
@@ -83,14 +83,14 @@ class trees(object):
     STREET_ADDRESS = 'street address'
     CITY_ADDRESS = 'city'
     POSTAL_CODE = 'postal code'
-    PLOT_WIDTH = 'plot width'
-    PLOT_LENGTH = 'plot length'
+    PLOT_WIDTH = 'planting site width'
+    PLOT_LENGTH = 'planting site length'
 
     # TODO: READONLY restore when implemented
     # READ_ONLY = 'read only'
 
-    OPENTREEMAP_PLOT_ID = 'opentreemap plot id'
-    EXTERNAL_ID_NUMBER = 'external id number'
+    OPENTREEMAP_PLOT_ID = 'planting site id'
+    EXTERNAL_ID_NUMBER = 'owner orig id'
 
     TREE_PRESENT = 'tree present'
 

--- a/opentreemap/importer/fields.py
+++ b/opentreemap/importer/fields.py
@@ -127,9 +127,27 @@ class trees(object):
     # TODO: READONLY restore when implemented
     BOOLEAN_FIELDS = {TREE_PRESENT}
 
+    EXPORTER_PAIRS = (
+        ('geom__x', POINT_X),
+        ('geom__y', POINT_Y),
+        ('address_street', STREET_ADDRESS),
+        ('address_city', CITY_ADDRESS),
+        ('address_zip', POSTAL_CODE),
+        ('width', PLOT_WIDTH),
+        ('length', PLOT_LENGTH),
+        ('tree__plot', OPENTREEMAP_PLOT_ID),
+        ('owner_orig_id', EXTERNAL_ID_NUMBER),
+        ('tree__species__genus', GENUS),
+        ('tree__species__species', SPECIES),
+        ('tree__species__cultivar', CULTIVAR),
+        ('tree__species__other_part_of_name', OTHER_PART_OF_NAME),
+        ('tree__species__common_name', COMMON_NAME),
+        ('tree__diameter', DIAMETER),
+        ('tree__height', TREE_HEIGHT),
+        ('tree__canopy_height', CANOPY_HEIGHT),
+        ('tree__date_planted', DATE_PLANTED),
+    )
+
     # TODO: READONLY restore when implemented
     # Note: this is a tuple and not a set so it will be ordered in exports
-    ALL = (POINT_X, POINT_Y, STREET_ADDRESS, CITY_ADDRESS, POSTAL_CODE,
-           PLOT_WIDTH, PLOT_LENGTH, OPENTREEMAP_PLOT_ID, EXTERNAL_ID_NUMBER,
-           TREE_PRESENT, GENUS, SPECIES, CULTIVAR, OTHER_PART_OF_NAME,
-           COMMON_NAME, DIAMETER, TREE_HEIGHT, CANOPY_HEIGHT, DATE_PLANTED)
+    ALL = tuple([p[1] for p in EXPORTER_PAIRS])

--- a/opentreemap/importer/fields.py
+++ b/opentreemap/importer/fields.py
@@ -137,6 +137,7 @@ class trees(object):
         ('length', PLOT_LENGTH),
         ('tree__plot', OPENTREEMAP_PLOT_ID),
         ('owner_orig_id', EXTERNAL_ID_NUMBER),
+        ('tree_present', TREE_PRESENT),
         ('tree__species__genus', GENUS),
         ('tree__species__species', SPECIES),
         ('tree__species__cultivar', CULTIVAR),

--- a/opentreemap/importer/fields.py
+++ b/opentreemap/importer/fields.py
@@ -3,25 +3,30 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+from treemap.models import Species
+
 
 class species(object):
+    def _verbose_name_lower(field_name):
+        return Species._meta.get_field(field_name).verbose_name.lower()
+
     # Fields of the OTM Species object
-    GENUS = 'genus'
-    SPECIES = 'species'
-    CULTIVAR = 'cultivar'
-    OTHER_PART_OF_NAME = 'other part of name'
-    COMMON_NAME = 'common name'
-    IS_NATIVE = 'is native'
-    FLOWERING_PERIOD = 'flowering period'
-    FRUIT_OR_NUT_PERIOD = 'fruit or nut period'
-    FALL_CONSPICUOUS = 'fall conspicuous'
-    FLOWER_CONSPICUOUS = 'flower conspicuous'
-    PALATABLE_HUMAN = 'palatable human'
-    HAS_WILDLIFE_VALUE = 'has wildlife value'
-    FACT_SHEET_URL = 'fact sheet url'
-    PLANT_GUIDE_URL = 'plant guide url'
-    MAX_DIAMETER = 'max diameter'
-    MAX_HEIGHT = 'max height'
+    GENUS = _verbose_name_lower('genus')
+    SPECIES = _verbose_name_lower('species')
+    CULTIVAR = _verbose_name_lower('cultivar')
+    OTHER_PART_OF_NAME = _verbose_name_lower('other_part_of_name')
+    COMMON_NAME = _verbose_name_lower('common_name')
+    IS_NATIVE = _verbose_name_lower('is_native')
+    FLOWERING_PERIOD = _verbose_name_lower('flowering_period')
+    FRUIT_OR_NUT_PERIOD = _verbose_name_lower('fruit_or_nut_period')
+    FALL_CONSPICUOUS = _verbose_name_lower('fall_conspicuous')
+    FLOWER_CONSPICUOUS = _verbose_name_lower('flower_conspicuous')
+    PALATABLE_HUMAN = _verbose_name_lower('palatable_human')
+    HAS_WILDLIFE_VALUE = _verbose_name_lower('has_wildlife_value')
+    FACT_SHEET_URL = _verbose_name_lower('fact_sheet_url')
+    PLANT_GUIDE_URL = _verbose_name_lower('plant_guide_url')
+    MAX_DIAMETER = _verbose_name_lower('max_diameter')
+    MAX_HEIGHT = _verbose_name_lower('max_height')
 
     # Other import and/or export fields
     ID = 'database id of species'
@@ -115,7 +120,7 @@ class trees(object):
     DATE_FIELDS = {DATE_PLANTED, DATE_REMOVED}
 
     STRING_FIELDS = {STREET_ADDRESS, CITY_ADDRESS, POSTAL_CODE, GENUS,
-                     SPECIES, CULTIVAR, OTHER_PART_OF_NAME, COMMON_NAME,
+                     CULTIVAR, OTHER_PART_OF_NAME, COMMON_NAME,
                      EXTERNAL_ID_NUMBER}
 
     POS_FLOAT_FIELDS = {PLOT_WIDTH, PLOT_LENGTH, DIAMETER, TREE_HEIGHT,
@@ -154,3 +159,9 @@ class trees(object):
     # TODO: READONLY restore when implemented
     # Note: this is a tuple and not a set so it will be ordered in exports
     ALL = tuple([p[1] for p in EXPORTER_PAIRS])
+
+
+def title_case(field_names):
+    """Return new collection of strings converted to title case"""
+    collection_type = type(field_names)
+    return collection_type(n.title() for n in field_names)

--- a/opentreemap/importer/fields.py
+++ b/opentreemap/importer/fields.py
@@ -106,12 +106,13 @@ class trees(object):
     TREE_HEIGHT = 'tree height'
     CANOPY_HEIGHT = 'canopy height'
     DATE_PLANTED = 'date planted'
+    DATE_REMOVED = 'date removed'
 
     # order matters, so this is a tuple and not a set
     SPECIES_FIELDS = (GENUS, SPECIES, CULTIVAR, OTHER_PART_OF_NAME,
                       COMMON_NAME)
 
-    DATE_FIELDS = {DATE_PLANTED}
+    DATE_FIELDS = {DATE_PLANTED, DATE_REMOVED}
 
     STRING_FIELDS = {STREET_ADDRESS, CITY_ADDRESS, POSTAL_CODE, GENUS,
                      SPECIES, CULTIVAR, OTHER_PART_OF_NAME, COMMON_NAME,
@@ -147,6 +148,7 @@ class trees(object):
         ('tree__height', TREE_HEIGHT),
         ('tree__canopy_height', CANOPY_HEIGHT),
         ('tree__date_planted', DATE_PLANTED),
+        ('tree__date_removed', DATE_REMOVED),
     )
 
     # TODO: READONLY restore when implemented

--- a/opentreemap/importer/fields.py
+++ b/opentreemap/importer/fields.py
@@ -90,7 +90,7 @@ class trees(object):
     # READ_ONLY = 'read only'
 
     OPENTREEMAP_PLOT_ID = 'planting site id'
-    EXTERNAL_ID_NUMBER = 'owner orig id'
+    EXTERNAL_ID_NUMBER = 'owner original id'
 
     TREE_PRESENT = 'tree present'
 

--- a/opentreemap/importer/fields.py
+++ b/opentreemap/importer/fields.py
@@ -136,7 +136,7 @@ class trees(object):
         ('address_zip', POSTAL_CODE),
         ('width', PLOT_WIDTH),
         ('length', PLOT_LENGTH),
-        ('tree__plot', OPENTREEMAP_PLOT_ID),
+        ('id', OPENTREEMAP_PLOT_ID),
         ('owner_orig_id', EXTERNAL_ID_NUMBER),
         ('tree_present', TREE_PRESENT),
         ('tree__species__genus', GENUS),

--- a/opentreemap/importer/migrations/0005_add_import_event_schema_version.py
+++ b/opentreemap/importer/migrations/0005_add_import_event_schema_version.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('importer', '0004_make_new_fields_nonnullable'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='speciesimportevent',
+            name='schema_version',
+            field=models.IntegerField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='treeimportevent',
+            name='schema_version',
+            field=models.IntegerField(null=True, blank=True),
+        ),
+    ]

--- a/opentreemap/importer/models/base.py
+++ b/opentreemap/importer/models/base.py
@@ -418,10 +418,9 @@ class GenericImportRow(models.Model):
             if value:
                 try:
                     datep = datetime.strptime(value, '%Y-%m-%d')
-                    self.cleaned[self.model_fields.DATE_PLANTED] = datep
+                    self.cleaned[field] = datep
                 except ValueError:
-                    self.append_error(errors.INVALID_DATE,
-                                      self.model_fields.DATE_PLANTED)
+                    self.append_error(errors.INVALID_DATE, field)
                     has_errors = True
 
         return has_errors

--- a/opentreemap/importer/models/base.py
+++ b/opentreemap/importer/models/base.py
@@ -173,6 +173,9 @@ class GenericImportEvent(models.Model):
     def legal_and_required_fields(self):
         raise Exception('Abstract Method')
 
+    def legal_and_required_fields_title_case(self):
+        raise Exception('Abstract Method')
+
     def validate_field_names(self, input_fields):
         """
         Make sure the imported file has valid columns

--- a/opentreemap/importer/models/species.py
+++ b/opentreemap/importer/models/species.py
@@ -63,6 +63,10 @@ class SpeciesImportEvent(GenericImportEvent):
         return (fields.species.ALL,
                 {fields.species.GENUS, fields.species.COMMON_NAME})
 
+    def legal_and_required_fields_title_case(self):
+        legal, required = self.legal_and_required_fields()
+        return fields.title_case(legal), fields.title_case(required)
+
 
 class SpeciesImportRow(GenericImportRow):
 

--- a/opentreemap/importer/models/species.py
+++ b/opentreemap/importer/models/species.py
@@ -27,6 +27,7 @@ class SpeciesImportEvent(GenericImportEvent):
     species information
     """
 
+    import_schema_version = 1  # Update if any column header name changes
     import_type = 'species'
 
     max_diameter_conversion_factor = models.FloatField(default=1.0)

--- a/opentreemap/importer/models/trees.py
+++ b/opentreemap/importer/models/trees.py
@@ -87,6 +87,7 @@ class TreeImportRow(GenericImportRow):
         'canopy_height': fields.trees.CANOPY_HEIGHT,
         'species': fields.trees.SPECIES_OBJECT,
         'date_planted': fields.trees.DATE_PLANTED,
+        'date_removed': fields.trees.DATE_REMOVED,
         # TODO: READONLY restore when implemented
         # 'readonly': fields.trees.READ_ONLY
     }

--- a/opentreemap/importer/models/trees.py
+++ b/opentreemap/importer/models/trees.py
@@ -25,6 +25,7 @@ class TreeImportEvent(GenericImportEvent):
     tree/plot information
     """
 
+    import_schema_version = 1  # Update if any column header name changes
     import_type = 'tree'
 
     plot_length_conversion_factor = models.FloatField(default=1.0)

--- a/opentreemap/importer/models/trees.py
+++ b/opentreemap/importer/models/trees.py
@@ -44,7 +44,10 @@ class TreeImportEvent(GenericImportEvent):
 
     def get_udf_column_name(self, udf_def):
         # Prefix with model name, e.g. "Density" -> "Tree: Density"
-        return "%s: %s" % (udf_def.model_type.lower(), udf_def.name.lower())
+        model_name = udf_def.model_type.lower()
+        if model_name == 'plot':
+            model_name = 'planting site'
+        return "%s: %s" % (model_name, udf_def.name.lower())
 
     def ordered_legal_fields(self):
         def udf_column_names(model_name):

--- a/opentreemap/importer/routes.py
+++ b/opentreemap/importer/routes.py
@@ -51,4 +51,7 @@ export_all_species = _api_call('GET', json_api_call(views.export_all_species))
 export_single_import = _api_call(
     'GET', json_api_call(views.export_single_import))
 
+download_import_template = _api_call(
+    'GET', views.download_import_template)
+
 merge_species = _api_call('POST', views.merge_species)

--- a/opentreemap/importer/templates/importer/partials/imports.html
+++ b/opentreemap/importer/templates/importer/partials/imports.html
@@ -37,7 +37,7 @@
                 <div class="instructions">
                   <p>Need help formatting your CSV?  We have formatting
                      <a href="{% static 'OpenTreeMap_Tree_Import_Guide.pdf' %}" target="_blank">instructions</a>
-                     and a <a href="{% static 'OpenTreeMap_Tree_Import_Template.csv' %}" target="_blank">template</a> to use.
+                     and a <a href="{% url 'importer:download_import_template' instance_url_name=request.instance.url_name import_type='tree' %}">template</a> to use.
                   </p>
                 </div>
               </div>
@@ -56,7 +56,7 @@
                 <div class="instructions">
                   <p>Need help formatting your CSV?  We have formatting
                      <a href="{% static 'OpenTreeMap_Species_Import_Guide.pdf' %}" target="_blank">instructions</a>
-                     and a <a href="{% static 'OpenTreeMap_Species_Import_Template.csv' %}" target="_blank">template</a> to use.
+                     and a <a href="{% url 'importer:download_import_template' instance_url_name=request.instance.url_name import_type='species' %}">template</a> to use.
                   </p>
                 </div>
               </div>

--- a/opentreemap/importer/tests.py
+++ b/opentreemap/importer/tests.py
@@ -293,26 +293,26 @@ class TreeValidationTest(TreeValidationTestBase):
 
     def test_otm_id(self):
         # silly invalid-int-errors should be caught
-        i = self.mkrow({'point x': '16',
-                        'point y': '20',
-                        'opentreemap plot id': '44b'})
+        i = self.mkrow({fields.trees.POINT_X: '16',
+                        fields.trees.POINT_Y: '20',
+                        fields.trees.OPENTREEMAP_PLOT_ID: '44b'})
         r = i.validate_row()
 
         self.assertFalse(r)
         self.assertHasError(i, errors.INT_ERROR, None)
 
-        i = self.mkrow({'point x': '25',
-                        'point y': '25',
-                        'opentreemap plot id': '-22'})
+        i = self.mkrow({fields.trees.POINT_X: '25',
+                        fields.trees.POINT_Y: '25',
+                        fields.trees.OPENTREEMAP_PLOT_ID: '-22'})
         r = i.validate_row()
 
         self.assertFalse(r)
         self.assertHasError(i, errors.POS_INT_ERROR)
 
         # With no plots in the system, all ids should fail
-        i = self.mkrow({'point x': '25',
-                        'point y': '25',
-                        'opentreemap plot id': '44'})
+        i = self.mkrow({fields.trees.POINT_X: '25',
+                        fields.trees.POINT_Y: '25',
+                        fields.trees.OPENTREEMAP_PLOT_ID: '44'})
         r = i.validate_row()
 
         self.assertFalse(r)
@@ -321,9 +321,9 @@ class TreeValidationTest(TreeValidationTestBase):
         p = mkPlot(self.instance, self.user)
 
         # With an existing plot it should be fine
-        i = self.mkrow({'point x': '25',
-                        'point y': '25',
-                        'opentreemap plot id': p.pk})
+        i = self.mkrow({fields.trees.POINT_Y: '25',
+                        fields.trees.POINT_X: '25',
+                        fields.trees.OPENTREEMAP_PLOT_ID: p.pk})
         r = i.validate_row()
 
         self.assertNotHasError(i, errors.INVALID_OTM_ID)
@@ -1198,12 +1198,12 @@ class TreeIntegrationTests(IntegrationTests):
         string_too_long = 'a' * 256
 
         csv = """
-        | point x    | point y    | opentreemap plot id | date planted |
-        | 25.0000002 | 25.0000002 |                       | 2012-02-18   |
-        | 25.1000002 | 25.1000002 | 133                   |              |
-        | 25.1000002 | 25.1000002 | -3                    | 2023-FF-33   |
-        | 25.1000002 | 25.1000002 | bar                   | 2012-02-91   |
-        | 25.1000002 | 25.1000002 | %s                    |              |
+| point x    | point y    | planting site id | date planted |
+| 25.0000002 | 25.0000002 |                  | 2012-02-18   |
+| 25.1000002 | 25.1000002 | 133              |              |
+| 25.1000002 | 25.1000002 | -3               | 2023-FF-33   |
+| 25.1000002 | 25.1000002 | bar              | 2012-02-91   |
+| 25.1000002 | 25.1000002 | %s               |              |
         """ % (p1.pk)
 
         gflds = [fields.trees.POINT_X, fields.trees.POINT_Y]
@@ -1239,10 +1239,10 @@ class TreeIntegrationTests(IntegrationTests):
 
 
     def test_unit_changes(self):
-        csv = """
-        | point x | point y | tree height | canopy height | diameter | plot width | plot length |
-        | 45.53   | 31.1    | 10.0        | 11.0          | 12.0     | 13.0       | 14.0        |
-        """
+        csv = ("| point x | point y | tree height | canopy height | "
+               "diameter | planting site width | planting site length |\n"
+               "| 45.53   | 31.1    | 10.0        | 11.0          | "
+               "12.0     | 13.0                | 14.0                 |")
 
         r = self.create_csv_request(csv, name='some name')
         ieid = process_csv(r, self.instance, self.import_type(),
@@ -1361,8 +1361,8 @@ class TreeIntegrationTests(IntegrationTests):
         # | 45.53   | 31.1    | 19.2       | 13          | false     |
         # """
         csv = """
-        | point x | point y | plot width | plot length |
-        | 45.53   | 31.1    | 19.2       | 13          |
+        | point x | point y | planting site width | planting site length |
+        | 45.53   | 31.1    | 19.2                | 13                   |
         """
 
         ieid = self.run_through_commit_views(csv)
@@ -1379,8 +1379,8 @@ class TreeIntegrationTests(IntegrationTests):
         # self.assertEqual(plot.readonly, False)
 
         csv = """
-        | point x | point y | external id number | opentreemap plot id |
-        | 45.53   | 31.1    | 443                | %s                  |
+        | point x | point y | owner orig id      | planting site id |
+        | 45.53   | 31.1    | 443                | %s               |
         """ % plot.id
 
         ieid = self.run_through_commit_views(csv)
@@ -1394,8 +1394,8 @@ class TreeIntegrationTests(IntegrationTests):
         p1 = mkPlot(self.instance, self.user)
 
         csv = """
-        | point x | point y | opentreemap plot id |
-        | 45.53   | 31.1    | %s                    |
+        | point x | point y | planting site id |
+        | 45.53   | 31.1    | %s               |
         """ % p1.pk
 
         self.run_through_commit_views(csv)

--- a/opentreemap/importer/tests.py
+++ b/opentreemap/importer/tests.py
@@ -588,12 +588,12 @@ class SpeciesCommitTest(SpeciesValidationTest):
             'common name': 'the common name',
             'cultivar': 'the cultivar',
             'other part of name': 'the other',
-            'is native': 'True',
+            'native to region': 'True',
             'flowering period': 'summer',
             'fruit or nut period': 'fall',
             'fall conspicuous': 'True',
             'flower conspicuous': 'True',
-            'palatable human': 'True',
+            'edible': 'True',
             'has wildlife value': 'True',
             'fact sheet url': 'the fact sheet url',
             'plant guide url': 'the plant guide url',
@@ -627,7 +627,7 @@ class SpeciesCommitTest(SpeciesValidationTest):
             'genus': 'Prunus',
             'species': 'americana',
             'common name': 'American plum',
-            'is native': 'true'})
+            'native to region': 'true'})
         self.assertNotHasError(row, errors.MERGE_REQUIRED)
         species = Species.objects.filter(otm_code='PRAM')
         self.assertEqual(1, species.count())
@@ -797,7 +797,7 @@ class SpeciesStatusValidationTest(SpeciesValidationTest):
             "common name": "American plum",
             "genus": "Prunus",
             "species": "americana",
-            "is native": "Yes",
+            "native to region": "Yes",
         })
 
     def test_different_than_empty_and_non_empty_field(self):
@@ -805,7 +805,7 @@ class SpeciesStatusValidationTest(SpeciesValidationTest):
             "common name": "Not a tree at all",
             "genus": "Prunus",
             "species": "americana",
-            "is native": "Yes",
+            "native to region": "Yes",
         })
         differing_field_names = self.get_field_names_for_error(
             row, errors.MERGE_REQUIRED)
@@ -816,7 +816,7 @@ class SpeciesStatusValidationTest(SpeciesValidationTest):
             "common name": "American plum",
             "genus": "Prunus",
             "species": "americana",
-            "is native": "I am not a boolean value",
+            "native to region": "I am not a boolean value",
         })
 
 
@@ -1424,7 +1424,7 @@ class TreeIntegrationTests(IntegrationTests):
         }
 
         csv = """
-        | point x | point y | opentreemap plot id |
+        | point x | point y | planting site id |
         | %(p1x)s | %(p1y)s | %(p1id)s            |
         | %(p2x)s | %(p2y)s | %(p2id)s            |
         """ % new_values

--- a/opentreemap/importer/tests.py
+++ b/opentreemap/importer/tests.py
@@ -1379,7 +1379,7 @@ class TreeIntegrationTests(IntegrationTests):
         # self.assertEqual(plot.readonly, False)
 
         csv = """
-        | point x | point y | owner orig id      | planting site id |
+        | point x | point y | owner original id  | planting site id |
         | 45.53   | 31.1    | 443                | %s               |
         """ % plot.id
 

--- a/opentreemap/importer/tests.py
+++ b/opentreemap/importer/tests.py
@@ -390,12 +390,12 @@ class TreeUdfValidationTest(TreeValidationTestBase):
 
         row = {'point x': '16',
                'point y': '20',
-               'plot: test date': '2015-12-08'}
+               'planting site: test date': '2015-12-08'}
         i = self.mkrow(row)
         i.validate_row()
         self.assertNotHasError(i, errors.INVALID_UDF_VALUE)
 
-        row['plot: test date'] = '12/8/15'
+        row['planting site: test date'] = '12/8/15'
         i = self.mkrow(row)
         i.validate_row()
         self.assertHasError(i, errors.INVALID_UDF_VALUE,
@@ -412,14 +412,14 @@ class TreeUdfValidationTest(TreeValidationTestBase):
 
         row = {'point x': '16',
            'point y': '20',
-           'plot: test choice': 'a'}
+           'planting site: test choice': 'a'}
 
         i = self.mkrow(row)
         i.validate_row()
 
         self.assertNotHasError(i, errors.INVALID_UDF_VALUE)
 
-        row['plot: test choice'] = 'z'
+        row['planting site: test choice'] = 'z'
 
         i = self.mkrow(row)
         i.validate_row()
@@ -439,27 +439,27 @@ class TreeUdfValidationTest(TreeValidationTestBase):
 
         row = {'point x': '16',
                'point y': '20',
-               'plot: test multichoice': '["a"]'}
+               'planting site: test multichoice': '["a"]'}
         i = self.mkrow(row)
         i.validate_row()
         self.assertNotHasError(i, errors.INVALID_UDF_VALUE)
 
-        row['plot: test multichoice'] = '"a"'
+        row['planting site: test multichoice'] = '"a"'
         i = self.mkrow(row)
         i.validate_row()
         self.assertNotHasError(i, errors.INVALID_UDF_VALUE)
 
-        row['plot: test multichoice'] = '["a","b"]'
+        row['planting site: test multichoice'] = '["a","b"]'
         i = self.mkrow(row)
         i.validate_row()
         self.assertNotHasError(i, errors.INVALID_UDF_VALUE)
 
-        row['plot: test multichoice'] = None
+        row['planting site: test multichoice'] = None
         i = self.mkrow(row)
         i.validate_row()
         self.assertNotHasError(i, errors.INVALID_UDF_VALUE)
 
-        row['plot: test multichoice'] = '[]'
+        row['planting site: test multichoice'] = '[]'
         i = self.mkrow(row)
         i.validate_row()
         self.assertNotHasError(i, errors.INVALID_UDF_VALUE)
@@ -468,13 +468,13 @@ class TreeUdfValidationTest(TreeValidationTestBase):
 
         # This is an error because the JSON parser requires that
         # strings be wrapped with double quotes.
-        row['plot: test multichoice'] = 'a'
+        row['planting site: test multichoice'] = 'a'
         i = self.mkrow(row)
         i.validate_row()
         self.assertHasError(i, errors.INVALID_UDF_VALUE,
                             data="[u'Test multichoice must be valid JSON']")
 
-        row['plot: test multichoice'] = '"a","b"'
+        row['planting site: test multichoice'] = '"a","b"'
         i = self.mkrow(row)
         i.validate_row()
         self.assertHasError(i, errors.INVALID_UDF_VALUE,
@@ -1342,8 +1342,8 @@ class TreeIntegrationTests(IntegrationTests):
         )
 
         csv = """
-        | point x | point y | tree: cuteness | plot: flatness |
-        | 26.00   | 26.00   | not much       | very           |
+        | point x | point y | tree: cuteness | planting site: flatness |
+        | 26.00   | 26.00   | not much       | very                    |
         """
 
         ieid = self.run_through_commit_views(csv)

--- a/opentreemap/importer/urls.py
+++ b/opentreemap/importer/urls.py
@@ -31,6 +31,9 @@ urlpatterns = patterns(
         name='export_all_species'),
     url(r'^export/%s/$' % _import_api_pattern, routes.export_single_import,
         name='export_single_import'),
+    url(r'^download_template/%s/$' % _type_pattern,
+        routes.download_import_template,
+        name='download_import_template'),
 
     # API
     url(r'^api/merge$', routes.merge_species, name='merge'),

--- a/opentreemap/importer/views.py
+++ b/opentreemap/importer/views.py
@@ -685,9 +685,7 @@ def process_csv(request, instance, import_type, **kwargs):
     filename = files.keys()[0]
     file_obj = files[filename]
 
-    file_obj = io.BytesIO(file_obj.read()
-                          .decode('latin1')
-                          .encode('utf-8'))
+    file_obj = io.BytesIO(decode(file_obj.read()).encode('utf-8'))
 
     owner = request.user
     ImportEventModel = get_import_event_model(import_type)
@@ -700,6 +698,16 @@ def process_csv(request, instance, import_type, **kwargs):
     run_import_event_validation.delay(import_type, ie.pk, file_obj)
 
     return ie.pk
+
+
+# http://stackoverflow.com/a/8898439/362702
+def decode(s):
+    for encoding in "utf-8-sig", "utf-16":
+        try:
+            return s.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+    return s.decode("latin-1")
 
 
 @transaction.atomic

--- a/opentreemap/importer/views.py
+++ b/opentreemap/importer/views.py
@@ -148,22 +148,26 @@ def _get_table_context(instance, table_name, page_number):
         status__in={
             GenericImportEvent.FINISHED_CREATING,
             GenericImportEvent.FAILED_FILE_VERIFICATION})
+    trees_inactive_q = inactive_q | ~Q(
+        schema_version=TreeImportEvent.import_schema_version)
+    species_inactive_q = inactive_q | ~Q(
+        schema_version=SpeciesImportEvent.import_schema_version)
 
     if table_name == TABLE_ACTIVE_TREES:
         title = _('Active Tree Imports')
-        rows = trees.exclude(inactive_q)
+        rows = trees.exclude(trees_inactive_q)
 
     elif table_name == TABLE_FINISHED_TREES:
         title = _('Finished Tree Imports')
-        rows = trees.filter(inactive_q)
+        rows = trees.filter(trees_inactive_q)
 
     elif table_name == TABLE_ACTIVE_SPECIES:
         title = _('Active Species Imports')
-        rows = species.exclude(inactive_q)
+        rows = species.exclude(species_inactive_q)
 
     elif table_name == TABLE_FINISHED_SPECIES:
         title = _('Finished Species Imports')
-        rows = species.filter(inactive_q)
+        rows = species.filter(species_inactive_q)
 
     else:
         raise Exception('Unexpected import table name: %s' % table_name)

--- a/opentreemap/treemap/migrations/0024_add_species_verbose_names.py
+++ b/opentreemap/treemap/migrations/0024_add_species_verbose_names.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0023_merge'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='species',
+            name='common_name',
+            field=models.CharField(max_length=255, verbose_name='Common Name'),
+        ),
+        migrations.AlterField(
+            model_name='species',
+            name='cultivar',
+            field=models.CharField(max_length=255, verbose_name='Cultivar', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='species',
+            name='fact_sheet_url',
+            field=models.URLField(max_length=255, verbose_name='Fact Sheet URL', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='species',
+            name='fall_conspicuous',
+            field=models.NullBooleanField(verbose_name='Fall Conspicuous'),
+        ),
+        migrations.AlterField(
+            model_name='species',
+            name='flower_conspicuous',
+            field=models.NullBooleanField(verbose_name='Flower Conspicuous'),
+        ),
+        migrations.AlterField(
+            model_name='species',
+            name='flowering_period',
+            field=models.CharField(max_length=255, verbose_name='Flowering Period', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='species',
+            name='fruit_or_nut_period',
+            field=models.CharField(max_length=255, verbose_name='Fruit or Nut Period', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='species',
+            name='genus',
+            field=models.CharField(max_length=255, verbose_name='Genus'),
+        ),
+        migrations.AlterField(
+            model_name='species',
+            name='has_wildlife_value',
+            field=models.NullBooleanField(verbose_name='Has Wildlife Value'),
+        ),
+        migrations.AlterField(
+            model_name='species',
+            name='max_diameter',
+            field=models.IntegerField(default=200, verbose_name='Max Diameter'),
+        ),
+        migrations.AlterField(
+            model_name='species',
+            name='max_height',
+            field=models.IntegerField(default=800, verbose_name='Max Height'),
+        ),
+        migrations.AlterField(
+            model_name='species',
+            name='other_part_of_name',
+            field=models.CharField(max_length=255, verbose_name='Other Part of Name', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='species',
+            name='plant_guide_url',
+            field=models.URLField(max_length=255, verbose_name='Plant Guide URL', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='species',
+            name='species',
+            field=models.CharField(max_length=255, verbose_name='Species', blank=True),
+        ),
+    ]

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -432,11 +432,13 @@ class Species(UDFModel, PendingAuditable):
     other_part_of_name = models.CharField(max_length=255, blank=True)
 
     ### From original OTM (some renamed) ###
+    # TODO: if we drop verbose name then this can re-import clean after export
     is_native = models.NullBooleanField(verbose_name='Native to Region')
     flowering_period = models.CharField(max_length=255, blank=True)
     fruit_or_nut_period = models.CharField(max_length=255, blank=True)
     fall_conspicuous = models.NullBooleanField()
     flower_conspicuous = models.NullBooleanField()
+    # TODO: if we drop verbose name then this can re-import clean after export
     palatable_human = models.NullBooleanField(verbose_name='Edible')
     has_wildlife_value = models.NullBooleanField()
     fact_sheet_url = models.URLField(max_length=255, blank=True)

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -425,28 +425,37 @@ class Species(UDFModel, PendingAuditable):
     # species row to a cannonical species. An otm_code
     # is usually the USDA code, but this is not guaranteed.
     otm_code = models.CharField(max_length=255)
-    common_name = models.CharField(max_length=255)
-    genus = models.CharField(max_length=255)
-    species = models.CharField(max_length=255, blank=True)
-    cultivar = models.CharField(max_length=255, blank=True)
-    other_part_of_name = models.CharField(max_length=255, blank=True)
+    common_name = models.CharField(max_length=255, verbose_name='Common Name')
+    genus = models.CharField(max_length=255, verbose_name='Genus')
+    species = models.CharField(max_length=255, blank=True,
+                               verbose_name='Species')
+    cultivar = models.CharField(max_length=255, blank=True,
+                                verbose_name='Cultivar')
+    other_part_of_name = models.CharField(max_length=255, blank=True,
+                                          verbose_name='Other Part of Name')
 
     ### From original OTM (some renamed) ###
-    # TODO: if we drop verbose name then this can re-import clean after export
     is_native = models.NullBooleanField(verbose_name='Native to Region')
-    flowering_period = models.CharField(max_length=255, blank=True)
-    fruit_or_nut_period = models.CharField(max_length=255, blank=True)
-    fall_conspicuous = models.NullBooleanField()
-    flower_conspicuous = models.NullBooleanField()
-    # TODO: if we drop verbose name then this can re-import clean after export
+    flowering_period = models.CharField(max_length=255, blank=True,
+                                        verbose_name='Flowering Period')
+    fruit_or_nut_period = models.CharField(max_length=255, blank=True,
+                                           verbose_name='Fruit or Nut Period')
+    fall_conspicuous = models.NullBooleanField(verbose_name='Fall Conspicuous')
+    flower_conspicuous = models.NullBooleanField(
+        verbose_name='Flower Conspicuous')
     palatable_human = models.NullBooleanField(verbose_name='Edible')
-    has_wildlife_value = models.NullBooleanField()
-    fact_sheet_url = models.URLField(max_length=255, blank=True)
-    plant_guide_url = models.URLField(max_length=255, blank=True)
+    has_wildlife_value = models.NullBooleanField(
+        verbose_name='Has Wildlife Value')
+    fact_sheet_url = models.URLField(max_length=255, blank=True,
+                                     verbose_name='Fact Sheet URL')
+    plant_guide_url = models.URLField(max_length=255, blank=True,
+                                      verbose_name='Plant Guide URL')
 
     ### Used for validation
-    max_diameter = models.IntegerField(default=DEFAULT_MAX_DIAMETER)
-    max_height = models.IntegerField(default=DEFAULT_MAX_HEIGHT)
+    max_diameter = models.IntegerField(default=DEFAULT_MAX_DIAMETER,
+                                       verbose_name='Max Diameter')
+    max_height = models.IntegerField(default=DEFAULT_MAX_HEIGHT,
+                                     verbose_name='Max Height')
 
     updated_at = models.DateTimeField(  # TODO: remove null=True
         null=True, auto_now=True, editable=False, db_index=True)


### PR DESCRIPTION
Connects #2531

If using `debugcelery.sh` you may need https://github.com/OpenTreeMap/otm-cloud/pull/188

Testing:

0. Run migrations

1. Go to your `latreemap` 

1. Go to the "Bulk Uploader" page. Imports with status "Verification Complete" (both tree and species) should:
  * be in the "Finished Imports" section
  * have no "Export" link
  * have no "Add to Tree Map" link when you click "View"

2. Download the template for trees and for species. The CSV column headers should:
  * be in a logical order
  * be capitalized, with spaces separating words
  * contain custom fields (but not Stewardship), prefixed with either "Planting Site:" or "Tree:"

4. Test importing a tree export:
  * Export all trees in the "West Whittier-Los Nietos" neighborhood (80 trees, 82 planting sites)
  * The CSV column headers should match the template (except now including Stewardship and Alerts)
  * Import the csv you exported. It should fail, saying that alerts and stewardship are unrecognized fields
  * Delete the Stewardship and Alerts columns from your csv, and import again. It should succeed, with 82 rows ready to add.
  * Click "Add to Tree Map". It should succeed.
  * Click the "Export" button next to your finished import. It should succeed (though the field names are lowercased)

3. Test importing a species export:
  * Export all species. The CSV column headers should match the template.
  * Import the csv you exported. It should succeed.
  * Click "View". It should show 758 species "Successfully Added".
  * Click the "Export" button next to your finished import. It should succeed (though the field names are lowercased)


  
