### PR TITLE
Prevent importing trees with identical lat/lon

### DIFF
--- a/opentreemap/importer/models/trees.py
+++ b/opentreemap/importer/models/trees.py
@@ -299,11 +299,6 @@ class TreeImportRow(GenericImportRow):
         if oid is not None:
             return True
 
-        plot_ids_from_this_import = TreeImportRow.objects\
-            .filter(import_event=self.import_event)\
-            .filter(plot__isnull=False)\
-            .values_list('plot__pk', flat=True)
-
         offset = 3.048  # 10ft in meters
         nearby_bbox = Polygon(((point.x - offset, point.y - offset),
                                (point.x - offset, point.y + offset),
@@ -316,8 +311,7 @@ class TreeImportRow(GenericImportRow):
         nearby = MapFeature.objects\
                            .filter(instance=self.import_event.instance)\
                            .filter(feature_type='Plot')\
-                           .filter(geom__intersects=nearby_bbox)\
-                           .exclude(pk__in=plot_ids_from_this_import)\
+                           .filter(geom__intersects=nearby_bbox)
 
         nearby = nearby.distance(point).order_by('distance')[:5]
 


### PR DESCRIPTION
Previously when validating proximity we ignored `plot_ids_from_this_import`.
(That code was added by @maurizi when we first brought in the OTM importer,
https://github.com/OpenTreeMap/otm-core/commit/2665ec61f06803a029983010ff165689de56a154).

I'm guessing we didn't want to reject trees from somebody's inventory which happened to be closer than 10 feet to each other.

But now we distinguish `DUPLICATE_TREE` (closer than 1 mm, an error) and `NEARBY_TREES` (closer than 10 feet, a warning). Trees with warnings will still be added during the "Add to Tree Map" step, so I'm removing the exclusion of `plot_ids_from_this_import`.

Here's how things will now work:

Validation step:
* If within 1 mm of tree in map, Error (`DUPLICATE_TREE`)
* If within 10 feet of tree in map, Warning (`NEARBY_TREE`)
* If within 1 mm of another tree in the same import, Ready to Add
* If within 10 feet another tree in the same import, Ready to Add

Add to Tree Map step:
* If within 1 mm of tree in map, Error (`DUPLICATE_TREE`)
* If within 10 feet of tree in map, Successfully Added
* If within 1 mm of another tree in the same import, Error (`DUPLICATE_TREE`)
* If within 10 feet another tree in the same import, Successfully Added

Connects OpenTreeMap/otm-addons#998

Testing:
1. Make an instance centered on Minneapolis
2. Import //fileshare/users/rmohr/notes/otm/importer/minneapolis_dup.csv (two trees, same lat/lon) -- there should be no errors during validation.
3. "Add to Tree Map" -- one tree should be successfully added and the other should give an error
4. Import //fileshare/users/rmohr/notes/otm/importer/minneapolis_near.csv (two trees, within 10 feet) -- there should be no errors during validation.
3. "Add to Tree Map" -- both trees should be successfully added