### PR TITLE
Show error message when uploading files larger than 1MB

### DIFF
--- a/opentreemap/treemap/templates/treemap/map_feature_detail.html
+++ b/opentreemap/treemap/templates/treemap/map_feature_detail.html
@@ -293,7 +293,8 @@ var mapFeatureOptions = {
         panelId: '#add-photo-modal',
         dataType: 'html',
         imageContainer: '#photo-carousel',
-        lightbox: '#photo-lightbox'
+        lightbox: '#photo-lightbox',
+        fileExceedsMaximumFileSize: '{% trans "{0} exceeds the maximum file size of {1}" %}'
     },
     location: {
         edit: '#edit-location',


### PR DESCRIPTION
Prevent image uploads for file sizes equal to or greater than 1MB.

**Test:**
* Rebuild static assets `./scripts/grunt.sh`
* Try to upload a file 1MB or larger
* Ensure you get an error toast if the file is too big

Connects #2525