### PR TITLE
Update stormwater benefit calculation to include drainage area

### DIFF
--- a/opentreemap/stormwater/benefits.py
+++ b/opentreemap/stormwater/benefits.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+from django.db.models import Sum
 from django.utils.translation import ugettext_lazy as _
 
 from treemap.ecobenefits import (BenefitCalculator, FEET_SQ_PER_METER_SQ,
@@ -20,32 +21,46 @@ class PolygonalBasinBenefitCalculator(BenefitCalculator):
         return self._benefits_for_feature_qs(features_qs, instance)
 
     def benefits_for_object(self, instance, feature):
-        from stormwater.models import PolygonalMapFeature
-        feature_qs = PolygonalMapFeature.objects.filter(pk=feature.pk)
+        feature_qs = feature.__class__.objects.filter(pk=feature.pk)
         stats, basis = self._benefits_for_feature_qs(feature_qs, instance)
         return stats, basis, None
 
     def _benefits_for_feature_qs(self, feature_qs, instance):
+        from stormwater.models import PolygonalMapFeature
+        feature_count = feature_qs.count()
+        feature_qs = feature_qs.filter(drainage_area__isnull=False)
+        poly_qs = PolygonalMapFeature.objects.filter(id__in=feature_qs)
         config = self.MapFeatureClass.get_config(instance)
         diversion_rate = config['diversion_rate']
         should_compute = (instance.annual_rainfall_inches is not None and
                           diversion_rate is not None and
                           config['should_show_eco'])
         if should_compute:
+            total_drainage_area = feature_qs.aggregate(
+                total_drainage_area=Sum('drainage_area')).get(
+                'total_drainage_area')
+            if total_drainage_area is None:
+                should_compute = False
+        if should_compute:
             annual_rainfall_ft = instance.annual_rainfall_inches * \
                 FEET_PER_INCH
             # annual stormwater diverted =
-            #     annual rainfall x area x fraction stormwater diverted
+            #     annual rainfall x (total feature area +
+            #     (total drainage area x fraction stormwater diverted))
+            total_drainage_area *= FEET_SQ_PER_METER_SQ
             feature_areas = \
-                self.MapFeatureClass.feature_qs_areas(feature_qs)
+                self.MapFeatureClass.feature_qs_areas(poly_qs)
             total_area = sum(feature_areas) * FEET_SQ_PER_METER_SQ
-            runoff_reduced = annual_rainfall_ft * total_area * diversion_rate
+            runoff_reduced = annual_rainfall_ft * (
+                total_area + total_drainage_area * diversion_rate)
             runoff_reduced *= GALLONS_PER_CUBIC_FT
             stats = self._format_stats(instance, runoff_reduced)
-            basis = self._get_basis(feature_qs.count(), 0)
+            features_used = poly_qs.count()
+            basis = self._get_basis(features_used,
+                                    feature_count - features_used)
         else:
             stats = {}
-            basis = self._get_basis(0, feature_qs.count())
+            basis = self._get_basis(0, feature_count)
         return stats, basis
 
     def _format_stats(self, instance, runoff_reduced):

--- a/opentreemap/stormwater/migrations/0008_benefits-calc-cache-flush.py
+++ b/opentreemap/stormwater/migrations/0008_benefits-calc-cache-flush.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from django.db.models import F
+
+
+def bump_universal_revs(apps, schema_editor):
+    Instance = apps.get_model('treemap', 'Instance')
+    attr = 'universal_rev'
+    Instance.objects.all().update(universal_rev=F(attr) + 1)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('stormwater', '0007_drainage_area_permissions'),
+        ('treemap', '0029_merge'),
+    ]
+
+    operations = [
+        migrations.RunPython(bump_universal_revs,
+                             migrations.RunPython.noop)
+    ]

--- a/opentreemap/stormwater/models.py
+++ b/opentreemap/stormwater/models.py
@@ -107,7 +107,7 @@ class Bioswale(PolygonalMapFeature):
 
     default_config = {
         'should_show_eco': False,
-        'diversion_rate': 0.95
+        'diversion_rate': 0.85
     }
 
 
