### PR TITLE
Let users delete trees and map features they created, regardless of permissions

### DIFF
--- a/opentreemap/api/views.py
+++ b/opentreemap/api/views.py
@@ -32,7 +32,8 @@ from treemap.decorators import api_admin_instance_request as \
     admin_instance_request
 from treemap.decorators import creates_instance_user
 from django_tinsel.exceptions import HttpBadRequestException
-from treemap.audit import Audit, approve_or_reject_audit_and_apply
+from treemap.audit import (Audit, approve_or_reject_audit_and_apply,
+                           AuthorizeException)
 
 from api.auth import create_401unauthorized
 from api.decorators import (check_signature, check_signature_and_require_login,
@@ -241,10 +242,8 @@ def remove_plot(request, instance, plot_id):
     try:
         plot.delete_with_user(request.user)
         return {"ok": True}
-    except Exception:
-        raise PermissionDenied(
-            '%s does not have permission to delete plot %s' %
-            (request.user.username, plot_id))
+    except AuthorizeException as e:
+        raise PermissionDenied(e.msg)
 
 
 @require_http_methods(["DELETE"])

--- a/opentreemap/treemap/lib/perms.py
+++ b/opentreemap/treemap/lib/perms.py
@@ -146,8 +146,6 @@ def is_deletable(instanceuser, obj):
     if _invalid_instanceuser(instanceuser):
         return False
     else:
-        # TODO: factor this off user and roll it into
-        # this module
         return obj.user_can_delete(instanceuser.user)
 
 
@@ -200,13 +198,6 @@ def map_feature_is_writable(role_related_obj, model_obj, field=None):
                         model_obj.__class__.__name__,
                         perm_attr=ALLOWS_WRITES,
                         predicate=any, field=field)
-
-
-def map_feature_is_deletable(role_related_obj, model_obj):
-    return _allows_perm(role_related_obj,
-                        model_obj.__class__.__name__,
-                        perm_attr=ALLOWS_WRITES,
-                        predicate=all)
 
 
 def plot_is_writable(role_related_obj, field=None):

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -579,6 +579,8 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
     hide_at_zoom = models.IntegerField(
         null=True, blank=True, default=None, db_index=True)
 
+    users_can_delete_own_creations = True
+
     def __init__(self, *args, **kwargs):
         super(MapFeature, self).__init__(*args, **kwargs)
         if self.feature_type == '':
@@ -947,6 +949,8 @@ class Tree(Convertible, UDFModel, PendingAuditable, ValidationMixin):
                                     verbose_name=_("Date Planted"))
     date_removed = models.DateField(null=True, blank=True,
                                     verbose_name=_("Date Removed"))
+
+    users_can_delete_own_creations = True
 
     objects = GeoHStoreUDFManager()
 

--- a/opentreemap/treemap/templates/treemap/map_feature_detail.html
+++ b/opentreemap/treemap/templates/treemap/map_feature_detail.html
@@ -127,7 +127,7 @@
                     data-always-enable="{{ last_effective_instance_user|is_deletable:tree }}"
                     data-disabled-title="{% trans "Deleting of trees is not available to all users" %}"
                     {% else %}
-                    data-always-enable="{{ last_effective_instance_user|map_feature_is_deletable:feature }}"
+                    data-always-enable="{{ last_effective_instance_user|is_deletable:feature }}"
                     {% if feature.is_plot %}
                     data-disabled-title="{% trans "Deleting of planting sites is not available to all users" %}"
                     {% else %}

--- a/opentreemap/treemap/templatetags/instance_config.py
+++ b/opentreemap/treemap/templatetags/instance_config.py
@@ -64,7 +64,6 @@ def as_json(d):
 udf_write_level = register.filter(perms.udf_write_level)
 geom_is_writable = register.filter(perms.geom_is_writable)
 map_feature_is_writable = register.filter(perms.map_feature_is_writable)
