### PR TITLE
Restore canopyBoundaryCategory to settings.js

### DIFF
--- a/opentreemap/treemap/templates/treemap/settings.js
+++ b/opentreemap/treemap/templates/treemap/settings.js
@@ -85,7 +85,8 @@ otm.settings.doubleClickInterval = '{{ settings.DOUBLE_CLICK_INTERVAL }}';
         'primaryColor': '{{ request.instance.config|primary_color }}',
         'secondaryColor': '{{ request.instance.config|secondary_color }}',
         'supportsEcobenefits': {{ request.instance_supports_ecobenefits|yesno:"true,false" }},
-        'canopyEnabled': {{ request.instance.canopy_enabled|yesno:"true,false" }}
+        'canopyEnabled': {{ request.instance.canopy_enabled|yesno:"true,false" }},
+        'canopyBoundaryCategory': '{{ request.instance.canopy_boundary_category }}'
     });
 {% endif %}
 


### PR DESCRIPTION
In b019bd3e we refactored `settings.js` to be compatible with our new Webpack-based bundling. The `canopyBoundaryCategory` property was [mistakenly omitted](https://github.com/OpenTreeMap/otm-core/commit/b019bd3ebac7208afdf115983b510ee54ffb5b10#diff-954ddbc65ef4c30a2e66f56d24773afcL70).

---

##### Testing

On `develop`, for an instance with canopy percentages configured, the layer will not display. On this branch, it will.

--- 

Connects to #2701 