### PR TITLE
Fix boundaries dropdown sort order

### DIFF
--- a/opentreemap/treemap/js/src/otmTypeahead.js
+++ b/opentreemap/treemap/js/src/otmTypeahead.js
@@ -64,7 +64,7 @@ var create = exports.create = function(options) {
         $hidden_input = $(options.hidden),
         $openButton = $(options.button),
         reverse = options.reverse,
-        sorter = _.isArray(options.sortKeys) ? getSortFunction(options.sortKeys) : undefined,
+        sorter = _.isArray(options.sortKeys) ? getSortFunction(options.sortKeys) : getSortFunction(['value']),
 
         setTypeaheadAfterDataLoaded = function($typeahead, key, query) {
             if (!key) {
@@ -94,7 +94,9 @@ var create = exports.create = function(options) {
             limit: 3000,
             source: function(query, sync, async) {
                 if (query === '') {
-                    sync(prefetchEngine.all());
+                    var result = prefetchEngine.all();
+                    result.sort(sorter);
+                    sync(result);
                 } else {
                     prefetchEngine.search(query, sync, async);
                 }

--- a/opentreemap/treemap/views/misc.py
+++ b/opentreemap/treemap/views/misc.py
@@ -122,7 +122,7 @@ def boundary_autocomplete(request, instance):
 
     boundaries = instance.boundaries \
                          .filter(searchable=True) \
-                         .order_by('name')[:max_items]
+                         .order_by('sort_order', 'name')[:max_items]
 
     return [{'name': boundary.name,
              'category': boundary.category,


### PR DESCRIPTION
* Update boundaries endpoint to order results by sort_order then name
* Ensure client-side results are sorted when displaying "all" results
  (Bloodhound orders "all" results by id)

Connects #2608