-map_feature_is_deletable = register.filter(perms.map_feature_is_deletable)
 plot_is_writable = register.filter(perms.plot_is_writable)
 is_deletable = register.filter(perms.is_deletable)
 is_read_or_write = register.filter(perms.is_read_or_write)

--- a/opentreemap/treemap/tests/__init__.py
+++ b/opentreemap/treemap/tests/__init__.py
@@ -129,6 +129,8 @@ def make_officer_role(instance):
         ('Plot', 'geom', FieldPermission.WRITE_DIRECTLY),
         ('Plot', 'length', FieldPermission.WRITE_DIRECTLY),
         ('Plot', 'readonly', FieldPermission.WRITE_DIRECTLY),
+        ('RainBarrel', 'geom', FieldPermission.WRITE_DIRECTLY),
+        ('RainBarrel', 'capacity', FieldPermission.WRITE_DIRECTLY),
         ('Tree', 'diameter', FieldPermission.WRITE_DIRECTLY),
         ('Tree', 'plot', FieldPermission.WRITE_DIRECTLY),
         ('Tree', 'height', FieldPermission.WRITE_DIRECTLY))

--- a/opentreemap/treemap/tests/test_audit.py
+++ b/opentreemap/treemap/tests/test_audit.py
@@ -14,6 +14,7 @@ from django.core.urlresolvers import reverse
 from django.db import IntegrityError, connection
 from django.contrib.gis.geos import Point
 
+from stormwater.models import RainBarrel
 from treemap.templatetags.util import audit_detail_link
 
 from treemap.models import (Tree, Plot, FieldPermission, User, InstanceUser,
@@ -28,7 +29,8 @@ from treemap.udf import UserDefinedFieldDefinition
 from treemap.tests import (make_instance, make_user_with_default_role,
                            make_user_and_role, make_commander_user,
                            make_officer_user, make_observer_user,
-                           make_apprentice_user, set_write_permissions)
+                           make_apprentice_user, set_write_permissions,
+                           make_admin_user)
 from treemap.tests.base import OTMTestCase
 
 
@@ -920,10 +922,7 @@ class UserRoleFieldPermissionTest(OTMTestCase):
             self.tree.delete_with_user(self.outlaw)
 
         iuser = self.outlaw.get_instance_user(self.instance)
-        role = Role.objects.create(instance=self.instance,
-                                   name=Role.ADMINISTRATOR,
-                                   rep_thresh=0)
-        iuser.role = role
+        iuser.admin = True
         iuser.save_with_user(self.commander)
 
         self.tree.delete_with_user(self.outlaw)
@@ -936,14 +935,12 @@ class UserRoleFieldPermissionTest(OTMTestCase):
         with self.assertRaises(AuthorizeException):
             self.plot.delete_with_user(self.outlaw, cascade=True)
 
-        with self.assertRaises(AuthorizeException):
-            self.tree.delete_with_user(self.officer)
-
-        with self.assertRaises(AuthorizeException):
-            self.plot.delete_with_user(self.officer, cascade=True)
-
         self.tree.delete_with_user(self.commander)
         self.plot.delete_with_user(self.commander, cascade=True)
+
+    def test_delete_object_you_created(self):
+        self.tree.delete_with_user(self.officer)
+        self.plot.delete_with_user(self.officer, cascade=True)
 
     def test_masking_authorized(self):
         "When masking with a superuser, nothing should happen"
@@ -1000,6 +997,40 @@ class UserRoleFieldPermissionTest(OTMTestCase):
 
         self.assertNotEqual(Tree.objects.get(pk=self.tree.pk).canopy_height,
                             110)
