### PR TITLE
Add canopy fields

### DIFF
--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -217,6 +217,22 @@ class Instance(models.Model):
     # Monotonically increasing number used to invalidate my InstanceAdjuncts
     adjuncts_timestamp = models.BigIntegerField(default=0)
 
+    """
+    Flag indicating whether canopy data is available and should be displayed.
+    """
+    # TODO: Switch to a BooleanField after the migration that adds this field
+    # has been deployed
+    canopy_enabled = models.NullBooleanField(default=False)
+
+    """
+    The boundary category to be used for showing a choropleth canopy
+    layer. max_length=255 matches Boundary.category
+    """
+    # TODO: Make this field non-nullable after the migration that adds
+    # this field has been deployed.
+    canopy_boundary_category = models.CharField(max_length=255, null=True,
+                                                blank=True)
+
     objects = models.GeoManager()
 
     def __unicode__(self):

--- a/opentreemap/treemap/migrations/0025_remove_null_from_boundary_updated_at.py
+++ b/opentreemap/treemap/migrations/0025_remove_null_from_boundary_updated_at.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0024_add_species_verbose_names'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='boundary',
+            name='updated_at',
+            field=models.DateTimeField(auto_now=True, db_index=True),
+        ),
+    ]

--- a/opentreemap/treemap/migrations/0026_add_canopy_fields.py
+++ b/opentreemap/treemap/migrations/0026_add_canopy_fields.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0025_remove_null_from_boundary_updated_at'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='boundary',
+            name='canopy_percent',
+            field=models.FloatField(null=True),
+        ),
+        migrations.AddField(
+            model_name='instance',
+            name='canopy_boundary_category',
+            field=models.CharField(max_length=255, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='instance',
+            name='canopy_enabled',
+            field=models.NullBooleanField(default=False),
+        ),
+    ]

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -1226,8 +1226,8 @@ class Boundary(models.Model):
     category = models.CharField(max_length=255)
     sort_order = models.IntegerField()
 
-    updated_at = models.DateTimeField(  # TODO: remove null=True
-        null=True, auto_now=True, editable=False, db_index=True)
+    updated_at = models.DateTimeField(auto_now=True, editable=False,
+                                      db_index=True)
 
     objects = models.GeoManager()
 

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -1229,6 +1229,8 @@ class Boundary(models.Model):
     updated_at = models.DateTimeField(auto_now=True, editable=False,
                                       db_index=True)
 
+    canopy_percent = models.FloatField(null=True)
+
     objects = models.GeoManager()
 
     def __unicode__(self):


### PR DESCRIPTION
Adds the fields required for showing canopy coverage for an instance.

- Instance.canopy_enabled: Whether or not the instance has canopy data
  available.
- Instance.canopy_boundary_category: The category of boundaries to use
  when showing a choropleth map of canopy coverage.
- Boundary.canopy_percent: The percent of the boundary area covered by
  tree canopy.

This PR builds on to of https://github.com/OpenTreeMap/otm-core/pull/2591 which cleans up an old backwards-compatible migration.

---

Connects to https://github.com/OpenTreeMap/otm-core/issues/2589