### PR TITLE
Show polygonal feature area

### DIFF
--- a/opentreemap/stormwater/models.py
+++ b/opentreemap/stormwater/models.py
@@ -33,6 +33,20 @@ class PolygonalMapFeature(MapFeature):
     def benefits(cls):
         return CountOnlyBenefitCalculator(cls)
 
+    def calculate_area(self):
+        """
+        Make a PostGIS query that accurately calculates the area of
+        the polygon by first casting it to a Geography.
+        """
+        if self.pk is None:
+            return None
+        area_sql = 'ST_Area(ST_Transform(polygon, 4326)::geography)'
+        area_col_name = 'area'
+        return PolygonalMapFeature.objects \
+                                  .filter(pk=self.pk) \
+                                  .extra(select={area_col_name: area_sql}) \
+                                  .values(area_col_name)[0][area_col_name]
+
 
 class Bioswale(PolygonalMapFeature):
     objects = GeoHStoreUDFManager()

--- a/opentreemap/stormwater/tests.py
+++ b/opentreemap/stormwater/tests.py
@@ -5,7 +5,12 @@ from __future__ import division
 
 from treemap.lib.udf import udf_create
 from treemap.tests.test_udfs import UdfCRUTestCase
+from treemap.tests import (make_instance, make_commander_user)
+from treemap.tests.base import OTMTestCase
+from django.contrib.gis.geos import Point, Polygon, MultiPolygon
 from django.test.utils import override_settings
+
+from stormwater.models import Bioswale
 
 
 @override_settings(FEATURE_BACKEND_FUNCTION=None)
@@ -19,3 +24,34 @@ class UdfGenericCreateTest(UdfCRUTestCase):
                 'udf.type': 'string'}
 
         udf_create(body, self.instance)
+
+
+@override_settings(FEATURE_BACKEND_FUNCTION=None)
+class PolygonalMapFeatureTest(OTMTestCase):
+    def test_calculate_area(self):
+        (x, y) = -76, 39
+        point = Point(x, y, srid=4326)
+        point.transform(3857)
+        d = 0.1
+        polygon = MultiPolygon(
+            Polygon(
+                ((x, y),
+                 (x, y + d),
+                 (x + d, y + d),
+                 (x + d, y),
+                 (x, y)), srid=4326),
+            srid=4326)
+        polygon.transform(3857)
+        expected_area_in_sq_meters = 96101812
+
+        self.instance = make_instance(point=point, edge_length=10000)
+        self.user = make_commander_user(instance=self.instance)
+        self.instance.add_map_feature_types(['Bioswale'])
+        self.bioswale = Bioswale(instance=self.instance,
+                                 geom=point,
+                                 polygon=polygon)
+        # Save the feature because `calculate_area` makes a query
+        # that applies PostGIS functions to the saved polygon.
+        self.bioswale.save_with_user(self.user)
+        self.assertAlmostEqual(self.bioswale.calculate_area(),
+                               expected_area_in_sq_meters, places=0)

--- a/opentreemap/treemap/lib/map_feature.py
+++ b/opentreemap/treemap/lib/map_feature.py
@@ -311,6 +311,9 @@ def context_dict_for_resource(request, resource, **kwargs):
 
     if isinstance(resource, PolygonalMapFeature):
         context['contained_plots'] = resource.contained_plots()
+        # TODO: Convert to map owner prefered units
+        display_area = int(round(resource.calculate_area(), 0))
+        context['area'] = '%d m²' % display_area
 
     return context
 

--- a/opentreemap/treemap/templates/treemap/partials/map_feature_accordion.html
+++ b/opentreemap/treemap/templates/treemap/partials/map_feature_accordion.html
@@ -27,6 +27,12 @@
     {% else %}
     <label>{{ term.Resource.singular }}</label>
     <div class="field-view">{{ title }}</div>
+
+    {% if area %}
+    <label>{% trans "Area" %}</label>
+    <div class="field-view">{{ area }}</div>
+    {% endif %}
+
     {% endif %}
 
     {% include "treemap/partials/eco_benefits.html" with hidecounts=True %}

--- a/opentreemap/treemap/templates/treemap/resource_detail.html
+++ b/opentreemap/treemap/templates/treemap/resource_detail.html
@@ -20,6 +20,13 @@
         <td>{{ feature.pk|unlocalize }}</td>
     </tr>
 
+    {% if area %}
+    <tr>
+        <td>{% trans "Area" %}</td>
+        <td>{{ area }}</td>
+    </tr>
+    {% endif %}
+
     {% block resource_details %}
     {% endblock resource_details %}
 


### PR DESCRIPTION
The new `calculate_area` method on `PolygonalMapFeature` executes a query using the accurate anywhere in the world PostGIS geography type.

`PolygonalMapFeature`s are rendered by the tiler like point feature, so we do not have access to the polygon for client-side area calculation. I opted to create a instance method that makes a separate area query rather than try annotating PolygonalMapFeature query sets because we never need the area of more than one feature at a time.

I have temporarily hard coded a square meter label into the templates until we have implemented unit configuration for stormwater map features.

---

##### Testing

Create a map with all three stormwater features and add one of each to the map. The Rain Garden and Bioswale should show a "Area" in square meters on both the map page sidebar and the detail page.

---

Connects to #2650 