### PR TITLE
Add back end support for green infrastructure ecobenefits

### DIFF
--- a/opentreemap/stormwater/benefits.py
+++ b/opentreemap/stormwater/benefits.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django.utils.translation import ugettext_lazy as _
+
+from treemap.ecobenefits import BenefitCalculator
+from map_features.benefits import (FEET_SQ_PER_METER_SQ, FEET_PER_INCH,
+                                   GALLONS_PER_CUBIC_FT)
+
+
+class PolygonalBasinBenefitCalculator(BenefitCalculator):
+
+    def __init__(self, MapFeatureClass):
+        self.MapFeatureClass = MapFeatureClass
+
+    def benefits_for_filter(self, instance, item_filter):
+        features_qs = item_filter.get_objects(self.MapFeatureClass)
+        return self._benefits_for_feature_qs(features_qs, instance)
+
+    def benefits_for_object(self, instance, feature):
+        from stormwater.models import PolygonalMapFeature
+        feature_qs = PolygonalMapFeature.objects.filter(pk=feature.pk)
+        stats, basis = self._benefits_for_feature_qs(feature_qs, instance)
+        return stats, basis, None
+
+    def _benefits_for_feature_qs(self, feature_qs, instance):
+        annual_rainfall_ft = instance.annual_rainfall_inches * FEET_PER_INCH
+        config = self.MapFeatureClass.get_config(instance)
+        diversion_rate = config['diversion_rate']
+        should_compute = (annual_rainfall_ft is not None and
+                          diversion_rate is not None and
+                          config['should_show_eco'])
+        if should_compute:
+            # annual stormwater diverted =
+            #     annual rainfall x area x fraction stormwater diverted
+            feature_areas = \
+                self.MapFeatureClass.feature_qs_areas(feature_qs)
+            total_area = sum(feature_areas) * FEET_SQ_PER_METER_SQ
+            runoff_reduced = annual_rainfall_ft * total_area * diversion_rate
+            runoff_reduced *= GALLONS_PER_CUBIC_FT
+            stats = self._format_stats(instance, runoff_reduced)
+            basis = self._get_basis(feature_qs.count(), 0)
+        else:
+            stats = {}
+            basis = self._get_basis(0, feature_qs.count())
+        return stats, basis
+
+    def _format_stats(self, instance, runoff_reduced):
+        factor_conversions = instance.eco_benefits_conversion
+        if factor_conversions:
+            currency = runoff_reduced * factor_conversions.h20_gal_to_currency
+        else:
+            currency = 0
+
+        return {
+            'resource': {
+                'runoff_reduced': {
+                    'value': runoff_reduced,
+                    'unit': 'gallons',
+                    'unit-name': 'green_infrastructure_eco',
+                    'currency': currency,
+                    'label': _('Stormwater runoff reduced')
+                }
+            }
+        }
+
+    def _get_basis(self, n_calc, n_discard):
+        return {
+            'resource': {
+                'n_objects_used': n_calc,
+                'n_objects_discarded': n_discard
+            }
+        }

--- a/opentreemap/stormwater/tests.py
+++ b/opentreemap/stormwater/tests.py
@@ -3,14 +3,18 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+from map_features.benefits import (FEET_SQ_PER_METER_SQ, FEET_PER_INCH,
+                                   GALLONS_PER_CUBIC_FT)
+from treemap.json_field import set_attr_on_json_field
 from treemap.lib.udf import udf_create
+from treemap.search import Filter
 from treemap.tests.test_udfs import UdfCRUTestCase
 from treemap.tests import (make_instance, make_commander_user)
 from treemap.tests.base import OTMTestCase
 from django.contrib.gis.geos import Point, Polygon, MultiPolygon
 from django.test.utils import override_settings
 
-from stormwater.models import Bioswale
+from stormwater.models import Bioswale, RainGarden
 
 
 @override_settings(FEATURE_BACKEND_FUNCTION=None)
@@ -28,12 +32,12 @@ class UdfGenericCreateTest(UdfCRUTestCase):
 
 @override_settings(FEATURE_BACKEND_FUNCTION=None)
 class PolygonalMapFeatureTest(OTMTestCase):
-    def test_calculate_area(self):
+    def setUp(self):
         (x, y) = -76, 39
-        point = Point(x, y, srid=4326)
-        point.transform(3857)
+        self.point = Point(x, y, srid=4326)
+        self.point.transform(3857)
         d = 0.1
