### PR TITLE
Initialize eco factors from instance bounds, not point

### DIFF
--- a/opentreemap/treemap/management/commands/create_instance.py
+++ b/opentreemap/treemap/management/commands/create_instance.py
@@ -110,11 +110,10 @@ class Command(BaseCommand):
         add_default_permissions(instance, roles=[role])
 
         eco_benefits_conversion = \
-            BenefitCurrencyConversion.get_default_for_point(Point(x, y))
+            BenefitCurrencyConversion.get_default_for_instance(instance)
         if eco_benefits_conversion:
             eco_benefits_conversion.save()
-
-        instance.eco_benefits_conversion = eco_benefits_conversion
+            instance.eco_benefits_conversion = eco_benefits_conversion
 
         instance.default_role = role
         instance.save()

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -196,17 +196,14 @@ class BenefitCurrencyConversion(Dictable, models.Model):
         }
 
     @classmethod
-    def get_default_for_point(cls, point):
+    def get_default_for_instance(cls, instance):
         """
-        Returns a new BenefitCurrencyConversion for the i-Tree region that
-        contains the given point.
+        Returns a new BenefitCurrencyConversion for the instance's (first)
+        i-Tree region. The instance must have bounds for this to work.
         """
-        regions_covered = ITreeRegion.objects.filter(geometry__contains=point)
+        regions_covered = instance.itree_regions()
 
-        if len(regions_covered) > 1:
-            raise MultipleObjectsReturned(
-                "There should not be overlapping i-Tree regions")
-        elif len(regions_covered) == 0:
+        if len(regions_covered) == 0:
             return None
 
         region_code = regions_covered[0].code


### PR DESCRIPTION
Sometimes the center of a treemap is not in any i-Tree region, but the treemaps bounds do overlap an i-Tree region.

Depends on OpenTreeMap/otm-addons#1194