### PR TITLE
Explain drainage_area when adding a resource

### DIFF
--- a/assets/css/sass/partials/pages/_addtree.scss
+++ b/assets/css/sass/partials/pages/_addtree.scss
@@ -155,6 +155,10 @@
                             border-left: none;
                         }
                     }
+
+                    .explanation {
+                        font-size: 1.2rem;
+                    }
                 }
 
                 @include checkboxes;

--- a/assets/css/sass/partials/pages/_addtree.scss
+++ b/assets/css/sass/partials/pages/_addtree.scss
@@ -158,6 +158,7 @@
 
                     .explanation {
                         font-size: 1.2rem;
+                        margin-top: 6px;
                     }
                 }
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
 django-extensions==1.6.1
 six==1.10.0
-django-debug-toolbar==1.4
+django-debug-toolbar==1.5

--- a/opentreemap/api/instance.py
+++ b/opentreemap/api/instance.py
@@ -181,7 +181,7 @@ def instance_info(request, instance):
             else:
                 model_inst = safe_get_model_class(fp.model_name)(
                     instance=instance)
-                data_type, __, choices = field_type_label_choices(
+                data_type, __, __, choices = field_type_label_choices(
                     model_inst, fp.field_name, fp.display_field_name)
 
             digits = get_digits_if_formattable(

--- a/opentreemap/opentreemap/context_processors.py
+++ b/opentreemap/opentreemap/context_processors.py
@@ -53,6 +53,20 @@ def global_settings(request):
     term = copy.copy(REPLACEABLE_TERMS)
     if hasattr(request, 'instance'):
         term.update(request.instance.config.get('terms', {}))
+        # config.get('terms') above populates the term context variable with
+        # model terminology provided it has been customized for the treemap
+        # instance, but fails to populate it with the default terminology. The
+        # for loop below ensures that term is populated with model terminology
+        # whether it has been customized or not.
+
+        # Convertible is the base class where the terminology class property is
+        # defined, so its leaf subclasses are the ones with default terminology
+        # we might care about.
+
+        # leaf_models_of_class uses recursive descent through the
+        # clz.__subclasses__ attributes, but it only iterates through a total
+        # of around ten nodes at present, so it is unlikely to be a performance
+        # problem.
         for clz in leaf_models_of_class(Convertible):
             term.update({
                 clz.__name__: clz.terminology(request.instance)})

--- a/opentreemap/opentreemap/context_processors.py
+++ b/opentreemap/opentreemap/context_processors.py
@@ -11,7 +11,8 @@ from django.contrib.staticfiles import finders
 from django.utils.timezone import now
 from django.utils.translation import ugettext as _
 
-from treemap.util import get_last_visited_instance
+from treemap.units import Convertible
+from treemap.util import get_last_visited_instance, leaf_models_of_class
 from treemap.models import InstanceUser
 
 
@@ -52,6 +53,9 @@ def global_settings(request):
     term = copy.copy(REPLACEABLE_TERMS)
     if hasattr(request, 'instance'):
         term.update(request.instance.config.get('terms', {}))
+        for clz in leaf_models_of_class(Convertible):
+            term.update({
+                clz.__name__: clz.terminology(request.instance)})
 
     ctx = {
         'SITE_ROOT': settings.SITE_ROOT,

--- a/opentreemap/stormwater/templates/stormwater/Bioswale_add.html
+++ b/opentreemap/stormwater/templates/stormwater/Bioswale_add.html
@@ -2,12 +2,13 @@
 {% load i18n %}
 {% load l10n %}
 {% load form_extras %}
+{% load util %}
 
 {% block resource_add_details %}
 <div class="resource-question">
-  {# Translators: singular means Bioswale #}
-  {% trans "How large is the area that drains into the {singular}?" as drainage_area %}
-  {% trans "Approximate size is fine. Do not include the area of the {singular} itself" as explanation %}
+  {# Translators: Bioswale.singular means Bioswale #}
+  {% trans "How large is the area that drains into the {Bioswale.singular}?"|interpolate_string:term as drainage_area %}
+  {% trans "Approximate size is fine. Do not include the area of the {Bioswale.singular} itself."|interpolate_string:term as explanation %}
   {% create drainage_area from "Bioswale.drainage_area" in request.instance withtemplate "treemap/field/div.html" withhelp explanation %}
 </div>
 {% endblock resource_add_details %}

--- a/opentreemap/stormwater/templates/stormwater/Bioswale_add.html
+++ b/opentreemap/stormwater/templates/stormwater/Bioswale_add.html
@@ -6,9 +6,17 @@
 
 {% block resource_add_details %}
 <div class="resource-question">
-  {# Translators: Bioswale.singular means Bioswale #}
-  {% trans "How large is the area that drains into the {Bioswale.singular}?"|interpolate_string:term as drainage_area %}
-  {% trans "Approximate size is fine. Do not include the area of the {Bioswale.singular} itself."|interpolate_string:term as explanation %}
+  {% captureas drainage_area %}
+    {% blocktrans with bioswale=term.Bioswale.singular %}
+      How large is the area that drains into the {{bioswale}}?
+    {% endblocktrans %}
+  {% endcaptureas %}
+  {% captureas explanation %}
+    {% blocktrans with bioswale=term.Bioswale.singular %}
+      Approximate size is fine.
+      Do not include the area of the {{bioswale}} itself.
+    {% endblocktrans %}
+  {% endcaptureas %}
   {% create drainage_area from "Bioswale.drainage_area" in request.instance withtemplate "treemap/field/div.html" withhelp explanation %}
 </div>
 {% endblock resource_add_details %}

--- a/opentreemap/stormwater/templates/stormwater/Bioswale_add.html
+++ b/opentreemap/stormwater/templates/stormwater/Bioswale_add.html
@@ -5,7 +5,9 @@
 
 {% block resource_add_details %}
 <div class="resource-question">
-  {% trans "What is the area of adjacent drainage?" as drainage_area %}
-  {% create drainage_area from "Bioswale.drainage_area" in request.instance withtemplate "treemap/field/div.html" %}
+  {# Translators: singular means Bioswale #}
+  {% trans "How large is the area that drains into the {singular}?" as drainage_area %}
+  {% trans "Approximate size is fine. Do not include the area of the {singular} itself" as explanation %}
+  {% create drainage_area from "Bioswale.drainage_area" in request.instance withtemplate "treemap/field/div.html" withhelp explanation %}
 </div>
 {% endblock resource_add_details %}

--- a/opentreemap/stormwater/templates/stormwater/RainGarden_add.html
+++ b/opentreemap/stormwater/templates/stormwater/RainGarden_add.html
@@ -2,12 +2,13 @@
 {% load i18n %}
 {% load l10n %}
 {% load form_extras %}
+{% load util %}
 
 {% block resource_add_details %}
 <div class="resource-question">
-  {# Translators: singular means Rain Garden #}
-  {% trans "How large is the area that drains into the {singular}?" as drainage_area %}
-  {% trans "Approximate size is fine. Do not include the area of the {singular} itself" as explanation %}
+  {# Translators: RainGarden.singular means Rain Garden #}
+  {% trans "How large is the area that drains into the {RainGarden.singular}?"|interpolate_string:term as drainage_area %}
+  {% trans "Approximate size is fine. Do not include the area of the {RainGarden.singular} itself."|interpolate_string:term as explanation %}
   {% create drainage_area from "RainGarden.drainage_area" in request.instance withtemplate "treemap/field/div.html" withhelp explanation %}
 </div>
 {% endblock resource_add_details %}

--- a/opentreemap/stormwater/templates/stormwater/RainGarden_add.html
+++ b/opentreemap/stormwater/templates/stormwater/RainGarden_add.html
@@ -6,7 +6,17 @@
 
 {% block resource_add_details %}
 <div class="resource-question">
-  {# Translators: RainGarden.singular means Rain Garden #}
+  {% captureas drainage_area %}
+    {% blocktrans with rain_garden=term.RainGarden.singular %}
+      How large is the area that drains into the {{rain_garden}}?
+    {% endblocktrans %}
+  {% endcaptureas %}
+  {% captureas explanation %}
+    {% blocktrans with rain_garden=term.RainGarden.singular %}
+      Approximate size is fine.
+      Do not include the area of the {{rain_garden}} itself.
+    {% endblocktrans %}
+  {% endcaptureas %}
   {% trans "How large is the area that drains into the {RainGarden.singular}?"|interpolate_string:term as drainage_area %}
   {% trans "Approximate size is fine. Do not include the area of the {RainGarden.singular} itself."|interpolate_string:term as explanation %}
   {% create drainage_area from "RainGarden.drainage_area" in request.instance withtemplate "treemap/field/div.html" withhelp explanation %}

--- a/opentreemap/stormwater/templates/stormwater/RainGarden_add.html
+++ b/opentreemap/stormwater/templates/stormwater/RainGarden_add.html
@@ -17,8 +17,6 @@
       Do not include the area of the {{rain_garden}} itself.
     {% endblocktrans %}
   {% endcaptureas %}
-  {% trans "How large is the area that drains into the {RainGarden.singular}?"|interpolate_string:term as drainage_area %}
-  {% trans "Approximate size is fine. Do not include the area of the {RainGarden.singular} itself."|interpolate_string:term as explanation %}
   {% create drainage_area from "RainGarden.drainage_area" in request.instance withtemplate "treemap/field/div.html" withhelp explanation %}
 </div>
 {% endblock resource_add_details %}

--- a/opentreemap/stormwater/templates/stormwater/RainGarden_add.html
+++ b/opentreemap/stormwater/templates/stormwater/RainGarden_add.html
@@ -5,7 +5,9 @@
 
 {% block resource_add_details %}
 <div class="resource-question">
-  {% trans "What is the area of adjacent drainage?" as drainage_area %}
-  {% create drainage_area from "RainGarden.drainage_area" in request.instance withtemplate "treemap/field/div.html" %}
+  {# Translators: singular means Rain Garden #}
+  {% trans "How large is the area that drains into the {singular}?" as drainage_area %}
+  {% trans "Approximate size is fine. Do not include the area of the {singular} itself" as explanation %}
+  {% create drainage_area from "RainGarden.drainage_area" in request.instance withtemplate "treemap/field/div.html" withhelp explanation %}
 </div>
 {% endblock resource_add_details %}

--- a/opentreemap/treemap/search_fields.py
+++ b/opentreemap/treemap/search_fields.py
@@ -183,7 +183,7 @@ def mobile_search_fields(instance):
 
         Model, field_name = _parse_field_info(instance, field)
         set_search_field_label(instance, field)
-        field_type, __, choices = field_type_label_choices(
+        field_type, __, __, choices = field_type_label_choices(
             Model, field_name, add_blank=ADD_BLANK_NEVER)
 
         if identifier == 'species.id':
@@ -236,7 +236,7 @@ def get_search_field_label(instance, field_info):
         else:
             label = Model._meta.verbose_name_plural
     else:
-        __, label, __ = field_type_label_choices(Model, field_name, '')
+        __, label, __, __ = field_type_label_choices(Model, field_name, '')
         if hasattr(Model, 'terminology'):
             prefix = force_text(Model.terminology(instance)['singular'])
         else:

--- a/opentreemap/treemap/templates/treemap/field/div.html
+++ b/opentreemap/treemap/templates/treemap/field/div.html
@@ -13,6 +13,9 @@
                 {% include "treemap/field/inputs.html" %}
                 {% endblock inputs %}
             </div>
+            {% if field.explanation %}
+                <p class="explanation">{{ field.explanation }}</p>
+            {% endif %}
             <div class="alert alert-danger text-danger"
                 style="display: none;"
                 {% include "treemap/field/attrs.html" with class="error" %}></div>

--- a/opentreemap/treemap/templates/treemap/resource_detail.html
+++ b/opentreemap/treemap/templates/treemap/resource_detail.html
@@ -102,7 +102,7 @@
 {% block delete_confirmation_text %}
 <p>
     <strong>{% trans "Warning!" %}</strong>
-    {% blocktrans with resource=term.resource.singular.lower %}
+    {% blocktrans with resource=term.Resource.singular.lower %}
     You are about to delete this {{ resource }}. Do you want to continue?
     {% endblocktrans %}
 </p>

--- a/opentreemap/treemap/templatetags/form_extras.py
+++ b/opentreemap/treemap/templatetags/form_extras.py
@@ -296,14 +296,6 @@ def field_type_label_choices(model, field_name, label=None,
     return field_type, label, explanation, choices
 
 
-def format_with_terminology(model, label):
-    terminology_fn = getattr(model.__class__, 'terminology', None)
-    instance = model.instance
-    if label and terminology_fn and instance:
-        return label.format(**terminology_fn(instance))
-    return label
-
-
 class AbstractNode(template.Node):
     def __init__(self, label, identifier, user, field_template, instance,
                  explanation):
@@ -405,8 +397,6 @@ class AbstractNode(template.Node):
                 model.instance, object_name, field_name)
             if units != '':
                 units = get_unit_name(units)
-            label = format_with_terminology(model, label)
-            explanation = format_with_terminology(model, explanation)
 
         if field_value is None:
             display_val = None

--- a/opentreemap/treemap/templatetags/util.py
+++ b/opentreemap/treemap/templatetags/util.py
@@ -6,6 +6,7 @@ import json
 
 from opentreemap.util import dotted_split
 
+from treemap.DotDict import DotDict
 from treemap.models import MapFeature, Tree, TreePhoto, MapFeaturePhoto, Audit
 from treemap.udf import UserDefinedCollectionValue
 from treemap.util import (get_filterable_audit_models, to_model_name,
@@ -92,6 +93,11 @@ def audit_detail_link(audit):
             return None
     else:
         return None
+
+
+@register.filter
+def interpolate_string(text, params):
+    return text.format(**DotDict(params))
 
 
 @register.filter


### PR DESCRIPTION
_Note to the reviewer: the rest of the requirements in this issue are
wholly addressed in the addons repository, and are entirely independent
of the core work represented by this PR. I think you can review this PR
without reference to the coming addons PR._

When adding a resource, if the choice is RainGarden or Bioswale,
when it prompts for drainage_area, provide help text below the input.
Also, update the question text.

Changes:

1) `assets/css/sass/partials/pages/_addtree.scss`: style the help text.
2) `stormwater/*_add.html`: update the question text and add
   the explanation to the `create` tag for RainGarden and Bioswale,
   and direct interpolation of their terminology.
3) `treemap/field/div.html`: add conditional explanation markup.
4) `treemap/templatetags/form_extras.py`: add "`withhelp`" keyword to and
   content to the tag nodes, defaulting to `Field.help_text`, if any,
   and interpolate label and explanation with terminology.
5) `treemap/search_fields.py`: adapt to interface change stemming from
   changes to `form_extras`.
6) Bump the required rev on `django-debug-toolbar` in `dev-requirements`
   because the previous rev now crashes in our environment.

--

Connects to #2704
Depends on OpenTreeMap/otm-addons#1231