### PR TITLE
Make drainage_area optional

### DIFF
--- a/opentreemap/stormwater/models.py
+++ b/opentreemap/stormwater/models.py
@@ -14,6 +14,7 @@ from treemap.ecobenefits import CountOnlyBenefitCalculator
 
 class PolygonalMapFeature(MapFeature):
     area_field_name = 'polygon'
+    enable_detail_next = True
 
     polygon = models.MultiPolygonField(srid=3857)
 

--- a/opentreemap/treemap/js/src/lib/addResourceMode.js
+++ b/opentreemap/treemap/js/src/lib/addResourceMode.js
@@ -55,6 +55,7 @@ function init(options) {
             typeName = $option.next().text().trim(),
             areaFieldName = $option.data('area-field-name'),
             skipDetailForm = $option.data('skip-detail-form') == 'True',
+            enableDetailNext = $option.data('enable-detail-next') == 'True',
             enableContinueEditing = $option.data('is-editable') == 'True',
             addFeatureUrl = reverse.add_map_feature({
                 instance_url_name: config.instance.url_name,
@@ -65,7 +66,7 @@ function init(options) {
             manager.stepControls.maxStepNumber = manager.stepControls.initialMaxStepNumber;
             manager.stepControls.enableNext(STEP_CHOOSE_TYPE, true);
             manager.stepControls.enableNext(STEP_OUTLINE_AREA, true);
-            manager.stepControls.enableNext(STEP_DETAILS, false);
+            manager.stepControls.enableNext(STEP_DETAILS, enableDetailNext);
             $summaryHead.text(typeName);
 
             var hasAreaStep = !!areaFieldName;

--- a/opentreemap/treemap/templates/treemap/partials/map_add_resource.html
+++ b/opentreemap/treemap/templates/treemap/partials/map_add_resource.html
@@ -24,6 +24,7 @@
                            data-area-field-name="{{ cls.area_field_name|default_if_none:"" }}"
                            data-is-editable="{{ cls.is_editable|default_if_none:"False" }}"
                            data-skip-detail-form="{{ cls.skip_detail_form|default:"False" }}"
+                           data-enable-detail-next="{{ cls.enable_detail_next|default:"False" }}"
                     /><label for="resourceType{{ cls.feature_type }}">
                       {% with terminology=cls|terminology:request.instance %}
                         {{ terminology.singular }}


### PR DESCRIPTION
Actually, the add resource detail step has always been optional. If you enter a
character, the Next button would be enabled, and remained enabled even if you
then delete the character.

Make the detail page for the polygonal map features come up with the Next
button enabled by adding a data attribute, enable-detail-next, and its
attendant class attribute on PolygonalMapFeature, then making the
addResourceMode js respect the data attribute.

--

Connects to #2708