### PR TITLE
Handle invisible plot ID field

### DIFF
--- a/opentreemap/treemap/lib/map_feature.py
+++ b/opentreemap/treemap/lib/map_feature.py
@@ -331,11 +331,17 @@ def context_dict_for_map_feature(request, feature, edit=False):
 
     user = request.user
     if user and user.is_authenticated():
-        feature.mask_unauthorized_fields(user)
         favorited = Favorite.objects \
             .filter(map_feature=feature, user=user).exists()
     else:
         favorited = False
+
+    # The mask_unauthorized_fields call can set feature.id to None,
+    # which prevents the Favorite query above from ever returning
+    # True. To avoid that we need to do the field masking after
+    # setting the favorited flag.
+    if user and user.is_authenticated():
+        feature.mask_unauthorized_fields(user)
 
     feature.convert_to_display_units()
 

--- a/opentreemap/treemap/templates/treemap/map_feature_detail.html
+++ b/opentreemap/treemap/templates/treemap/map_feature_detail.html
@@ -89,8 +89,8 @@
             data-href="{{ request.get_full_path }}"
             data-is-favorited="{{ favorited }}"
             data-always-enable="{{ request.user.is_authenticated }}"
-            data-favorite-url="{% url 'favorite_map_feature' instance_url_name=request.instance.url_name feature_id=feature.id %}"
-            data-unfavorite-url="{% url 'unfavorite_map_feature' instance_url_name=request.instance.url_name feature_id=feature.id %}">
+            data-favorite-url="{% url 'favorite_map_feature' instance_url_name=request.instance.url_name feature_id=feature.pk %}"
+            data-unfavorite-url="{% url 'unfavorite_map_feature' instance_url_name=request.instance.url_name feature_id=feature.pk %}">
             {% if favorited %}
               <i id="favorite-star" class="icon-star"></i>
             {% else %}
@@ -277,7 +277,7 @@ var mapFeatureOptions = {
         deleteCancel: '#delete-cancel',
         deleteConfirmationBox: '#delete-confirmation-box',
     },
-    featureId: {{ feature.id }},
+    featureId: {{ feature.pk }},
     sidebar: '#sidebar',
     form: '#map-feature-form',
     inlineEditForm: {


### PR DESCRIPTION
Instance admins can set the permissions on the Plot.id field to "Invisible." This is not a useful feature, and we intend to replace it with a better permission system.

For now, referencing `pk` rather than `id` prevents template rendering errors and we can fix the problem of a map feature not showing up as favorited on the detail page by performing the favorite check before the fields are masked.

---

##### Testing

On the `develop` branch, on the roles management page for an instance you own, set Planting Site Id to Invisible on the Administrator role. Attempting to view a tree detail page will raise an exception. Switch to this branch and detail pages should load without error and the favoriting feature should work.

---

Connects to https://github.com/OpenTreeMap/otm-core/issues/2594