### PR TITLE
On import, strip leading and trailing blanks from headers

### DIFF
--- a/opentreemap/importer/tasks.py
+++ b/opentreemap/importer/tasks.py
@@ -22,7 +22,7 @@ def _create_rows_for_event(ie, csv_file):
     # so we can show progress. Caller does manual cleanup if necessary.
     reader = utf8_file_to_csv_dictreader(csv_file)
 
-    field_names = reader.fieldnames
+    field_names = [f.strip() for f in reader.fieldnames]
     ie.field_order = json.dumps(field_names)
     ie.save()
 

--- a/opentreemap/importer/views.py
+++ b/opentreemap/importer/views.py
@@ -378,8 +378,7 @@ def _get_status_panel(instance, ie, panel_spec, page_number=1):
     if is_species and status == GenericImportRow.VERIFIED:
         query = query.filter(merged=True)
 
-    field_names_original = [f for f
-                            in json.loads(ie.field_order)
+    field_names_original = [f.strip() for f in json.loads(ie.field_order)
                             if f != 'ignore']
     field_names = [f.lower() for f in field_names_original]
 


### PR DESCRIPTION
Also strip when reading headers from DB since unstripped ones were saved in the past

Connects #2532