### PR TITLE
Feature/import update

### DIFF
--- a/opentreemap/importer/models/base.py
+++ b/opentreemap/importer/models/base.py
@@ -70,6 +70,18 @@ class GenericImportEvent(models.Model):
         t = "Unknown Error While %s" if self.is_lost else "%s"
         return t % self.status_description()
 
+    def is_past_verifying_stage(self):
+        # This method is used by tasks for concurrency control
+        self.refresh_from_db()
+        return self.status in {
+            GenericImportEvent.FINISHED_VERIFICATION,
+            GenericImportEvent.CREATING,
+            GenericImportEvent.FINISHED_CREATING,
+            GenericImportEvent.FAILED_FILE_VERIFICATION,
+            GenericImportEvent.CANCELED,
+            GenericImportEvent.VERIFICATION_ERROR
+        }
+
     def status_description(self):
         summaries = {
             self.PENDING_VERIFICATION: "Not Yet Started",

--- a/opentreemap/importer/models/base.py
+++ b/opentreemap/importer/models/base.py
@@ -71,8 +71,6 @@ class GenericImportEvent(models.Model):
         return t % self.status_description()
 
     def is_past_verifying_stage(self):
-        # This method is used by tasks for concurrency control
-        self.refresh_from_db()
         return self.status in {
             GenericImportEvent.FINISHED_VERIFICATION,
             GenericImportEvent.CREATING,

--- a/opentreemap/importer/tasks.py
+++ b/opentreemap/importer/tasks.py
@@ -122,6 +122,7 @@ def run_import_event_validation(import_type, import_event_id, file_obj):
 @transaction.atomic
 def _update_ie_status(ie):
     # Protect against race condition between task completion and main task
+    ie.refresh_from_db()
     if not ie.is_past_verifying_stage():
         ie.status = GenericImportEvent.VERIFIYING
         ie.update_progress_timestamp_and_save()

--- a/opentreemap/importer/tasks.py
+++ b/opentreemap/importer/tasks.py
@@ -101,7 +101,7 @@ def run_import_event_validation(import_type, import_event_id, file_obj):
             group_result.save()
             ie.task_id = group_result.id
 
-        _update_ie_status(ie)
+        _assure_status_is_at_least_verifying(ie)
 
     except Exception as e:
         ie.status = GenericImportEvent.VERIFICATION_ERROR
@@ -120,7 +120,7 @@ def run_import_event_validation(import_type, import_event_id, file_obj):
 
 
 @transaction.atomic
-def _update_ie_status(ie):
+def _assure_status_is_at_least_verifying(ie):
     # Protect against race condition between task completion and main task
     ie.refresh_from_db()
     if not ie.is_past_verifying_stage():

--- a/opentreemap/importer/tasks.py
+++ b/opentreemap/importer/tasks.py
@@ -8,6 +8,7 @@ import json
 from celery import task, chord
 from django.core.exceptions import ObjectDoesNotExist
 from django.conf import settings
+from django.db import transaction
 
 from importer.models.base import GenericImportEvent, GenericImportRow
 from importer.models.species import SpeciesImportEvent, SpeciesImportRow
@@ -100,8 +101,8 @@ def run_import_event_validation(import_type, import_event_id, file_obj):
             group_result.save()
             ie.task_id = group_result.id
 
-        ie.status = GenericImportEvent.VERIFIYING
-        ie.update_progress_timestamp_and_save()
+        _update_ie_status(ie)
+
     except Exception as e:
         ie.status = GenericImportEvent.VERIFICATION_ERROR
         ie.mark_finished_and_save()
@@ -116,6 +117,14 @@ def run_import_event_validation(import_type, import_event_id, file_obj):
             # TODO: At the very least, we should add logging.
             pass
         return
+
+
+@transaction.atomic
+def _update_ie_status(ie):
+    # Protect against race condition between task completion and main task
+    if not ie.is_past_verifying_stage():
+        ie.status = GenericImportEvent.VERIFIYING
+        ie.update_progress_timestamp_and_save()
 
 
 @task()
@@ -152,6 +161,10 @@ def commit_import_event(import_type, import_event_id):
     finalize_task = _finalize_commit.si(import_type, import_event_id)
 
     async_result = chord(commit_tasks, finalize_task).delay()
+    # Protect against a race condition where finalize_task's ie
+    # may have already been updated to FINISHED_CREATING and saved to the db,
+    # rendering this instance of the ie model obsolete.
+    ie.refresh_from_db()
     if async_result:
         ie.task_id = async_result.id
         ie.save()

--- a/opentreemap/importer/templates/importer/partials/row_status.html
+++ b/opentreemap/importer/templates/importer/partials/row_status.html
@@ -29,7 +29,9 @@
         <div class="alert alert-danger">
         {# TODO: Link to the plan page #}
         {% blocktrans %}
-        Your tree map currently contains {{ tree_count }} trees. This data upload will cause your tree map to exceed the {{ tree_limit }} number of trees included in your plan. Please add more trees to your plan or upload {{ remaining_tree_limit }} or fewer trees.
+        Your tree map currently contains {{ tree_count }} trees. This data
+upload will cause your tree map to exceed the number of trees included in your
+plan ({{ tree_limit }}). Please add more trees to your plan or upload {{ remaining_tree_limit }} or fewer trees.
         {% endblocktrans %}
         </div>
     {% elif ie.can_add_to_map %}

--- a/opentreemap/importer/views.py
+++ b/opentreemap/importer/views.py
@@ -313,7 +313,15 @@ def _get_tree_limit_context(ie):
 
     tree_count = MapFeature.objects.filter(instance=ie.instance).count()
     remaining_tree_limit = tree_limit - tree_count
-    verified_count = ie.rows().filter(status=TreeImportRow.VERIFIED).count()
+
+    added_site_q =\
+        Q(data__contains='"planting site id": ""') |\
+        ~Q(data__contains='"planting site id"')
+    verified_added_q = Q(status=TreeImportRow.VERIFIED) & added_site_q
+
+    verified_count = ie.rows()\
+        .filter(verified_added_q)\
+        .count()
 
     tree_limit_exceeded = remaining_tree_limit - verified_count < 0
 


### PR DESCRIPTION
Bulk importer should not raise a tree limit exception if the imports are updates to existing
planting sites.

---

Changes:

1. importer/views.py - the basic fix, to `_get_tree_limit_context`, to only count csv rows without planting site ids toward the tree limit test
2. importer/tasks.py - fix race conditions in import event status update, which affect both tests and celery eager mode
3. importer/base.py - add a method to `GenericImportEvent` to support the race condition fixes
4. importer/tests.py - add a class `TreeLimitTests` to test for importing with row count exactly equal to limit (exercises race fixes), for importing too many new plots (regression test), and for importing updates that would fail the limit test if they were new plots

---

Testing:
* Automation: scripts/manage.sh test importer.tests.TreeLimitTests
* Manual:
   1. As super admin, set the tree count limit to something very small, like 3, and make instance a paid account
   2. As the instance admin, create trees up to the limit
   3. Export a csv of the instance
   4. Remove stewardship columns, if any (which the importer regards as invalid)
   5. Change a field in every row, e.g. diameter
   6. Save the changes as a csv, and import it
   7. When the import shows up in verified, click View, and scroll to the bottom to verify that there is no complaint about tree limit being exceeded
   8. Click Commit
   9. Verify that the import shows up in Creating and Finished, with no tree limit complaint

---

Connects to #2638 