### PR TITLE
Imports respect instance units

### DIFF
--- a/opentreemap/importer/models/trees.py
+++ b/opentreemap/importer/models/trees.py
@@ -13,6 +13,7 @@ from django.db import transaction
 
 from treemap.models import Species, Plot, Tree, MapFeature
 from treemap.lib.object_caches import udf_defs
+from treemap.units import storage_to_instance_units_factor
 
 from importer.models.base import GenericImportRow, GenericImportEvent
 from importer import fields
@@ -332,10 +333,15 @@ class TreeImportRow(GenericImportRow):
         else:
             return True
 
-    def validate_species_max(self, field, max_val, err):
+    def validate_species_max(self, field, value_name, max_val, err):
         inputval = self.cleaned.get(field, None)
-        if inputval:
-            if max_val and inputval > max_val:
+        if inputval and max_val:
+            # inputval is in instance units but max_val is in storage units.
+            # Convert max_val to instance units before comparing.
+            factor = storage_to_instance_units_factor(
+                self.import_event.instance, 'tree', value_name)
+            max_val *= factor
+            if inputval > max_val:
                 self.append_error(err, field, max_val)
                 return False
 
@@ -343,12 +349,12 @@ class TreeImportRow(GenericImportRow):
 
     def validate_species_dbh_max(self, species):
         return self.validate_species_max(
-            fields.trees.DIAMETER,
+            fields.trees.DIAMETER, 'diameter',
             species.max_diameter, errors.SPECIES_DBH_TOO_HIGH)
 
     def validate_species_height_max(self, species):
         return self.validate_species_max(
-            fields.trees.TREE_HEIGHT,
+            fields.trees.TREE_HEIGHT, 'height',
             species.max_height, errors.SPECIES_HEIGHT_TOO_HIGH)
 
     def validate_species(self):

--- a/opentreemap/importer/templates/importer/partials/imports.html
+++ b/opentreemap/importer/templates/importer/partials/imports.html
@@ -17,18 +17,18 @@
                   <div class="input-group">
                     {% trans "CSV to Upload:" %} <input type="file" name="file" accept="text/csv,.csv">
                   </div><!-- /input-group -->
-                  <div id="importer-tree-units" style="display: none;">
+                  <div id="importer-tree-units" style="display: none; padding-top:10px">
                     {% with u=importer_instance_units %}
                     {% with pl=u.plot_length pw=u.plot_width td=u.tree_diameter th=u.tree_height tch=u.tree_canopy_height %}
                     {% blocktrans %}
                     <h5>Unit Warning</h5>
                     <p>The following units are used for your tree map.</p>
                     <p>Please ensure that your file contains measurements of the same unit.</p>
-                    <p>Plot Length: {{ pl }}</p>
-                    <p>Plot Width: {{ pw }}</p>
                     <p>Tree Diameter: {{ td }}</p>
                     <p>Tree Height: {{ th }}</p>
                     <p>Tree Canopy Height: {{ tch }}</p>
+                    <p>Planting Site Length: {{ pl }}</p>
+                    <p>Planting Site Width: {{ pw }}</p>
                     {% endblocktrans %}
                     {% endwith %}
                     {% endwith %}


### PR DESCRIPTION
* Fetch and use instance's units for tree imports
* Refactor nearby code
* Respect unit conversions when validating against species max diameter/height
* Make tests actually test these things

Also tweak units warning:
* Show tree units first
* "Plot" -> "Planting Site"
* Tweak spacing

To test:
1) Make an instance centered on Minneapolis
2) Change units to metric for tree and plot fields (cm for diameter, m for the rest)
3) Import `//fileshare/users/rmohr/notes/otm/importer/minneapolis1.csv`
4) Verify values are correct by looking at tree detail

Connects #189