### PR TITLE
Fix broken test and make the map_feature_types property safer

### DIFF
--- a/opentreemap/stormwater/migrations/0007_drainage_area_permissions.py
+++ b/opentreemap/stormwater/migrations/0007_drainage_area_permissions.py
@@ -32,7 +32,7 @@ def add_permissions_all(apps, schema_editor):
             return True
 
     for instance in Instance.objects.filter(config__contains='"Plot",'):
-        types = instance.config['map_feature_types']
+        types = instance.map_feature_types
         if 'Bioswale' in types or 'RainGarden' in types:
             for role in Role.objects.filter(instance=instance):
                 perm_specs = [

--- a/opentreemap/stormwater/migrations/0007_drainage_area_permissions.py
+++ b/opentreemap/stormwater/migrations/0007_drainage_area_permissions.py
@@ -32,7 +32,7 @@ def add_permissions_all(apps, schema_editor):
             return True
 
     for instance in Instance.objects.filter(config__contains='"Plot",'):
-        types = instance.map_feature_types
+        types = instance.config['map_feature_types']
         if 'Bioswale' in types or 'RainGarden' in types:
             for role in Role.objects.filter(instance=instance):
                 perm_specs = [

--- a/opentreemap/stormwater/tests.py
+++ b/opentreemap/stormwater/tests.py
@@ -19,8 +19,7 @@ from stormwater.models import Bioswale, RainGarden
 @override_settings(FEATURE_BACKEND_FUNCTION=None)
 class UdfGenericCreateTest(UdfCRUTestCase):
     def test_non_treemap_model(self):
-        self.instance.map_feature_types += ['Bioswale']
-        self.instance.save()
+        self.instance.add_map_feature_types(['Bioswale'])
 
         body = {'udf.name': 'Testing choice',
                 'udf.model': 'Bioswale',
@@ -50,7 +49,6 @@ class PolygonalMapFeatureTest(OTMTestCase):
 
         self.instance = make_instance(point=self.point, edge_length=10000)
         self.user = make_commander_user(instance=self.instance)
-        self.instance.remove_map_feature_types(keep=['Plot'])
         self.instance.add_map_feature_types(['Bioswale', 'RainGarden'])
 
         self.instance.annual_rainfall_inches = 30

--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -3,6 +3,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+from copy import deepcopy
+
 from django.contrib.gis.db import models
 from django.contrib.gis.db.models import Extent
 from django.contrib.gis.geos import MultiPolygon, Polygon
@@ -203,7 +205,7 @@ class Instance(models.Model):
 
     """
     Config contains a bunch of configuration variables for a given instance,
-    which can be accessed via properties such as `map_feature_types`.
+    which can be accessed via properties such as `annual_rainfall_inches`.
     Note that it is a DotDict, and so supports get() with a dotted key and a
     default, e.g.
         instance.config.get('fruit.apple.type', 'delicious')
@@ -242,7 +244,7 @@ class Instance(models.Model):
 
     def _make_config_property(prop, default=None):
         def get_config(self):
-            return self.config.get(prop, default)
+            return self.config.get(prop, deepcopy(default))
 
         def set_config(self, value):
             self.config[prop] = value
@@ -257,8 +259,10 @@ class Instance(models.Model):
 
     scss_variables = _make_config_property('scss_variables')
 
-    map_feature_types = _make_config_property('map_feature_types', ['Plot'])
+    _map_feature_types = _make_config_property('map_feature_types', ['Plot'])
 
+    # Never access this property directly.
+    # Use the map feature class methods, get_config and set_config_property
     map_feature_config = _make_config_property('map_feature_config', {})
 
     annual_rainfall_inches = _make_config_property('annual_rainfall_inches',
@@ -276,6 +280,13 @@ class Instance(models.Model):
     custom_layers = _make_config_property('custom_layers', [])
 
     non_admins_can_export = models.BooleanField(default=True)
+
+    @property
+    def map_feature_types(self):
+        """
+        To update, use add_map_feature_types and remove_map_feature_types.
+        """
+        return self._map_feature_types
 
     def advanced_search_fields(self, user):
         return advanced_search_fields(self, user)
@@ -430,6 +441,16 @@ class Instance(models.Model):
 
     @transaction.atomic
     def remove_map_feature_types(self, remove=None, keep=None):
+        """
+        remove_map_feature_types(self, remove=None, keep=None)
+
+        Either remove the map feature types in the remove argument,
+        or remove all but the types in the keep argument.
+        The types to remove or keep is a list of map feature class names.
+
+        Then remove map feature config for all removed map features,
+        and save the instance!!!
+        """
         from treemap.util import to_object_name
         if keep and remove:
             raise Exception('Invalid use of remove_map_features API: '
@@ -455,11 +476,21 @@ class Instance(models.Model):
                 # non-plot mobile_api_fields are not currently
                 # supported, but when they are added, they should
                 # also be removed here.
-        self.map_feature_types = remaining_types
+        self._map_feature_types = remaining_types
         self.save()
 
     @transaction.atomic
     def add_map_feature_types(self, types):
+        """
+        add_map_feature_types(self, types)
+
+        types is a list of map feature class names.
+
+        Add these types to the instance config,
+        save the instance!!!,
+        and create udf rows for udfs that have settings defaults,
+        if they don't already exist.
+        """
         from treemap.models import MapFeature  # prevent circular import
         from treemap.audit import add_default_permissions
 
@@ -469,7 +500,7 @@ class Instance(models.Model):
         if len(dups) > 0:
             raise ValidationError('Map feature types already added: %s' % dups)
 
-        self.map_feature_types = list(self.map_feature_types) + list(types)
+        self._map_feature_types = list(self.map_feature_types) + list(types)
         self.save()
 
         for type, clz in zip(types, classes):


### PR DESCRIPTION
UdfGenericCreateTest.test_non_treemap_model was simply appending 'Bioswale' to
map_feature_types with the += operator, bypassing add_map_feature_types.
Fix it to use add_map_feature_types.

In instance, return deepcopy(default) from the getter of the property returned
by _make_config_property, to prevent any code from changing the default for all
instances by mistake.

Additionally, replace map_feature_types with \_map_feature_types, to signal that
the setter is "private", and provide a get-only map_feature_types property,
with a docstring pointing at add_ & remove_map_feature_types functions.

--

Connects to #2703
Depends on OpenTreeMap/otm-addons#1227