### PR TITLE
Fix random_trees command delete option and add delete_data command

### DIFF
--- a/opentreemap/treemap/management/commands/delete_data.py
+++ b/opentreemap/treemap/management/commands/delete_data.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from treemap.management.util import InstanceDataCommand
+
+
+class Command(InstanceDataCommand):
+
+    def handle(self, *args, **options):
+        """ Delete all map feature data """
+        # The superclass handles deleting data if the 'delete' option is true
+        options['delete'] = True
+        self.setup_env(*args, **options)

--- a/opentreemap/treemap/management/util.py
+++ b/opentreemap/treemap/management/util.py
@@ -6,10 +6,15 @@ from __future__ import division
 from optparse import make_option
 
 from django.core.management.base import BaseCommand
+from django.db import connection, transaction
 
-from treemap.models import (Instance, User, Plot, Tree, Role, InstanceUser,
-                            MapFeature)
-from treemap.audit import add_default_permissions
+from otm_comments.models import EnhancedThreadedComment
+
+from importer.models import TreeImportRow
+
+from treemap.models import (Instance, User, Tree, Role, InstanceUser,
+                            MapFeature, MapFeaturePhoto, Favorite)
+from treemap.audit import add_default_permissions, Audit
 
 
 class InstanceDataCommand(BaseCommand):
@@ -29,13 +34,9 @@ class InstanceDataCommand(BaseCommand):
                     action='store_true',
                     dest='delete',
                     default=False,
-                    help='Delete previous trees/plots in the instance first'),
-        make_option('-k', '--kill_resources',
-                    action='store_true',
-                    dest='delete_resources',
-                    default=False,
-                    help='Delete previous resources in the instance first'),)
+                    help='Delete all previous data in the instance first'))
 
+    @transaction.atomic
     def setup_env(self, *args, **options):
         """ Create some seed data """
         if options['instance']:
@@ -68,25 +69,148 @@ class InstanceDataCommand(BaseCommand):
 
         add_default_permissions(instance)
 
-        dt = 0
-        dp = 0
         if options.get('delete', False):
-            for t in Tree.objects.all():
-                t.delete_with_user(user)
-                dt += 1
-            for p in Plot.objects.all():
-                p.delete_with_user(user)
-                dp += 1
+            # Can't delete through the ORM because it will pull all the data
+            # into memory for signal handlers, then run out of memory and crash
+            # BUT... cascading delete is not handled at the DB level, so we
+            # need to delete from all related tables in the right order
 
-            self.stdout.write("Deleted %s trees and %s plots" % (dt, dp))
+            n_photo = MapFeaturePhoto.objects.filter(instance=instance).count()
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    DELETE FROM treemap_treephoto t
+                    WHERE t.mapfeaturephoto_ptr_id IN
+                        (SELECT id
+                         FROM treemap_mapfeaturephoto p
+                         WHERE p.instance_id = %s)
+                    """,
+                    (instance.pk,))
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    'DELETE FROM treemap_mapfeaturephoto t WHERE t.instance_id = %s',  # NOQA
+                    (instance.pk,))
+            self.stdout.write("Deleted %s photos" % n_photo)
 
-        dr = 0
-        if options.get('delete_resources', False):
-            for f in MapFeature.objects.all():
-                if f.feature_type != 'Plot':
-                    f.delete_with_user(user)
-                    dr += 1
+            n_trees = Tree.objects.filter(instance=instance).count()
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    'DELETE FROM treemap_tree t WHERE t.instance_id = %s',
+                    (instance.pk,))
+            self.stdout.write("Deleted %s trees" % n_trees)
 
-            self.stdout.write("Deleted %s resources" % dr)
+            n_favorites = Favorite.objects \
+                .filter(map_feature__instance=instance).count()
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    DELETE FROM treemap_favorite f
+                    WHERE f.map_feature_id IN
+                        (SELECT id
+                         FROM treemap_mapfeature m
+                         WHERE m.instance_id = %s)
+                    """,
+                    (instance.pk,))
+            self.stdout.write("Deleted %s favorites" % n_favorites)
+
+            n_comments = EnhancedThreadedComment.objects \
+                .filter(instance=instance).count()
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    DELETE FROM otm_comments_enhancedthreadedcommentflag f
+                    WHERE f.comment_id IN
+                        (SELECT threadedcomment_ptr_id
+                         FROM otm_comments_enhancedthreadedcomment c
+                         WHERE c.instance_id = %s)
+                    """,
+                    (instance.pk,))
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    DELETE FROM otm_comments_enhancedthreadedcomment c
+                    WHERE c.instance_id = %s
+                    """,
+                    (instance.pk,))
+            self.stdout.write("Deleted %s comments" % n_comments)
+
+            n_rows = TreeImportRow.objects \
+                .filter(plot__instance=instance).count()
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    UPDATE importer_treeimportrow r
+                    SET plot_id = NULL
+                    WHERE r.import_event_id IN
+                        (SELECT id
+                         FROM importer_treeimportevent e
+                         WHERE e.instance_id = %s)
+                    """,
+                    (instance.pk,))
+            self.stdout.write("Nulled out plot in %s import rows" % n_rows)
+
+            n_features = MapFeature.objects.filter(instance=instance).count()
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    DELETE FROM treemap_plot p
+                    WHERE p.mapfeature_ptr_id IN
+                        (SELECT id
+                         FROM treemap_mapfeature f
+                         WHERE f.instance_id = %s)
+                    """,
+                    (instance.pk,))
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    DELETE FROM stormwater_bioswale b
+                    WHERE b.polygonalmapfeature_ptr_id IN
+                        (SELECT id
+                         FROM treemap_mapfeature f
+                         WHERE f.instance_id = %s)
+                    """,
+                    (instance.pk,))
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    DELETE FROM stormwater_raingarden b
+                    WHERE b.polygonalmapfeature_ptr_id IN
+                        (SELECT id
+                         FROM treemap_mapfeature f
+                         WHERE f.instance_id = %s)
+                    """,
+                    (instance.pk,))
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    DELETE FROM stormwater_rainbarrel b
+                    WHERE b.mapfeature_ptr_id IN
+                        (SELECT id
+                         FROM treemap_mapfeature f
+                         WHERE f.instance_id = %s)
+                    """,
+                    (instance.pk,))
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    """
+                    DELETE FROM stormwater_polygonalmapfeature b
+                    WHERE b.mapfeature_ptr_id IN
+                        (SELECT id
+                         FROM treemap_mapfeature f
+                         WHERE f.instance_id = %s)
+                    """,
+                    (instance.pk,))
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    'DELETE FROM treemap_mapfeature f WHERE f.instance_id = %s',  # NOQA
+                    (instance.pk,))
+            self.stdout.write("Deleted %s map features" % n_features)
+
+            n_audits = Audit.objects.filter(instance=instance).count()
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    'DELETE FROM treemap_audit a WHERE a.instance_id = %s',
+                    (instance.pk,))
+            self.stdout.write("Deleted %s audits" % n_audits)
 
         return instance, user


### PR DESCRIPTION
The --delete option to random_trees was incorrectly attempting to delete
all trees from all maps, not just the map associated with the command.

I switched the option to delete via SQL for better performance and so that
it could delete audits and other related objects as well.

I also added a delete_data command, which deletes all trees, plots, map
features and other related data from the given map, leaving mainly only
the import history and customizations in place.

Connects to #1139