### PR TITLE
Fix renaming numeric UDF field choices

### DIFF
--- a/opentreemap/treemap/udf.py
+++ b/opentreemap/treemap/udf.py
@@ -335,6 +335,10 @@ class UserDefinedFieldDefinition(models.Model):
 
     def _validate_and_update_choice(
             self, datatype, old_choice_value, new_choice_value):
+
+        # Prevent validation errors when the choice value is numeric.
+        old_choice_value = unicode(old_choice_value)
+
         if datatype['type'] not in ('choice', 'multichoice'):
             raise ValidationError(
                 {'datatype': [_("Can't change choices "


### PR DESCRIPTION
Numeric choice values are parsed as numbers on the frontend, which
causes a validation failure on the backend when renaming numeric
fields, because `1 != "1"`.

Fixed by ensuring that the validation logic compares choice values as
strings.

Connects #2557