### PR TITLE
Fix searchBar.js entry module.

### DIFF
--- a/opentreemap/treemap/js/src/searchBar.js
+++ b/opentreemap/treemap/js/src/searchBar.js
@@ -1,3 +1,3 @@
 "use strict";
 
-require("treemap/lib/searchBar.js").init();
+require("treemap/lib/searchBar.js").initDefaults();


### PR DESCRIPTION
This was a regression caused from the switch-over to using Webpack.
It was calling `searchBar.init()` when we should have been calling
`searchBar.initDefault()`, as `.init()` is intended for use on the map page.

Connects to #2679
Connects to OpenTreeMap/otm-clients#250