### PR TITLE
Update Google Analytics tracking code

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -124,7 +124,7 @@ module.exports = function(grunt) {
                 src: [],
                 dest: appBundlePath,
                 options: {
-                    alias: getRegularAliases(),
+                    alias: getRegularAliases().concat(['autotrack:']),
                     aliasMappings: {
                         cwd:'treemap/js/lib/',
                         src: ['*.js'],

--- a/opentreemap/treemap/templates/base.html
+++ b/opentreemap/treemap/templates/base.html
@@ -30,19 +30,36 @@
 
     {% block head_extra %}
     {% endblock head_extra %}
+
+    {% if settings.GLOBAL_GOOGLE_ANALYTICS_ID and settings.APP_GOOGLE_ANALYTICS_ID %}
+    <!-- Google Analytics -->
+    <script>
+    (function() {
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+      ga('create', '{{ settings.APP_GOOGLE_ANALYTICS_ID }}', 'auto');
+      ga('create', '{{ settings.GLOBAL_GOOGLE_ANALYTICS_ID }}', 'auto', 'global');
+      ga('require', 'autotrack');
+      ga('global.require', 'autotrack');
+
+      {% if request.user.is_authenticated %}
+      ga('set', 'userId', '{{ request.user.pk }}')
+      ga('global.set', 'userId', '{{ request.user.pk }}')
+      {% endif %}
+
+      {% block google_analytics_actions %}
+      ga('send', 'pageview');
+      ga('global.send', 'pageview');
+      {% endblock google_analytics_actions %}
+    })();
+    </script>
+    <!-- End Analytics -->
+    {% endif %}
   </head>
   <body>
-    {% if settings.GOOGLE_ANALYTICS_ID %}
-    <!-- Google Tag Manager -->
-    <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-{{ settings.GOOGLE_ANALYTICS_ID }}"
-                      height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','GTM-{{ settings.GOOGLE_ANALYTICS_ID }}');</script>
-    <!-- End Google Tag Manager -->
-    {% endif %}
     <div {% block outermost_atts %}{% endblock outermost_atts %} class="wrapper">
       {% block topnav %}
       <!-- Top Nav -->
@@ -208,6 +225,7 @@
 
     <script type="text/javascript">
       (function(require) {
+          require("autotrack");
           require("treemap/buttonEnabler").run({ config: otm.settings });
           require("treemap/export").run({ config: otm.settings });
       })(require);

--- a/opentreemap/treemap/templates/instance_base.html
+++ b/opentreemap/treemap/templates/instance_base.html
@@ -14,6 +14,17 @@
 {% endif %}
 {% endblock application_css %}
 
+{% block google_analytics_actions %}
+{# for instance-specific pages, remove the url_name from the url for better tracking #}
+var pathname = document.location.pathname;
+pathname = pathname.replace(/\/[a-zA-Z]+[a-zA-Z0-9\-]*\//, '/<instance_url_name>/');
+
+// Note: we're only removing the url_name on the app tracker, not the global tracker
+// This way we can still see which instances get more traffic and look at usage differences between them
+ga('set', 'page', pathname);
+{{ block.super }}
+{% endblock google_analytics_actions %}
+
 {% block instance_title %} | {{ request.instance.name }}{% endblock %}
 
 {% block instancetopnav %}
@@ -28,6 +39,7 @@
           <a data-href="{% url 'map' instance_url_name=request.instance.url_name %}?m=addTree"
              data-always-enable="{{ last_effective_instance_user|plot_is_creatable }}"
              data-disabled-title='{% trans "Adding trees is not available to all users" %}'
+             data-event-category="add-tree" data-event-action="start-add-tree"
              data-action='addtree'>{% trans "Add a Tree" %}</a>
         </li>
         <li>
@@ -44,6 +56,7 @@
          data-always-enable='{{ last_effective_instance_user|plot_is_creatable }}'
          data-disabled-title='{% trans "Adding trees is not available to all users" %}'
          data-href="{% url 'map' instance_url_name=request.instance.url_name %}?m=addTree"
+         data-event-category="add-tree" data-event-action="start-add-tree"
          disabled='disabled'>{% trans "Add a Tree" %}</a>
     </li>
   {% endif %}
@@ -145,6 +158,7 @@
       <a class="btn btn-primary addBtn"
          data-action='addtree'
          data-feature="add_plot"
+         data-event-category="add-tree" data-event-action="start-add-tree"
          data-always-enable="{{ last_effective_instance_user|plot_is_creatable }}"
          data-disabled-title="{% trans "Adding trees is not available to all users" %}"
          data-href="{% url 'map' instance_url_name=request.instance.url_name %}?m=addTree"
@@ -169,10 +183,13 @@
 {% block searchoptions %}
 <div class="search-options">
   <div class="btn-group">
-    <button id="search-advanced" class="btn btn-default btn-sm">{% trans "Advanced" %}</button>
-    <button id="search-reset" class="btn btn-default btn-sm">{% trans "Reset" %}</button>
+    <button id="search-advanced" class="btn btn-default btn-sm"
+        data-event-category="search" data-event-action="toggle-advanced">{% trans "Advanced" %}</button>
+    <button id="search-reset" class="btn btn-default btn-sm"
+        data-event-category="search" data-event-action="reset">{% trans "Reset" %}</button>
   </div>
-  <a id="perform-search" class="btn btn-primary btn-lg btn-block">{% trans "Search" %}</a>
+  <a id="perform-search" class="btn btn-primary btn-lg btn-block"
+        data-event-category="search" data-event-action="do-search">{% trans "Search" %}</a>
 </div>
 {% endblock searchoptions %}
 

--- a/opentreemap/treemap/templates/treemap/map-add-tree.html
+++ b/opentreemap/treemap/templates/treemap/map-add-tree.html
@@ -4,7 +4,7 @@
 {% with nsteps=3 %}
 <div class="sidebar-inner">
     <a href="javascript:;" class="close cancelBtn small">×</a>
-    <h3>Add a Tree</h3>
+    <h3>{% trans "Add a Tree" %}</h3>
     <div class="add-step-container" id="add-tree-container">
         {% include "treemap/partials/step_set_location.html" with first=True feature_name="tree" %}
         <div class="add-step">
@@ -31,31 +31,35 @@
                 <h3 class="summaryHead"></h3>
                 <h6 class="summarySubhead"></h6>
                 <h4 class="summaryAddress"></h4>
-                <h6>Nearby Address</h6>
+                <h6>{% trans "Nearby Address" %}</h6>
                 <hr/>
                 <label>{% trans "After I add this tree..." %}</label>
                 <div>
-                    <input type="radio" name="addFeatureOptions" value="copy" id="addtree-addsame" /><label for="addtree-addsame">
+                    <input type="radio" name="addFeatureOptions" value="copy" id="addtree-addsame"
+                           data-event-category="add-tree" data-event-action="done-add-copy" /><label for="addtree-addsame">
                         {% trans "Add another tree with these details" %}
                     </label>
                 </div>
                 <div>
-                    <input type="radio" name="addFeatureOptions" value="new" id="addtree-addnew" /><label for="addtree-addnew">
+                    <input type="radio" name="addFeatureOptions" value="new" id="addtree-addnew" 
+                           data-event-category="add-tree" data-event-action="done-add-new" /><label for="addtree-addnew">
                         {% trans "Add another tree with new details" %}
                     </label>
                 </div>
                 <div>
-                    <input type="radio" name="addFeatureOptions" value="edit" id="addtree-viewdetails" /><label for="addtree-viewdetails">
+                    <input type="radio" name="addFeatureOptions" value="edit" id="addtree-viewdetails"
+                           data-event-category="add-tree" data-event-action="done-edit" /><label for="addtree-viewdetails">
                         {% trans "Continue editing this tree" %}
                     </label>
                 </div>
                 <div>
-                    <input type="radio" name="addFeatureOptions" value="close" id="addtree-done" checked /><label for="addtree-done">
+                    <input type="radio" name="addFeatureOptions" value="close" id="addtree-done" checked
+                           data-event-category="add-tree" data-event-action="done-close" /><label for="addtree-done">
                         {% trans "I'm done!" %}
                     </label>
                 </div>
             </div>
-            {% include 'treemap/partials/step_controls.html' with last=True %}
+            {% include 'treemap/partials/step_controls.html' with last=True feature_name="tree" %}
         </div>
     </div>
 </div>

--- a/opentreemap/treemap/templates/treemap/partials/step_controls.html
+++ b/opentreemap/treemap/templates/treemap/partials/step_controls.html
@@ -16,7 +16,7 @@
         </li>
         {% endif %}
         <li class="next">
-            <a href="#">
+            <a href="#"{% if feature_name and last %} data-event-category="add-{{ feature_name }}" data-event-action="confirm-done"{% endif %}>
                 {% if last %} Done {% else %} Next &raquo; {% endif %}
             </a>
         </li>

--- a/opentreemap/treemap/templates/treemap/user.html
+++ b/opentreemap/treemap/templates/treemap/user.html
@@ -15,6 +15,16 @@
 active
 {% endblock %}
 
+{% block google_analytics_actions %}
+{# for user-specific pages, remove the username from the url for better tracking #}
+var pathname = document.location.pathname;
+pathname = pathname.replace(/users\/[\w.@+-]+\//, 'users/<username>/');
+
+ga('set', 'page', pathname);
+ga('global.set', 'page', pathname);
+{{ block.super }}
+{% endblock google_analytics_actions %}
+
 {% block header %}
 {% load i18n %}
 <div class="header">

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "doc": "doc"
   },
   "dependencies": {
+    "autotrack": "^0.6.5",
     "baconjs": "~0.6",
     "console-browserify": "~1.0.1",
     "dragula": "^2.0.2",


### PR DESCRIPTION
 - Switches from using Google Tag Manager to using `analytics.js` directly
 - Uses two trackers with different IDs for tracking events by map and in aggregate
 - Removes URLs from instance and user specific page hits to allow for aggregate analysis
 - Brings in the `autotrack` analytics plugin, and uses it to enable tracking of some of search and the add tree process.

Connects to #2576