### PR TITLE
Make Boundary.updated_at not nullable

### DIFF
--- a/opentreemap/treemap/migrations/0025_remove_null_from_boundary_updated_at.py
+++ b/opentreemap/treemap/migrations/0025_remove_null_from_boundary_updated_at.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0024_add_species_verbose_names'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='boundary',
+            name='updated_at',
+            field=models.DateTimeField(auto_now=True, db_index=True),
+        ),
+    ]

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -1226,8 +1226,8 @@ class Boundary(models.Model):
     category = models.CharField(max_length=255)
     sort_order = models.IntegerField()
 
-    updated_at = models.DateTimeField(  # TODO: remove null=True
-        null=True, auto_now=True, editable=False, db_index=True)
+    updated_at = models.DateTimeField(auto_now=True, editable=False,
+                                      db_index=True)
 
     objects = models.GeoManager()
 


### PR DESCRIPTION
Removes a TODO from the code. When this field was added it was marked as nullable so that the migration would be backwards compatible. The the current production database does not have any null values in this column.