### PR TITLE
Loosen the selenium package version spec

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 PyVirtualDisplay==0.1.5
-selenium==2.53.1
+selenium>=2.53.6,<3.0.0
 coverage==4.0.3


### PR DESCRIPTION
On several occasions we have run into unit test failures that were resolved by updating the selenium package. Because this package is only installed in dev and test environments loosening the version specification will not jeopardize the repeatability of production builds.

2.53.6 was the latest version at the time of this commit.