### PR TITLE
Show a map marker when a location search succeeds

### DIFF
--- a/opentreemap/treemap/js/src/mapPage.js
+++ b/opentreemap/treemap/js/src/mapPage.js
@@ -6,7 +6,7 @@ var $ = require('jquery'),
     _ = require('lodash'),
     Bacon = require('baconjs'),
     L = require('leaflet'),
-    BU = require('treemap/baconUtils'),
+    U = require('treemap/utility'),
     MapManager = require('treemap/MapManager'),
     mapManager = new MapManager(),
     urlState = require('treemap/urlState'),
@@ -26,7 +26,7 @@ module.exports.init = function (options) {
     // if the map is not already zoomed in.
     var searchBar = SearchBar.init(config);
 
-    searchBar.geocodedLocationStream.onValue(mapManager, 'setCenterWM');
+    searchBar.geocodedLocationStream.onValue(_.partial(onLocationFound, config, mapManager));
 
     var triggeredQueryStream =
         Bacon.mergeAll(
@@ -43,6 +43,10 @@ module.exports.init = function (options) {
     triggeredQueryStream.onValue(searchBar.applySearchToDom);
 
     builtSearchEvents.onValue(urlState.setSearch);
+
+    searchBar.searchChangedStream.onValue(function () {
+        clearFoundLocationMarker(mapManager.map);
+    });
 
     boundarySelect.init({
         config: config,
@@ -63,6 +67,29 @@ module.exports.init = function (options) {
         initMapState: urlState.init
     };
 };
+
+function onLocationFound(config, mapManager, location) {
+    var latLng = U.webMercatorToLeafletLatLng(location.x, location.y),
+        marker = L.marker(latLng, {
+            icon: L.icon({
+                iconUrl: config.staticUrl + 'img/marker.png',
+                iconSize: [21, 25],
+                iconAnchor: [10, 24]
+            }),
+            clickable: false,
+            keyboard: false
+        });
+    marker.addTo(mapManager.map);
+    mapManager.map.foundLocationMarker = marker;
+    mapManager.setCenterLL(latLng);
+}
+
+function clearFoundLocationMarker(map) {
+    if (map.foundLocationMarker) {
+        map.removeLayer(map.foundLocationMarker);
+        map.foundLocationMarker = null;
+    }
+}
 
 // Extract and return numeric region ID from JSON search object, or
 // return undefined if a region is not specified in the search object.

--- a/opentreemap/treemap/js/src/searchBar.js
+++ b/opentreemap/treemap/js/src/searchBar.js
@@ -329,6 +329,9 @@ module.exports = exports = {
                 })
                 .map(Search.buildSearch),
             uSearch = udfcSearch.init(resetStream),
+            searchChangedStream = Bacon
+                .mergeAll(searchStream, resetStream)
+                .map(true),
 
             geocodeResponseStream = geocoderInvokeUi({
                 config: config,
@@ -348,7 +351,7 @@ module.exports = exports = {
         initSearchUi(config, searchStream);
 
         return {
-            // a stream events corresponding to clicks on the reset button.
+            // a stream of events corresponding to clicks on the reset button.
             resetStream: resetStream,
 
             // the final, pinpointed stream of geocoded locations
@@ -359,6 +362,9 @@ module.exports = exports = {
             // Stream of search events, carries the filter object and display
             // list with it. should be used by consumer to execute searches.
             filterNonGeocodeObjectStream: filtersStream,
+
+            // has a value on all events that change the current search
+            searchChangedStream: searchChangedStream,
 
             applySearchToDom: function (search) {
                 Search.applySearchToDom(search);


### PR DESCRIPTION
* Marker is removed when user starts a new search or clicks the "Reset" button.
* Icon uses otherwise-unused `marker.png`.
* Marker displays on top of other layers, but is not clickable.

Connects #2588

![image](https://cloud.githubusercontent.com/assets/2162993/15832003/44515d42-2bee-11e6-8ca4-cf3c5baae115.png)
