### PR TITLE
Fix infinite loop of browser map state

### DIFF
--- a/opentreemap/treemap/js/src/urlState.js
+++ b/opentreemap/treemap/js/src/urlState.js
@@ -126,6 +126,10 @@ function set(key, value, options) {
         var newState = _.extend({}, _state);
         newState[key] = value;
 
+        // Serialize and deserialize state to ensure that deserializing state
+        // from the URL will match the stored state (mostly matter for float precision)
+        newState = getStateFromUrl(getUrlFromState(newState));
+
         // Prevent data from being pushed to _stateChangeBus by making _state
         // identical to newState.
         if (options.silent) {
@@ -196,8 +200,12 @@ module.exports = {
 };
 
 function getStateFromCurrentUrl() {
+    return getStateFromUrl(_window.getLocationHref());
+}
+
+function getStateFromUrl(urlText) {
     var newState = {},
-        query = url.parse(_window.getLocationHref(), true).query,
+        query = url.parse(urlText, true).query,
         allKeys = _.union(_.keys(deserializers), _.keys(query));
 
     _.each(allKeys, function(k) {

--- a/opentreemap/treemap/js/test/urlState.js
+++ b/opentreemap/treemap/js/test/urlState.js
@@ -130,15 +130,15 @@ var urlStateTests = {
         var context = createContext();
         urlState.init(context);
         urlState.stateChangeStream.take(1).onValue(function(state) {
-            assert.deepEqual(state, {bar: 2});
+            assert.deepEqual(state, {bar: '2'});
             done();
         });
         // This should NOT trigger an update on stateChangeStream.
-        urlState.set('foo', 1, {
+        urlState.set('foo', '1', {
             silent: true
         });
         // This SHOULD trigger an update on stateChangeStream.
-        urlState.set('bar', 2, {
+        urlState.set('bar', '2', {
             silent: false
         });
     }


### PR DESCRIPTION
When panning or zooming the map, we store the map state in the URL.
Conversely, when changing the URL, we pan or zoom the map to match the new URL.

Because we used a fixed precision when storing lat/lng in the URL, but did not
do so for the state object that stored the current zoom/lat/lng, it was
possible for changes to the map state to cause an infinite loop, where the URL
and map state would constantly change but never get in sync with each other.

By serializing and deserializing our internal state object whenever we change
the URL, we ensure that when we later compare the current state object to the
new state to try and detect changes we'll never encounter these loops.

Connects to #2558