### PR TITLE
Add regional canopy filter legend

### DIFF
--- a/opentreemap/treemap/css/sass/partials/pages/_map.scss
+++ b/opentreemap/treemap/css/sass/partials/pages/_map.scss
@@ -1,5 +1,17 @@
 // Partial: Map Page
 
+// Keep these colors in sync with otm-tiler/style/canopy.mms
+$light-to-dark-green: #ffffff 10%,
+                      #f6f9f4 10%, #f6f9f4 20%,
+                      #d7ebc7 20%, #d7ebc7 30%,
+                      #b8dd9b 30%, #b8dd9b 40%,
+                      #99cf6f 40%, #99cf6f 50%,
+                      #7ac143 50%, #7ac143 60%,
+                      #5ba63b 60%, #5ba63b 70%,
+                      #3d8c33 70%, #3d8c33 80%,
+                      #1e722b 80%, #1e722b 90%,
+                      #005824 90%;
+
 #streetview {
     width: 200px;
     height: 180px;
@@ -240,4 +252,29 @@
 .canopy-filter {
     background: #fff;
     padding: 10px;
+
+    .from-label,
+    .to-label {
+        position: absolute;
+        top: 30px;
+        font-size: smaller;
+    }
+    .from-label {
+        left: 10px;
+    }
+    .to-label {
+        right: 10px;
+    }
+
+   .color-ramp {
+       display: inline-block;
+       width: 150px;
+       height: 10px;
+       border: 1px solid #ddd;
+
+       &.light-to-dark-green {
+           background: -webkit-linear-gradient(90deg, $light-to-dark-green);
+           background: linear-gradient(90deg, $light-to-dark-green);
+       }
+   }
 }

--- a/opentreemap/treemap/js/src/MapManager.js
+++ b/opentreemap/treemap/js/src/MapManager.js
@@ -11,7 +11,7 @@ var $ = require('jquery'),
     urlState = require('treemap/urlState'),
 
     layersLib = require('treemap/layers'),
-    CanopyFilterControl = require('treemap/CanopyFilterControl'),
+    CanopyFilterControl = require('treemap/controls').CanopyFilterControl,
 
     MIN_ZOOM_OPTION = layersLib.MIN_ZOOM_OPTION,
     MAX_ZOOM_OPTION = layersLib.MAX_ZOOM_OPTION,

--- a/opentreemap/treemap/js/src/controls.js
+++ b/opentreemap/treemap/js/src/controls.js
@@ -35,20 +35,30 @@ var CanopyFilterControl = L.Control.extend({
             step: 1,
             drag_interval: true,
             hide_min_max: true,
+            hide_from_to: true,
             grid: false,
             postfix: '%',
             onChange: function (data) {
-                self._changeBus.push({
+                changeBus.push({
                     canopyMin: data.from / 100,
                     canopyMax: data.to / 100
                 });
             },
         });
 
-        var el = $el.get(0);
+        this.tilerArgsProp.onValue(function(value) {
+            $el.find('.from-label').text(Math.floor(value.canopyMin * 100) + '%');
+            $el.find('.to-label').text(Math.floor(value.canopyMax * 100) + '%');
+        });
+    },
+
+    onAdd: function(map) {
+        var el = this.$el.get(0);
         L.DomEvent.disableClickPropagation(el);
         return el;
     }
 });
 
-module.exports = CanopyFilterControl;
+module.exports = {
+    CanopyFilterControl: CanopyFilterControl
+};

--- a/opentreemap/treemap/js/src/controls.js
+++ b/opentreemap/treemap/js/src/controls.js
@@ -15,18 +15,17 @@ var CanopyFilterControl = L.Control.extend({
     },
 
     initialize: function() {
-        this._changeBus = new Bacon.Bus();
-        this.tilerArgsProp = this._changeBus.toProperty({
+        var self = this,
+            $el = $(canopyFilterTmpl()),
+            changeBus = new Bacon.Bus();
+
+        this.$el = $el;
+        this.tilerArgsProp = changeBus.toProperty({
             canopyMin: 0,
             canopyMax: 1
         });
-    },
 
-    onAdd: function(map) {
-        var self = this,
-            $el = $(canopyFilterTmpl());
-
-        $el.find('[name="canopy-slider"]').ionRangeSlider({
+        this.$el.find('[name="canopy-slider"]').ionRangeSlider({
             type: 'double',
             min: 0,
             max: 100,

--- a/opentreemap/treemap/templates/treemap/partials/canopy_filter_control.html
+++ b/opentreemap/treemap/templates/treemap/partials/canopy_filter_control.html
@@ -1,8 +1,13 @@
 {% load i18n %}
 
 <script type="text/template" id="canopy-filter-tmpl">
-<div class="canopy-filter leaflet-control leaflet-bar">
-    <h4>{% trans "Regional Canopy Filter" %}</h4>
+<div class="canopy-filter leaflet-control leaflet-bar text-center">
+    <strong>{% trans "Regional Canopy Filter" %}</strong>
+    <span class="from-label"></span>
+    <span class="to-label"></span>
     <input type="text" name="canopy-slider" value="" />
+    <div class="legend">
+        <div class="color-ramp light-to-dark-green"></div>
+    </div>
 </div>
 </script>


### PR DESCRIPTION
This alters the style of the regional canopy filter control somewhat and adds a legend.

![screenshot 2016-06-27 at 16 20 16](https://cloud.githubusercontent.com/assets/43062/16394417/188eeea4-3c83-11e6-8e2f-28508bb7995d.png)

Connects #2629