### PR TITLE
Bump pyrollbar to 0.12.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,5 +28,5 @@ django-tinsel==0.1.1
 django-url-tools==0.0.8
 django-redis==4.3.0
 hiredis==0.2.0
-rollbar==0.11.1
+rollbar==0.12.1
 django-statsd-mozilla==0.3.16


### PR DESCRIPTION
Most of the changes in the `CHANGELOG` are bug fixes. There is one breaking change in the 0.12.x jump, but it pertains to Twisted support.

See also: https://github.com/rollbar/pyrollbar/blob/master/CHANGELOG.md

---

**Testing**

Provision and ensure that 0.12.1 is installed.