### PR TITLE
Apply search filter changes when geocoded address is active

### DIFF
--- a/opentreemap/treemap/js/src/lib/mapPage.js
+++ b/opentreemap/treemap/js/src/lib/mapPage.js
@@ -35,9 +35,13 @@ module.exports.init = function (options) {
             searchBar.resetStream.map({})
         );
 
+    var geocodeEvents = searchBar.searchFiltersProp
+        .sampledBy(searchBar.geocodedLocationStream);
+
     var builtSearchEvents = Bacon.mergeAll(
             triggeredQueryStream,
-            searchBar.filterNonGeocodeObjectStream);
+            searchBar.filterNonGeocodeObjectStream,
+            geocodeEvents);
 
     triggeredQueryStream.onValue(searchBar.applySearchToDom);
 

--- a/opentreemap/treemap/js/src/lib/searchBar.js
+++ b/opentreemap/treemap/js/src/lib/searchBar.js
@@ -324,7 +324,12 @@ module.exports = exports = {
                 button: '#perform-search'
             }),
             resetStream = $("#search-reset").asEventStream("click"),
+            searchFiltersProp = searchStream.map(Search.buildSearch).toProperty(),
             filtersStream = searchStream
+                // Filter out geocoded selections.
+                // The search datum will have a different object format
+                // depending on the type of location selected in the
+                // typeahead box.
                 .filter(function() {
                     var datum = getSearchDatum();
                     return !(datum && datum.magicKey);
@@ -363,6 +368,10 @@ module.exports = exports = {
             // Stream of search events, carries the filter object and display
             // list with it. should be used by consumer to execute searches.
             filterNonGeocodeObjectStream: filtersStream,
+
+            // Current value of search filters updated every time the
+            // "Search" button is pressed.
+            searchFiltersProp: searchFiltersProp,
 
             // has a value on all events that change the current search
             searchChangedStream: searchChangedStream,


### PR DESCRIPTION
This fixes a bug where advanced search filters would get stuck after
selecting a geocoded address in the locations autocomplete dropdown.

The Bacon stream responsible for triggering map and URL state changes
was only firing for non-geocode searches. I fixed this by merging in the
geocoding event stream so that map and URL state changes happen for both
geocode and non-geocode searches.

One unintended, but appreciated side-effect, is that selecting a
geocoded address will now remove the active boundary polygon from the
map. The previous behavior was a side-effect made possible only because we
were *not* applying search filters after selecting a geocoded address.

**Testing**

1. Verify that switching between a boundary and an address, clears the boundary polygon.

2. Verify that search filters work while a geocoded address is selected.

Connects #2466
Connects #2660 