### PR TITLE
Make management sidebar click targets full height of row

### DIFF
--- a/assets/css/sass/partials/pages/_admin.scss
+++ b/assets/css/sass/partials/pages/_admin.scss
@@ -108,7 +108,7 @@
                 }
 
                 tr {
-                    padding: 10px 0;
+                    padding: 0;
                     display: block;
                     width: 100%;
                     position: relative;
@@ -128,14 +128,14 @@
 
                     td:first-child {
                         vertical-align: top;
+                        padding: 10px 0;
                     }
 
                     .section-title {
                         cursor: pointer;
                         width: 100%;
                         display: block;
-                        padding: 0;
-                        margin-top: 4px;
+                        padding: 12px 0;
                         white-space: nowrap;
 
                         i {
@@ -586,7 +586,7 @@
         position: absolute;
         left: 0;
         right: 0;
-        
+
         @media (max-width: 768px) {
             text-align: left;
             padding-left: 10px;


### PR DESCRIPTION
Addressing https://github.com/OpenTreeMap/otm-addons/issues/1144

There are still some gaps in the click target, to the left of the label. They are minimal, and due to the use of a `table` to do the layout of the sidebar. 