### PR TITLE
Fix UI tests

### DIFF
--- a/opentreemap/treemap/tests/base.py
+++ b/opentreemap/treemap/tests/base.py
@@ -5,7 +5,7 @@ test_settings = {
     # Use a faster password hasher for unit tests to improve performance
     'PASSWORD_HASHERS': ('django.contrib.auth.hashers.MD5PasswordHasher',),
 
-    'STATIC_URL': 'http://localhost:/static/',
+    'STATIC_URL': '/static/',
 
     # Without this we'd need to invalidate the cache before every test.
     'USE_OBJECT_CACHES': False,

--- a/opentreemap/treemap/tests/ui/__init__.py
+++ b/opentreemap/treemap/tests/ui/__init__.py
@@ -26,39 +26,6 @@ from treemap.lib.object_caches import clear_caches
 from treemap.plugin import setup_for_ui_test
 
 
-def patch_broken_pipe_error():
-    """
-    Monkey Patch BaseServer.handle_error to not write
-    a stacktrace to stderr on broken pipe.
-    http://stackoverflow.com/a/21788372/362702
-    """
-    import sys
-    from SocketServer import BaseServer
-    from wsgiref import handlers
-
-    handle_error = BaseServer.handle_error
-    log_exception = handlers.BaseHandler.log_exception
-
-    def is_broken_pipe_error():
-        type, err, tb = sys.exc_info()
-        return repr(err) == "error(32, 'Broken pipe')"
-
-    def my_handle_error(self, request, client_address):
-        if not is_broken_pipe_error():
-            handle_error(self, request, client_address)
-
-    def my_log_exception(self, exc_info):
-        if not is_broken_pipe_error():
-            log_exception(self, exc_info)
-
-    BaseServer.handle_error = my_handle_error
-    handlers.BaseHandler.log_exception = my_log_exception
-
-# In many tests we close the browser when there are still pending requests,
-# such as for map tiles. When running on a dev machine that leads to messy
-# output about "broken pipe" errors. Muzzle it.
-patch_broken_pipe_error()
-
 DISPLAY_WIDTH = 1280
 DISPLAY_HEIGHT = 1024
 

--- a/opentreemap/treemap/tests/ui/__init__.py
+++ b/opentreemap/treemap/tests/ui/__init__.py
@@ -6,10 +6,10 @@ from __future__ import division
 import importlib
 from time import sleep
 
-from django.test import LiveServerTestCase
 from django.test.utils import override_settings
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 
 from registration.models import RegistrationProfile
 
@@ -30,7 +30,7 @@ DISPLAY_WIDTH = 1280
 DISPLAY_HEIGHT = 1024
 
 
-class UITestCase(LiveServerTestCase):
+class UITestCase(StaticLiveServerTestCase):
     def use_xvfb(self):
         from pyvirtualdisplay import Display
         self.display = Display('xvfb',

--- a/opentreemap/treemap/tests/ui/uitest_map.py
+++ b/opentreemap/treemap/tests/ui/uitest_map.py
@@ -171,6 +171,11 @@ class MapTest(TreemapUITestCase):
             # Click on the tree we added
             self.click_point_on_map(20, 20)
 
+            # Need to wait until the marker shows up to click the edit button
+            # Not a problem for real usage as it only takes a single event loop
+            self.wait_until_present(
+                'img[src="/static/img/mapmarker_viewmode.png"]')
+
             self.click_when_visible('#quick-edit-button')
             self.wait_until_visible('#save-details-button')
 
@@ -225,6 +230,11 @@ class ModeChangeTest(TreemapUITestCase):
 
             # Click on the tree we added
             self.click_point_on_map(20, 20)
+
+            # Need to wait until the marker shows up to click the edit button
+            # Not a problem for real usage as it only takes a single event loop
+            self.wait_until_present(
+                'img[src="/static/img/mapmarker_viewmode.png"]')
 
             # enter edit mode, which should lock
             self.click_when_visible('#quick-edit-button')


### PR DESCRIPTION
A couple of small changes here:
 - A code cleanup to remove a monkey patch that is no longer needed
 - Some changes to test setup to fix regressions introduced by the switch to Webpack
 - A fix to a UI test that seems to have started failing due to timing issues

Connects to OpenTreeMap/otm-cloud#258