### PR TITLE
Improve default map extent to be based on feature locations

### DIFF
--- a/opentreemap/opentreemap/util.py
+++ b/opentreemap/opentreemap/util.py
@@ -119,3 +119,15 @@ def add_rollbar_handler(logger, level=logging.WARNING):
         rollbar_handler = RollbarHandler()
         rollbar_handler.setLevel(level)
         logger.addHandler(rollbar_handler)
+
+
+def extent_as_json(extent):
+    xmin, ymin, xmax, ymax = extent
+
+    return json.dumps({'xmin': xmin, 'ymin': ymin, 'xmax': xmax, 'ymax': ymax})
+
+
+def extent_intersection(*extents):
+    extents = zip(*extents)
+    xmins, ymins, xmaxes, ymaxes = extents
+    return (max(xmins), max(ymins), min(xmaxes), min(ymaxes))

--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from __future__ import division
 
 from django.contrib.gis.db import models
+from django.contrib.gis.db.models import Extent
 from django.contrib.gis.geos import MultiPolygon, Polygon
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import RegexValidator
@@ -15,6 +16,8 @@ from django.utils.translation import ugettext_lazy as _
 import hashlib
 import json
 from urllib import urlencode
+
+from opentreemap.util import extent_intersection, extent_as_json
 
 from treemap.search_fields import (DEFAULT_MOBILE_SEARCH_FIELDS,
                                    DEFAULT_MOBILE_API_FIELDS,
@@ -28,6 +31,8 @@ from treemap.species.codes import (species_codes_for_regions,
                                    all_species_codes, ITREE_REGION_CHOICES)
 
 URL_NAME_PATTERN = r'[a-zA-Z]+[a-zA-Z0-9\-]*'
+
+_DEFAULT_REV = 1
 
 
 def reserved_name_validator(name):
@@ -171,9 +176,10 @@ class Instance(models.Model):
     modified in a way that would affect ecobenefit calculations.
     Its value is part of cache keys for non-search ecobenefit summaries.
     """
-    geo_rev = models.IntegerField(default=1)
-    universal_rev = models.IntegerField(default=1, null=True, blank=True)
-    eco_rev = models.IntegerField(default=1)
+    geo_rev = models.IntegerField(default=_DEFAULT_REV)
+    universal_rev = models.IntegerField(default=_DEFAULT_REV,
+                                        null=True, blank=True)
+    eco_rev = models.IntegerField(default=_DEFAULT_REV)
 
     eco_benefits_conversion = models.ForeignKey(
         'BenefitCurrencyConversion', null=True, blank=True)
@@ -291,12 +297,25 @@ class Instance(models.Model):
         return n > 1
 
     @property
-    def extent_as_json(self):
-        boundary = self.bounds.geom.boundary
-        xmin, ymin, xmax, ymax = boundary.extent
+    def map_extent_as_json(self):
+        feature_extent = self.mapfeature_set \
+            .aggregate(Extent('geom'))['geom__extent']
+        bounds_extent = self.bounds_extent
 
-        return json.dumps({'xmin': xmin, 'ymin': ymin,
-                           'xmax': xmax, 'ymax': ymax})
+        if feature_extent is not None:
+            intersection = extent_intersection(feature_extent, bounds_extent)
+            return extent_as_json(intersection)
+
+        return extent_as_json(bounds_extent)
+
+    @property
+    def bounds_extent(self):
+        boundary = self.bounds.geom.boundary
+        return boundary.extent
+
+    @property
+    def bounds_extent_as_json(self):
+        return extent_as_json(self.bounds_extent)
 
     @property
     def bounds_as_geojson(self):

--- a/opentreemap/treemap/js/src/MapManager.js
+++ b/opentreemap/treemap/js/src/MapManager.js
@@ -42,8 +42,7 @@ MapManager.prototype = {
         this._utfLayer = utfLayer;
         allPlotsLayer.setOpacity(0.3);
 
-        options.centerWM = options.centerWM || config.instance.center;
-        options.zoom = options.zoom || this.ZOOM_DEFAULT;
+        options.bounds = getDomMapAttribute('bounds', options.domId);
         var map = this.createMap(options);
 
         if (options.plotLayerViewOnly) {
@@ -115,11 +114,20 @@ MapManager.prototype = {
     createMap: function (options) {
         var center = options.centerWM || {x: 0, y: 0},
             zoom = options.zoom || 2,
-            map = L.map(options.domId, {
-                center: U.webMercatorToLeafletLatLng(center.x, center.y),
-                zoom: zoom
-            }),
+            bounds = options.bounds,
+            map = L.map(options.domId),
             basemapMapping = getBasemapLayers(options.config);
+
+        if (_.isUndefined(bounds)) {
+            map.setView(U.webMercatorToLeafletLatLng(center.x, center.y), zoom);
+        } else {
+            map.fitBounds([
+                    U.webMercatorToLeafletLatLng(bounds.xmin, bounds.ymin),
+                    U.webMercatorToLeafletLatLng(bounds.xmax, bounds.ymax)
+                ],
+                MAX_ZOOM_OPTION
+            );
+        }
 
         if (_.isArray(basemapMapping)) {
             _.each(_.values(basemapMapping),

--- a/opentreemap/treemap/templates/treemap/map.html
+++ b/opentreemap/treemap/templates/treemap/map.html
@@ -26,7 +26,8 @@
   </div>
   <div id="map" class="map"
        data-has-boundaries="{{ has_boundaries }}"
-       data-has-polygons="{{ has_polygons }}">
+       data-has-polygons="{{ has_polygons }}"
+       data-bounds="{{ request.instance.map_extent_as_json }}">
   </div>
   <div class="sidebar">
     <div id="sidebar-browse-trees">

--- a/opentreemap/treemap/templates/treemap/settings.js
+++ b/opentreemap/treemap/templates/treemap/settings.js
@@ -75,7 +75,7 @@ otm.settings.doubleClickInterval = '{{ settings.DOUBLE_CLICK_INTERVAL }}';
             'x': '{{ request.instance.center.x }}',
             'y': '{{ request.instance.center.y }}'
         },
-        'extent': {{ request.instance.extent_as_json|safe }},
+        'extent': {{ request.instance.bounds_extent_as_json|safe }},
         'bounds': {{ request.instance.bounds_as_geojson|safe }},
         'basemap': {
             'type': '{{ request.instance.basemap_type }}',


### PR DESCRIPTION
We previously always centered the map on the map center point with a fixed
zoom.
With this change, we instead position the map so that all features added
to the map are visible. If a map has no trees yet, we position the map so
that all of the map's bounds are visible.

Connects to OpenTreeMap/otm-addons#1155