### PR TITLE
Make instance canopy fields non-null

### DIFF
--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -220,17 +220,13 @@ class Instance(models.Model):
     """
     Flag indicating whether canopy data is available and should be displayed.
     """
-    # TODO: Switch to a BooleanField after the migration that adds this field
-    # has been deployed
-    canopy_enabled = models.NullBooleanField(default=False)
+    canopy_enabled = models.BooleanField(default=False)
 
     """
     The boundary category to be used for showing a choropleth canopy
     layer. max_length=255 matches Boundary.category
     """
-    # TODO: Make this field non-nullable after the migration that adds
-    # this field has been deployed.
-    canopy_boundary_category = models.CharField(max_length=255, null=True,
+    canopy_boundary_category = models.CharField(max_length=255, default='',
                                                 blank=True)
 
     objects = models.GeoManager()

--- a/opentreemap/treemap/migrations/0027_make_instance_canopy_fields_non_null.py
+++ b/opentreemap/treemap/migrations/0027_make_instance_canopy_fields_non_null.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0026_add_canopy_fields'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='instance',
+            name='canopy_boundary_category',
+            field=models.CharField(default='', max_length=255, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='instance',
+            name='canopy_enabled',
+            field=models.BooleanField(default=False),
+        ),
+    ]


### PR DESCRIPTION
This cleans up the backwards compatible 0026 migration.

---

Connects to https://github.com/OpenTreeMap/otm-core/issues/2589