### PR TITLE
Increase max upload filesize

### DIFF
--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -45,6 +45,7 @@ AWS_HEADERS = {
 
 # Size is in bytes (20 MB)
 MAXIMUM_IMAGE_SIZE = int(os.environ.get('DJANGO_MAXIMUM_IMAGE_SIZE', 20971520))
+MAXIMUM_IMAGE_SIZE_MB = MAXIMUM_IMAGE_SIZE / 1024 / 1024
 
 # API distance check, in meters
 MAP_CLICK_RADIUS = 100

--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -43,8 +43,8 @@ AWS_HEADERS = {
     'Cache-Control': 'max-age=86400',
 }
 
-# Size is in bytes
-MAXIMUM_IMAGE_SIZE = 20971520  # 20mb
+# Size is in bytes (20 MB)
+MAXIMUM_IMAGE_SIZE = int(os.environ.get('DJANGO_MAXIMUM_IMAGE_SIZE', 20971520))
 
 # API distance check, in meters
 MAP_CLICK_RADIUS = 100

--- a/opentreemap/treemap/js/src/imageUploadPanel.js
+++ b/opentreemap/treemap/js/src/imageUploadPanel.js
@@ -19,9 +19,6 @@ require('jqueryIframeTransport');
 require('jqueryFileUpload');
 
 
-var MAX_FILE_SIZE_BYTES = 1048576; // 1 MB (Default Nginx client_max_body_size value)
-
-
 module.exports.init = function(options) {
     var $panel = $(options.panelId),
         $image = $(options.imageElement),
@@ -104,10 +101,11 @@ module.exports.init = function(options) {
         data.process(function() {
             var defer = $.Deferred();
             _.each(data.files, function(file) {
-                if (file.size >= MAX_FILE_SIZE_BYTES) {
-                    var message = options.fileExceedsMaximumFileSize
+                if (file.size >= options.maxImageSize) {
+                    var mb = options.maxImageSize / 1024 / 1024,
+                        message = options.fileExceedsMaximumFileSize
                             .replace('{0}', file.name)
-                            .replace('{1}', MAX_FILE_SIZE_BYTES / 1024 / 1024 + ' MB');
+                            .replace('{1}', mb + ' MB');
                     toastr.error(message);
                     defer.reject([data]);
                 }

--- a/opentreemap/treemap/templates/treemap/map_feature_detail.html
+++ b/opentreemap/treemap/templates/treemap/map_feature_detail.html
@@ -294,7 +294,8 @@ var mapFeatureOptions = {
         dataType: 'html',
         imageContainer: '#photo-carousel',
         lightbox: '#photo-lightbox',
-        fileExceedsMaximumFileSize: '{% trans "{0} exceeds the maximum file size of {1}" %}'
+        fileExceedsMaximumFileSize: '{% trans "{0} exceeds the maximum file size of {1}" %}',
+        maxImageSize: {{ settings.MAXIMUM_IMAGE_SIZE }}
     },
     location: {
         edit: '#edit-location',

--- a/opentreemap/treemap/templates/treemap/partials/upload_image.html
+++ b/opentreemap/treemap/templates/treemap/partials/upload_image.html
@@ -1,3 +1,5 @@
+{% load i18n %}
+
 <div id="{{ panel_id }}" class="modal fade">
   <div class="modal-dialog">
     <div class="modal-content">
@@ -6,6 +8,11 @@
         <h2>{{ title }}</h2>
       </div>
       <div class="modal-body">
+        <p>
+          {% blocktrans with settings.MAXIMUM_IMAGE_SIZE_MB as max_image_size %}
+            Maximum file size: {{ max_image_size }}MB
+          {% endblocktrans %}
+        </p>
         <input class="fileChooser" type="file" name="file" data-url="{{ upload_photo_endpoint }}" accept="image/*">
         <div class="progress">
           <div class="progress-bar-info" style="width: 0%; height: 100%"></div>


### PR DESCRIPTION
Read `MAXIMUM_IMAGE_SIZE` from an environmental variable and pass that
value to the client-side JS instead of hard-coding it.

Depends on https://github.com/OpenTreeMap/otm-cloud/pull/233