### PR TITLE
Support custom layers

### DIFF
--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -250,6 +250,8 @@ class Instance(models.Model):
     search_config = _make_config_property('search_config',
                                           DEFAULT_SEARCH_FIELDS)
 
+    custom_layers = _make_config_property('custom_layers', [])
+
     non_admins_can_export = models.BooleanField(default=True)
 
     def advanced_search_fields(self, user):

--- a/opentreemap/treemap/js/src/MapManager.js
+++ b/opentreemap/treemap/js/src/MapManager.js
@@ -103,6 +103,8 @@ MapManager.prototype = {
             fixZoomLayerSwitch(map, boundariesLayer);
         }
 
+        _.each(config.instance.customLayers, _.partial(addCustomLayer, this, config));
+
         if (options.trackZoomLatLng) {
             map.on("moveend", _.partial(serializeZoomLatLngFromMap, map));
             urlState.stateChangeStream.filter('.zoomLatLng')
@@ -272,6 +274,14 @@ function fixZoomLayerSwitch(map, layer) {
             layer._clearBgBuffer();
         }
     });
+}
+
+function addCustomLayer(mapManager, config, layerInfo) {
+    var layer = layersLib.createCustomLayer(layerInfo, config);
+    mapManager.layersControl.addOverlay(layer, layerInfo.name);
+    if (layerInfo.showByDefault) {
+        mapManager.map.addLayer(layer);
+    }
 }
 
 module.exports = MapManager;

--- a/opentreemap/treemap/js/src/layers.js
+++ b/opentreemap/treemap/js/src/layers.js
@@ -14,6 +14,7 @@ var $ = require("jquery"),
     BASE_LAYER_OPTION = exports.BASE_LAYER_OPTION = {zIndex: 0},
     BOUNDARY_LAYER_OPTION = {zIndex: 1},
     OVERLAY_PANE_Z_INDEX = exports.OVERLAY_PANE_Z_INDEX = 2,
+    CUSTOM_LAYER_OPTION = {zIndex: 2},
     FEATURE_LAYER_OPTION = {zIndex: 3};
 
 ////////////////////////////////////////////////
@@ -77,6 +78,21 @@ exports.createPlotUTFLayer = function (config) {
     };
 
     return layer;
+};
+
+exports.createCustomLayer = function(layerInfo, config) {
+    if (layerInfo.type === 'tile') {
+        var options = _.extend({}, CUSTOM_LAYER_OPTION);
+        options.maxZoom = layerInfo.maxZoom || MAX_ZOOM_OPTION.maxZoom;
+        if (layerInfo.maxNativeZoom) {
+            // NOTE: this won't work until we upgrade to Leaflet > 0.7
+            options.maxNativeZoom = layerInfo.maxNativeZoom;
+        }
+        if (layerInfo.opacity) {
+            options.opacity = layerInfo.opacity;
+        }
+        return L.tileLayer(layerInfo.url, options);
+    }
 };
 
 ////////////////////////////////////////////////

--- a/opentreemap/treemap/templates/treemap/settings.js
+++ b/opentreemap/treemap/templates/treemap/settings.js
@@ -82,6 +82,7 @@ otm.settings.doubleClickInterval = '{{ settings.DOUBLE_CLICK_INTERVAL }}';
             'data': '{{ request.instance.basemap_data }}',
             'bing_api_key': '{{ BING_API_KEY }}'
         },
+        'customLayers': {{ request.instance.custom_layers|as_json|safe }},
         'primaryColor': '{{ request.instance.config|primary_color }}',
         'secondaryColor': '{{ request.instance.config|secondary_color }}',
         'supportsEcobenefits': {{ request.instance_supports_ecobenefits|yesno:"true,false" }}


### PR DESCRIPTION
Allows defining per-instance custom layers, toggleable in the layer selector.

Caveat -- layer disappears if you zoom in further than tiles are available. We need to upgrade Leaflet.

Connects #2577

Testing:

1) Start a Django shell, and enter the code below.
2) `patreemap` should now show the canopy layer by default
3) In `phillytreemap` you can toggle the layer on, and see how it looks with trees

```python
import json
i = Instance.objects.get(url_name='patreemap')
layers = [
            {
                "name": "Tree Canopy",
                "type": "tile",
                "url": "http://com.azavea.datahub.tms.s3.amazonaws.com/treecanopy-2006-2008-pa/{z}/{x}/{y}.png",
                "maxNativeZoom": 17,
                "opacity": 0.5,
                "showByDefault": True
            }
        ]
i.config.custom_layers = layers
i.save()

i = Instance.objects.get(url_name='phillytreemap')
layers = [
            {
                "name": "Tree Canopy",
                "type": "tile",
                "url": "http://com.azavea.datahub.tms.s3.amazonaws.com/treecanopy-2006-2008-pa/{z}/{x}/{y}.png",
                "maxNativeZoom": 17,
                "opacity": 0.5,
                "showByDefault": False
            }
        ]
i.config.custom_layers = layers
i.save()
```