+
+
+class UserCanDeleteTestCase(OTMTestCase):
+    def setUp(self):
+        instance = make_instance()
+
+        self.creator_user = make_officer_user(instance)
+        self.admin_user = make_admin_user(instance)
+        self.other_user = make_officer_user(instance, username='other')
+
+        self.plot = Plot(geom=instance.center, instance=instance)
+        self.plot.save_with_user(self.creator_user)
+
+        self.tree = Tree(plot=self.plot, instance=instance)
+        self.tree.save_with_user(self.creator_user)
+
+        self.rainBarrel = RainBarrel(geom=instance.center, instance=instance,
+                                     capacity=5)
+        self.rainBarrel.save_with_user(self.creator_user)
+
+    def assert_can_delete(self, user, deletable, should_be_able_to_delete):
+        can = deletable.user_can_delete(user)
+        self.assertEqual(can, should_be_able_to_delete)
+
+    def test_user_can_delete(self):
+        self.assert_can_delete(self.creator_user, self.plot, True)
+        self.assert_can_delete(self.admin_user, self.plot, True)
+        self.assert_can_delete(self.other_user, self.plot, False)
+        self.assert_can_delete(self.creator_user, self.rainBarrel, True)
+        self.assert_can_delete(self.admin_user, self.rainBarrel, True)
+        self.assert_can_delete(self.other_user, self.rainBarrel, False)
+        self.assert_can_delete(self.creator_user, self.tree, True)
+        self.assert_can_delete(self.admin_user, self.tree, True)
+        self.assert_can_delete(self.other_user, self.tree, False)
 
 
 class FieldPermMgmtTest(OTMTestCase):

--- a/opentreemap/treemap/views/map_feature.py
+++ b/opentreemap/treemap/views/map_feature.py
@@ -34,7 +34,6 @@ from treemap.lib.map_feature import (get_map_feature_or_404,
                                      context_dict_for_plot,
                                      context_dict_for_resource,
                                      context_dict_for_map_feature)
-from treemap.lib.perms import map_feature_is_deletable
 from treemap.views.misc import add_map_info_to_context
 
 
@@ -155,10 +154,7 @@ def update_map_feature_detail(request, instance, feature_id):
 
 def delete_map_feature(request, instance, feature_id):
     feature = get_map_feature_or_404(feature_id, instance)
-    if not map_feature_is_deletable(request.user.get_instance_user(instance),
-                                    feature):
-        raise ValidationError("map feature not deletable")
-    feature.delete_with_user(request.user)
+    feature.delete_with_user(request.user)  # may raise AuthorizeException
     update_hide_at_zoom_after_delete(feature)
     return {'ok': True}
 


### PR DESCRIPTION
* Declare on models `MapFeature` and `Tree` that users should be able to delete objects they create (via `users_can_delete_own_creations = True`)
* Update `Authorizable.user_can_delete()`, which checks whether a user is allowed to delete an object:
  * If user lacks delete permission and model has `users_can_delete_own_creations == True`, check Audit table to see if user created object.
  * Change administrator test to check `admin` field rather than role name

Related updates in the 3 places we check delete permissions:

1. Delete from a mobile app (`remove_plot` in `api.views`) -- relies on `user_can_delete()` to raise an exception if user not allowed to delete
   * Changed to catch `AuthorizeException` instead of `Exception`, and use its message instead of making a new one

2. Click the "Delete" button on the map feature detail page (`delete_map_feature` in `treemap.views.map_feature`)
   * Changed to work like deleting from mobile app -- remove "deletable" check and rely on `AuthorizeException`.

3. Enable/disable "Delete" button on map feature detail page
   * Changed to use `is_deletable` filter, which calls `user_can_delete()` (the predicate used when actually deleting).
   * Remove now-unused `map_feature_is_deletable` filter.

Connects #1003

Testing:

You will need two users with role "Editor" and one user with role "Administrator".
* As the admin user, make tree height and plot length "Read Only" for both Editors and Administrators.
* As the first editor user, create two trees and an empty planting site.
* As the first editor user, delete the first tree and its planting site (allowed because you created them).
* As the second editor user, you shouldn't be able to delete the second tree or the empty planting site (because you don't have permission to write all fields and you didn't create them).
* As the admin user, you should be able to delete the second tree and the empty planting site (because admins can always delete).