### PR TITLE
Explicitly set publicPath for production webpack configuration

### DIFF
--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -25,4 +25,6 @@ config.plugins.concat([
     new webpack.optimize.OccurrenceOrderPlugin()
 ]);
 
+config.output.publicPath = '/static/';
+
 module.exports = config;


### PR DESCRIPTION
`django-webpack-loader` defers to `publicPath` if it is available when
creating `<script>` tags, and otherwise constructs the path using the
bundle name and the value of the `BUNDLE_DIR_NAME` setting.

In practice, I was unable to find a value for `BUNDLE_DIR_NAME` that worked
for both locating the bundles on the local filesystem and creating URLs.

Setting `publicPath` explicitly (as we already do for development) works
around the issue.