-        polygon = MultiPolygon(
+        self.polygon = MultiPolygon(
             Polygon(
                 ((x, y),
                  (x, y + d),
@@ -41,17 +45,83 @@ class PolygonalMapFeatureTest(OTMTestCase):
                  (x + d, y),
                  (x, y)), srid=4326),
             srid=4326)
-        polygon.transform(3857)
-        expected_area_in_sq_meters = 96101812
+        self.polygon.transform(3857)
 
-        self.instance = make_instance(point=point, edge_length=10000)
+        self.polygon_area_sq_meters = 96101811.9499
+
+        self.instance = make_instance(point=self.point, edge_length=10000)
         self.user = make_commander_user(instance=self.instance)
-        self.instance.add_map_feature_types(['Bioswale'])
-        self.bioswale = Bioswale(instance=self.instance,
-                                 geom=point,
-                                 polygon=polygon)
-        # Save the feature because `calculate_area` makes a query
+        self.instance.add_map_feature_types(['Bioswale', 'RainGarden'])
+
+        self.instance.annual_rainfall_inches = 30
+        Bioswale.set_config_property(self.instance, 'diversion_rate', .5)
+
+    def _make_map_feature(self, MapFeatureClass):
+        feature = MapFeatureClass(instance=self.instance,
+                                  geom=self.point,
+                                  polygon=self.polygon)
+        # Save the feature because area calculations make a query
         # that applies PostGIS functions to the saved polygon.
-        self.bioswale.save_with_user(self.user)
-        self.assertAlmostEqual(self.bioswale.calculate_area(),
-                               expected_area_in_sq_meters, places=0)
+        feature.save_with_user(self.user)
+        return feature
+
+    def test_calculate_area(self):
+        bioswale = self._make_map_feature(Bioswale)
+        self.assertAlmostEqual(bioswale.calculate_area(),
+                               self.polygon_area_sq_meters, places=0)
+
+    def assert_basis(self, basis, n_used, n_discarded):
+        self.assertEqual(basis['resource']['n_objects_used'], n_used)
+        self.assertEqual(basis['resource']['n_objects_discarded'], n_discarded)
+
+    def _get_runoff_reduced(self, feature, expect_empty=False):
+        benefits, basis, error = feature.benefits.benefits_for_object(
+            self.instance, feature)
+
+        self.assertIsNone(error)
+        if expect_empty:
+            self.assert_basis(basis, 0, 1)
+            return 0
+        else:
+            self.assert_basis(basis, 1, 0)
+            return benefits['resource']['runoff_reduced']['value']
+
+    def _assert_runoff_reduced(self, area_sq_meters, diversion_rate,
+                               runoff_reduced):
+        area = area_sq_meters * FEET_SQ_PER_METER_SQ
+        rainfall_ft = self.instance.annual_rainfall_inches * FEET_PER_INCH
+        expected = rainfall_ft * area * diversion_rate * GALLONS_PER_CUBIC_FT
+        self.assertAlmostEqual(runoff_reduced, expected, places=0)
+
+    def test_rain_garden(self):
+        feature = self._make_map_feature(RainGarden)
+        runoff_reduced = self._get_runoff_reduced(feature)
+        self._assert_runoff_reduced(
+            self.polygon_area_sq_meters, .95, runoff_reduced)
+
+    def test_bioswale(self):
+        feature = self._make_map_feature(Bioswale)
+        runoff_reduced = self._get_runoff_reduced(feature)
+        # Note Bioswale diversion rate set to .5 in setUp()
+        self._assert_runoff_reduced(
+            self.polygon_area_sq_meters, .5, runoff_reduced)
+
+    def test_eco_not_wanted(self):
+        RainGarden.set_config_property(self.instance, 'should_show_eco', False)
+        feature = self._make_map_feature(RainGarden)
+        runoff_reduced = self._get_runoff_reduced(feature, expect_empty=True)
+        self.assertEqual(runoff_reduced, 0)
+
+    def test_bulk(self):
+        self._make_map_feature(Bioswale)
+        self._make_map_feature(Bioswale)
+
+        benefits, basis = Bioswale.benefits.benefits_for_filter(
+            self.instance, Filter('', '', self.instance))
+
+        runoff_reduced = benefits['resource']['runoff_reduced']['value']
+
+        self.assert_basis(basis, 2, 0)
+        self._assert_runoff_reduced(
+            2 * self.polygon_area_sq_meters, .5, runoff_reduced)
+

--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -259,6 +259,11 @@ class Instance(models.Model):
 
     map_feature_types = _make_config_property('map_feature_types', ['Plot'])
 
+    map_feature_config = _make_config_property('map_feature_config', {})
+
+    annual_rainfall_inches = _make_config_property('annual_rainfall_inches',
+                                                   None)
+
     mobile_search_fields = _make_config_property('mobile_search_fields',
                                                  DEFAULT_MOBILE_SEARCH_FIELDS)
 


### PR DESCRIPTION
* Add `PolygonalBasinBenefitCalculator` to compute `runoff_reduced` ecobenefit for both `RainGarden` and `Bioswale`
* Don't have to loop over features to calculate runoff reduced -- just sum the areas
* Refactor existing area computation code so it can be used for eco calculations also
* Rename the GSI eco category from `la_eco` to `green_infrastructure_eco`

Note: You must reprovision your app because of a `local_settings.j2` change in `otm-cloud`

Also, in `MapFeature` add `get_config` and `set_config_property` to manage configuration of a map feature type for an instance. For example, the `Bioswale` class declares its default configuration this way:
```py
    default_config = {
        'should_show_eco': True,
        'diversion_rate': 0.95
    }
```
Overrides for an instance are stored on `instance.config.map_feature_config`. For example, if a user decides not to display ecobenefits for Bioswales, `instance.config.map_feature_config` would be:
```json
{
    "Bioswale": {
        "should_show_eco": false
    }
}
```
Code referencing these properties should use `MapFeature.get_config`, and code setting these properties should use `set_config_property`.

Depends on OpenTreeMap/otm-cloud#256
Depends on OpenTreeMap/otm-addons#1213

Connects #2647
Connects #2648