@@ -164,7 +164,7 @@ class RainGarden(PolygonalMapFeature):
 
     default_config = {
         'should_show_eco': False,
-        'diversion_rate': 0.95
+        'diversion_rate': 0.85
     }
 
 

--- a/opentreemap/stormwater/tests.py
+++ b/opentreemap/stormwater/tests.py
@@ -32,22 +32,12 @@ class UdfGenericCreateTest(UdfCRUTestCase):
 class PolygonalMapFeatureTest(OTMTestCase):
     def setUp(self):
         (x, y) = -76, 39
-        self.point = Point(x, y, srid=4326)
-        self.point.transform(3857)
-        d = 0.1
-        self.polygon = MultiPolygon(
-            Polygon(
-                ((x, y),
-                 (x, y + d),
-                 (x + d, y + d),
-                 (x + d, y),
-                 (x, y)), srid=4326),
-            srid=4326)
-        self.polygon.transform(3857)
+        self.point = self._make_point(x, y)
+        self.polygon = self._make_square_polygon(x, y)
 
         self.polygon_area_sq_meters = 96101811.9499
 
-        self.instance = make_instance(point=self.point, edge_length=10000)
+        self.instance = make_instance(point=self.point, edge_length=1000000)
         self.user = make_commander_user(instance=self.instance)
         self.instance.add_map_feature_types(['Bioswale', 'RainGarden'])
 
@@ -55,10 +45,30 @@ class PolygonalMapFeatureTest(OTMTestCase):
         Bioswale.set_config_property(self.instance, 'diversion_rate', .5)
         Bioswale.set_config_property(self.instance, 'should_show_eco', True)
 
-    def _make_map_feature(self, MapFeatureClass):
+    def _make_point(self, x, y):
+        point = Point(x, y, srid=4326)
+        point.transform(3857)
+        return point
+
+    def _make_square_polygon(self, x, y):
+        d = 0.1
+        polygon = MultiPolygon(
+            Polygon(
+                ((x, y),
+                 (x, y + d),
+                 (x + d, y + d),
+                 (x + d, y),
+                 (x, y)), srid=4326),
+            srid=4326)
+        polygon.transform(3857)
+        return polygon
+
+    def _make_map_feature(self, MapFeatureClass, drainage_area=None,
+                          geom=None, polygon=None):
         feature = MapFeatureClass(instance=self.instance,
-                                  geom=self.point,
-                                  polygon=self.polygon)
+                                  geom=(geom or self.point),
+                                  polygon=(polygon or self.polygon),
+                                  drainage_area=drainage_area)
         # Save the feature because area calculations make a query
         # that applies PostGIS functions to the saved polygon.
         feature.save_with_user(self.user)
@@ -85,36 +95,58 @@ class PolygonalMapFeatureTest(OTMTestCase):
             self.assert_basis(basis, 1, 0)
             return benefits['resource']['stormwater']['value']
 
-    def _assert_runoff_reduced(self, area_sq_meters, diversion_rate,
-                               runoff_reduced):
+    def _assert_runoff_reduced(self, area_sq_meters, drainage_area_sq_meters,
+                               diversion_rate, runoff_reduced):
         area = area_sq_meters * FEET_SQ_PER_METER_SQ
+        drainage_area = drainage_area_sq_meters * FEET_SQ_PER_METER_SQ
         rainfall_ft = self.instance.annual_rainfall_inches * FEET_PER_INCH
-        expected = rainfall_ft * area * diversion_rate * GALLONS_PER_CUBIC_FT
+        adjusted_area = area + (drainage_area * diversion_rate)
+        expected = rainfall_ft * adjusted_area * GALLONS_PER_CUBIC_FT
         self.assertAlmostEqual(runoff_reduced, expected, places=0)
 
     def test_rain_garden(self):
         RainGarden.set_config_property(self.instance, 'should_show_eco', True)
-        feature = self._make_map_feature(RainGarden)
+        drainage_area_sq_meters = 100000000.0
+        feature = self._make_map_feature(RainGarden, drainage_area_sq_meters)
         runoff_reduced = self._get_runoff_reduced(feature)
         self._assert_runoff_reduced(
-            self.polygon_area_sq_meters, .95, runoff_reduced)
+            self.polygon_area_sq_meters, drainage_area_sq_meters,
+            .85, runoff_reduced)
 
     def test_bioswale(self):
