### PR TITLE
Patch leaflet to respect maxZoom in Map.fitBounds

### DIFF
--- a/assets/js/vendor/leaflet.js
+++ b/assets/js/vendor/leaflet.js
@@ -14,6 +14,11 @@
 // is resolved in master, but the suggested fix doesn't appear there.
 // See https://github.com/azavea/OTM2/issues/776
 
+// HOTFIX 3 applied:
+// https://github.com/Leaflet/Leaflet/issues/2101
+// Respect maxZoom option in Map.fitBounds
+// This was added in https://github.com/Leaflet/Leaflet/commit/c3734e5a91bdfa850339ff797e876f2dba9d9cfd
+
 (function (window, document, undefined) {
 var oldL = window.L,
     L = {};
@@ -1603,6 +1608,7 @@ L.Map = L.Class.extend({
 		    nePoint = this.project(bounds.getNorthEast(), zoom),
 		    center = this.unproject(swPoint.add(nePoint).divideBy(2).add(paddingOffset), zoom);
 
+		zoom = (typeof options.maxZoom === 'number') ? Math.min(options.maxZoom, zoom) : zoom;
 		return this.setView(center, zoom, options);
 	},
 


### PR DESCRIPTION
We need this limiting when zooming the map to the extent of all features, but we are waiting for the Leaflet 1.0 release to upgrade the entire library.

---

##### Testing

Create an instance. Add a single plot, and refresh the map page. On `develop` the map feature will not be clickable because the map tells the UTF grid plugin that it is showing a zoom level > 1000 and the UTF grid plugin does not make tile requests. On this branch, the feature will be clickable.

---

Connects to #2663