### PR TITLE
Ensure checkbox value is always True or False

### DIFF
--- a/opentreemap/treemap/js/src/editableForm.js
+++ b/opentreemap/treemap/js/src/editableForm.js
@@ -100,7 +100,10 @@ exports.init = function(options) {
                     if ($(display).is('[data-value]')) {
                         $input = FH.getSerializableField($(editFields), field);
                         if ($input.is('[type="checkbox"]')) {
-                            value = $input.is(':checked') ? "Yes" : "No";
+                            // To set a custom display value, use these data attributes:
+                            // - data-bool-true-text
+                            // - data-bool-false-text
+                            value = $input.is(':checked') ? "True" : "False";
                         } else if ($input.is('[data-date-format]')) {
                             value = FH.getTimestampFromDatepicker($input);
                         } else if ($input.is('select[multiple]')) {


### PR DESCRIPTION
This reverts a change that was made to set a custom display value in the
super admin. The super admin addon has been updated to use data
attributes to set a custom display value instead of hard-coding them
here.

The value field for checkboxes must always be True or False for parity
with the Django backend. Otherwise, checkbox values will become corrupt after
saving the form multiple times via ajax.

Ref https://github.com/OpenTreeMap/otm-addons/issues/1173