### PR TITLE
Add a merge migration

### DIFF
--- a/opentreemap/treemap/migrations/0029_merge.py
+++ b/opentreemap/treemap/migrations/0029_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0027_make_instance_canopy_fields_non_null'),
+        ('treemap', '0028_auto_20160531_1537'),
+    ]
+
+    operations = [
+    ]


### PR DESCRIPTION
Merging a pull request containing 0027_make_instance_canopy_fields_non_null created a migration conflict. I created the merge migration in this commit with the following command:

```
$ vagrant ssh app -c 'cd /opt/app/core/opentreemap \
&& envdir /etc/otm.d/env ./manage.py makemigrations --merge'
Merging treemap
  Branch 0027_make_instance_canopy_fields_non_null
    - Alter field canopy_boundary_category on instance
    - Alter field canopy_enabled on instance
  Branch 0028_auto_20160531_1537
    - Add field searchable to boundary
    - Alter field searchable on boundary
```