### PR TITLE
Filter polygonal map features by current instance

### DIFF
--- a/opentreemap/treemap/lib/map_feature.py
+++ b/opentreemap/treemap/lib/map_feature.py
@@ -249,7 +249,9 @@ def context_dict_for_plot(request, plot, tree_id=None, **kwargs):
     context['photo_upload_share_text'] = _photo_upload_share_text(
         plot, tree is not None)
 
-    pmfs = PolygonalMapFeature.objects.filter(polygon__contains=plot.geom)
+    pmfs = PolygonalMapFeature.objects.filter(
+        polygon__contains=plot.geom,
+        mapfeature_ptr__instance_id=instance.id)
 
     if pmfs:
         context['containing_polygonalmapfeature'] = pmfs[0].cast_to_subtype()


### PR DESCRIPTION
Fixes a bug where plots were being associated with polygonal map
features from other instances.

Test by creating a rain garden on Map A, then adding a tree at the same spot on Map B. The tree on Map B should *not* be associated with a polygonal map feature.

Connects #2599