### PR TITLE
Push URL state to app when state is pushed or replaced, not just when popped

### DIFF
--- a/opentreemap/treemap/js/src/urlState.js
+++ b/opentreemap/treemap/js/src/urlState.js
@@ -18,7 +18,10 @@ var _state = null,
     _window = null;
 
 function HistoryApi() {
+    var stateChangeCallback = null;
+
     function onStateChange(callback) {
+        stateChangeCallback = callback;
         window.onpopstate = callback;
     }
     function getState() {
@@ -26,9 +29,15 @@ function HistoryApi() {
     }
     function pushState(state, title, url) {
         history.pushState(state, title, url);
+        if (stateChangeCallback) {
+            stateChangeCallback();
+        }
     }
     function replaceState(state, title, url) {
         history.replaceState(state, title, url);
+        if (stateChangeCallback) {
+            stateChangeCallback();
+        }
     }
     return {
         onStateChange: onStateChange,


### PR DESCRIPTION
When we updated `urlState.HistoryApi` to use the browser `History` API instead of `native.history.js` the changes were incomplete (https://github.com/OpenTreeMap/otm-core/pull/2435). The latter called its `onStateChange` callback for any change to the URL -- push, replace, or pop. The former has only a hook for pop.

The fix is to call the `onStateChange` callback ourselves when pushing or replacing URL state.

Connects OpenTreeMap/otm-addons#1114