### PR TITLE
Fix the styling of long field names in advanced search dropdowns

### DIFF
--- a/opentreemap/treemap/css/sass/modules/_checkboxes.scss
+++ b/opentreemap/treemap/css/sass/modules/_checkboxes.scss
@@ -1,8 +1,8 @@
 @mixin checkboxes {
-	input[type='radio'],
+    input[type='radio'],
     input[type='checkbox'] {
         opacity: 0;
-        float: left;
+        position: absolute;
         width: 0;
 
         & + label {
@@ -22,7 +22,7 @@
         }
 
         @include select-none;
-	}
+    }
     input[type='radio']:checked + label {
         background-image: url(/static/img/radio.png);
     }


### PR DESCRIPTION
Firefox was not respecting the 0 width style, which caused the checkboxes
to have a padding on the left for the "invisible" checkboxes, *unless*
they had text long enough to wrap.

By using fixed positioning to place the inputs off the screen, we get
around browser inconsistencies with width, while still keeping the inputs
functionally invisible, but still enabled.

Connects to #2463