-        feature = self._make_map_feature(Bioswale)
+        drainage_area_sq_meters = 100000000.0
+        feature = self._make_map_feature(Bioswale, drainage_area_sq_meters)
         runoff_reduced = self._get_runoff_reduced(feature)
         # Note Bioswale diversion rate set to .5 in setUp()
         self._assert_runoff_reduced(
-            self.polygon_area_sq_meters, .5, runoff_reduced)
+            self.polygon_area_sq_meters, drainage_area_sq_meters,
+            .5, runoff_reduced)
+
+    def test_bioswale_no_drainage(self):
+        feature = self._make_map_feature(Bioswale)
+        runoff_reduced = self._get_runoff_reduced(feature, expect_empty=True)
+        self.assertEqual(runoff_reduced, 0)
 
     def test_eco_not_wanted(self):
         RainGarden.set_config_property(self.instance, 'should_show_eco', False)
-        feature = self._make_map_feature(RainGarden)
+        drainage_area_sq_meters = 100000000.0
+        feature = self._make_map_feature(RainGarden,
+                                         drainage_area=drainage_area_sq_meters)
         runoff_reduced = self._get_runoff_reduced(feature, expect_empty=True)
         self.assertEqual(runoff_reduced, 0)
 
     def test_bulk(self):
-        self._make_map_feature(Bioswale)
-        self._make_map_feature(Bioswale)
+        drainage_area_sq_meters = 100000000.0
+        # NOTE
+        # Today, no check is made for overlapping stormwater resources.
+        # In the future, either overlap should be invalid,
+        # or the intersection should only be counted once in the total area.
+        self._make_map_feature(Bioswale,
+                               drainage_area=drainage_area_sq_meters)
+        self._make_map_feature(Bioswale,
+                               geom=self._make_point(-75.5, 39),
+                               polygon=self._make_square_polygon(-75.5, 39),
+                               drainage_area=drainage_area_sq_meters)
 
         benefits, basis = Bioswale.benefits.benefits_for_filter(
             self.instance, Filter('', '', self.instance))
@@ -123,4 +155,29 @@ class PolygonalMapFeatureTest(OTMTestCase):
 
         self.assert_basis(basis, 2, 0)
         self._assert_runoff_reduced(
-            2 * self.polygon_area_sq_meters, .5, runoff_reduced)
+            2 * self.polygon_area_sq_meters,
+            2 * drainage_area_sq_meters,
+            .5, runoff_reduced)
+
+    def test_bulk_partial_drainage_known(self):
+        drainage_area_sq_meters = 100000000.0
+        # NOTE
+        # Today, no check is made for overlapping stormwater resources.
+        # In the future, either overlap should be invalid,
+        # or the intersection should only be counted once in the total area.
+        self._make_map_feature(Bioswale,
+                               drainage_area=drainage_area_sq_meters)
+        self._make_map_feature(Bioswale,
+                               geom=self._make_point(-75.5, 39),
+                               polygon=self._make_square_polygon(-75.5, 39))
+
+        benefits, basis = Bioswale.benefits.benefits_for_filter(
+            self.instance, Filter('', '', self.instance))
+
+        runoff_reduced = benefits['resource']['stormwater']['value']
+
+        self.assert_basis(basis, 1, 1)
+        self._assert_runoff_reduced(
+            self.polygon_area_sq_meters,
+            drainage_area_sq_meters,
+            .5, runoff_reduced)


### PR DESCRIPTION
Note: you might still see incorrect aggregate results in your browser due to
OpenTreeMap/otm-core#2707. Going in with the shell and kicking universal_revs a
couple times seems to resolve it.

Added the new calculation to stormwater/benefits.py. Since drainage_area is not
in PolygonalMapFeature, had to change the interface to the internal
_benefits_for_feature_qs and pass in a qs of the original map feature class.

The new calculation also calls for a default constant of 0.85.

Updated tests accordingly.

--

Connected to #2689