### PR TITLE
Add searchable field to Bounds model

### DIFF
--- a/opentreemap/treemap/migrations/0027_boundary_searchable.py
+++ b/opentreemap/treemap/migrations/0027_boundary_searchable.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0026_add_canopy_fields'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='boundary',
+            name='searchable',
+            field=models.NullBooleanField(default=True),
+        ),
+    ]

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -1230,6 +1230,7 @@ class Boundary(models.Model):
                                       db_index=True)
 
     canopy_percent = models.FloatField(null=True)
+    searchable = models.NullBooleanField(default=True)
 
     objects = models.GeoManager()
 

--- a/opentreemap/treemap/views/misc.py
+++ b/opentreemap/treemap/views/misc.py
@@ -120,7 +120,9 @@ def boundary_to_geojson(request, instance, boundary_id):
 def boundary_autocomplete(request, instance):
     max_items = request.GET.get('max_items', None)
 
-    boundaries = instance.boundaries.order_by('name')[:max_items]
+    boundaries = instance.boundaries \
+                         .filter(searchable=True) \
+                         .order_by('name')[:max_items]
 
     return [{'name': boundary.name,
              'category': boundary.category,


### PR DESCRIPTION
The purpose of this field is to disable boundaries from appearing in the
frontend "Search by Location" autocomplete popup.

**Test:**

1. Run migrations
    ```sh
    ./scripts/manage.sh migrate
    ```

2. Disable searching on all boundaries (if you dare)
    ```sh
    vagrant ssh services -c 'sudo -u postgres psql otm -c "update treemap_boundary set searchable=false"'
    ```

3. Verify that no boundaries appear in the "Search by Location" autocomplete

**Note:** You may have to clear localStorage to see this change.

```
localStorage.clear()
```

Connects #2598