### PR TITLE
Address issue with incorrect calls to MapFeature.cast_to_subtype

### DIFF
--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -728,6 +728,11 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
         Return the concrete subclass instance. For example, if self is
         a MapFeature with subtype Plot, return self.plot
         """
+        if type(self) is not MapFeature:
+            # This shouldn't really ever happen, but there's no point trying to
+            # cast a subclass to itself
+            return self
+
         ft = self.feature_type
         if hasattr(self, ft.lower()):
             return getattr(self, ft.lower())


### PR DESCRIPTION
For unknown reasons, sometimes when `MapFeature.cast_to_subtype` is called
on Plot objects, they lack the `plot` attribute pointing from the
MapFeature superclass to the Plot subclass, causing `cast_to_subtype` to
incorrectly trest those objects as `PolygonalMapFeature` classes.

This works around the issue by having `cast_to_subtype` to just return
`self` if not called on the `MapFeature` superclass.

Connects to #2555