### PR TITLE
Refresh details when hitting "Save" on a plot/resource detail page

### DIFF
--- a/opentreemap/stormwater/templates/stormwater/Bioswale_detail.html
+++ b/opentreemap/stormwater/templates/stormwater/Bioswale_detail.html
@@ -1,4 +1,4 @@
-{% extends "treemap/resource_detail.html" %}
+{% extends "treemap/partials/resource_detail.html" %}
 {% load i18n %}
 {% load l10n %}
 {% load form_extras %}

--- a/opentreemap/stormwater/templates/stormwater/Bioswale_detail.html
+++ b/opentreemap/stormwater/templates/stormwater/Bioswale_detail.html
@@ -4,5 +4,5 @@
 {% load form_extras %}
 
 {% block resource_details %}
-{% field _("Adjacent Drainage Area") from "bioswale.drainage_area" for request.user withtemplate "treemap/field/tr.html" %}
+    {% field _("Adjacent Drainage Area") from "bioswale.drainage_area" for request.user withtemplate "treemap/field/tr.html" %}
 {% endblock resource_details %}

--- a/opentreemap/stormwater/templates/stormwater/RainBarrel_detail.html
+++ b/opentreemap/stormwater/templates/stormwater/RainBarrel_detail.html
@@ -1,4 +1,4 @@
-{% extends "treemap/resource_detail.html" %}
+{% extends "treemap/partials/resource_detail.html" %}
 {% load i18n %}
 {% load l10n %}
 {% load form_extras %}

--- a/opentreemap/stormwater/templates/stormwater/RainBarrel_detail.html
+++ b/opentreemap/stormwater/templates/stormwater/RainBarrel_detail.html
@@ -4,5 +4,5 @@
 {% load form_extras %}
 
 {% block resource_details %}
-{% field _("Capacity") from "rainBarrel.capacity" for request.user withtemplate "treemap/field/tr.html" %}
+    {% field _("Capacity") from "rainBarrel.capacity" for request.user withtemplate "treemap/field/tr.html" %}
 {% endblock resource_details %}

--- a/opentreemap/stormwater/templates/stormwater/RainGarden_detail.html
+++ b/opentreemap/stormwater/templates/stormwater/RainGarden_detail.html
@@ -1,4 +1,4 @@
-{% extends "treemap/resource_detail.html" %}
+{% extends "treemap/partials/resource_detail.html" %}
 {% load i18n %}
 {% load l10n %}
 {% load form_extras %}

--- a/opentreemap/stormwater/templates/stormwater/RainGarden_detail.html
+++ b/opentreemap/stormwater/templates/stormwater/RainGarden_detail.html
@@ -4,5 +4,5 @@
 {% load form_extras %}
 
 {% block resource_details %}
-{% field _("Adjacent Drainage Area") from "rainGarden.drainage_area" for request.user withtemplate "treemap/field/tr.html" %}
+    {% field _("Adjacent Drainage Area") from "rainGarden.drainage_area" for request.user withtemplate "treemap/field/tr.html" %}
 {% endblock resource_details %}

--- a/opentreemap/treemap/js/src/lib/inlineEditForm.js
+++ b/opentreemap/treemap/js/src/lib/inlineEditForm.js
@@ -18,10 +18,10 @@ exports.init = function(options) {
         section = options.section || 'body',
         form = options.form || section + ' form',
         $section = $(section),
-        $edit = options.edit ? $(options.edit) : $section.find('.editBtn'),
-        $save = options.save ? $(options.save) : $section.find('.saveBtn'),
-        $cancel = options.cancel ? $(options.cancel) : $section.find('.cancelBtn'),
-        $spinner = options.spinner ? $(options.spinner) : $section.find('.spinner'),
+        edit = options.edit || '.editBtn',
+        save = options.save || '.saveBtn',
+        cancel = options.cancel || '.cancelBtn',
+        spinner = options.spinner || '.spinner',
         displayFields = options.displayFields || section + ' [data-class="display"]',
         editFields = options.editFields || section + ' [data-class="edit"]',
         validationFields = options.validationFields || section + ' [data-class="error"]',
@@ -30,17 +30,17 @@ exports.init = function(options) {
         onSaveAfter = options.onSaveAfter || _.identity,
 
         showSavePending = function (saveIsPending) {
-            $spinner.toggle(saveIsPending);
-            $save.prop('disabled', saveIsPending);
-            $cancel.prop('disabled', saveIsPending);
+            $section.find(spinner).toggle(saveIsPending);
+            $section.find(save).prop('disabled', saveIsPending);
+            $section.find(cancel).prop('disabled', saveIsPending);
         },
 
-        editStream = $edit.asEventStream('click').map(editableForm.editStartAction),
-        saveStream = (options.saveStream || $save.asEventStream('click'))
+        editStream = $section.asEventStream('click', edit).map(editableForm.editStartAction),
+        saveStream = (options.saveStream || $section.asEventStream('click', save))
             .doAction(showSavePending, true)
             .map('save:start'),
         externalCancelStream = BU.triggeredObjectStream('cancel'),
-        cancelStream = $cancel.asEventStream('click').map('cancel'),
+        cancelStream = $section.asEventStream('click', cancel).map('cancel'),
         globalCancelStream = cancelStream.merge(externalCancelStream),
 
         actionStream = new Bacon.Bus(),

--- a/opentreemap/treemap/js/src/lib/mapFeatureDelete.js
+++ b/opentreemap/treemap/js/src/lib/mapFeatureDelete.js
@@ -10,34 +10,21 @@ var dom = {
     deleteConfirm: '#delete-confirm',
     deleteCancel: '#delete-cancel',
     deleteConfirmationBox: '#delete-confirmation-box',
+    spinner: '.spinner'
 };
 
 exports.init = function(options) {
     options = options || {};
-    var $delete = $(dom.delete),
-        $deleteConfirm = $(dom.deleteConfirm),
-        $deleteCancel = $(dom.deleteCancel),
-        $deleteConfirmationBox = $(dom.deleteConfirmationBox),
 
-        resetUIState = function () {
-            if (options.resetUIState) {
-                options.resetUIState();
-            }
-            $deleteConfirmationBox.hide();
-        },
-
-        getUrls = options.getUrls || function () {
-            return {deleteUrl: document.URL,
-                    afterDeleteUrl: reverse.map(config.instance.url_name)};
-        };
-
-    $deleteConfirm.click(function () {
-        var urls = getUrls();
+    $(dom.deleteConfirm).click(function () {
+        var deleteUrl = options.deleteUrl || document.URL,
+            successUrl = options.successUrl || reverse.map(config.instance.url_name);
+        $(dom.spinner).show();
         $.ajax({
-            url: urls.deleteUrl,
+            url: deleteUrl,
             type: 'DELETE',
             success: function () {
-                window.location = urls.afterDeleteUrl;
+                window.location = successUrl;
             },
             error: function () {
                 toastr.error("Cannot delete");
@@ -45,9 +32,10 @@ exports.init = function(options) {
         });
     });
 
-    $deleteCancel.click(resetUIState);
-    $delete.click(function () { 
-        resetUIState();
-        $deleteConfirmationBox.show(); 
+    $(dom.deleteCancel).click(function () {
+        $(dom.deleteConfirmationBox).hide();
+    });
+    $(dom.delete).click(function () {
+        $(dom.deleteConfirmationBox).show();
     });
 };

--- a/opentreemap/treemap/js/src/lib/plotAddTree.js
+++ b/opentreemap/treemap/js/src/lib/plotAddTree.js
@@ -2,7 +2,6 @@
 
 var $ = require('jquery'),
     R = require('ramda'),
-    Bacon = require('baconjs'),
     FH = require('treemap/lib/fieldHelpers.js');
 
 require('treemap/lib/baconUtils.js');

--- a/opentreemap/treemap/js/src/lib/plotDetail.js
+++ b/opentreemap/treemap/js/src/lib/plotDetail.js
@@ -26,105 +26,105 @@ var dom = {
 };
 
 exports.init = function(form) {
-function excludeNullMap(obs, fn) {
-    return obs.map(fn)
-        .filter(R.not(_.isUndefined))
-        .filter(R.not(_.isNull));
-}
-
-var $treeSection = $(dom.treeSection),
-    newTreeIdStream = excludeNullMap(form.saveOkStream,
-        '.responseData.treeId'),
-    newTitleStream = excludeNullMap(form.saveOkStream,
-        '.responseData.feature.title'),
-    newAddressStream = excludeNullMap(form.saveOkStream,
-        '.responseData.feature.address_full'),
-
-    getPlotUrlFromTreeUrl = _.compose(U.removeLastUrlSegment,
-        U.removeLastUrlSegment);
-
-// tree id is the sole datapoint used to determine the state
-// of the plot to be acted upon.
-// this *must be calculated dynamically* to handle the case
-// in which a tree is added and then deleted without a
-// page refresh in between.
-// this information is used for:
-// * deciding which warning message to show
-// * The url to post a delete verb to
-// * the url to redirect to
-function getTreeId() {
-    return $(dom.treeIdColumn).attr('data-tree-id');
-}
-
-function getUrls() {
-    var deleteUrl = document.URL,
-        afterDeleteUrl = reverse.map(config.instance.url_name),
-        currentlyOnTreeUrl = _.contains(U.getUrlSegments(document.URL), "trees");
-
-    if (getTreeId() !== '' && currentlyOnTreeUrl) {
-        afterDeleteUrl = getPlotUrlFromTreeUrl(document.URL);
-    } else if (getTreeId() !== '') {
-        deleteUrl = 'trees/' + getTreeId() + '/';
-        afterDeleteUrl = document.URL;
+    function excludeNullMap(obs, fn) {
+        return obs.map(fn)
+            .filter(R.not(_.isUndefined))
+            .filter(R.not(_.isNull));
     }
-    return {
-        deleteUrl: deleteUrl,
-        afterDeleteUrl: afterDeleteUrl
-    };
-}
-
-mapFeatureDelete.init({
-    getUrls: getUrls,
-    resetUIState: function () {
-        if (getTreeId() === '') {
-            $('#delete-plot-warning').show();
-            $('#delete-tree-warning').hide();
-        } else {
-            $('#delete-tree-warning').show();
-            $('#delete-plot-warning').hide();
+    
+    var $treeSection = $(dom.treeSection),
+        newTreeIdStream = excludeNullMap(form.saveOkStream,
+            '.responseData.treeId'),
+        newTitleStream = excludeNullMap(form.saveOkStream,
+            '.responseData.feature.title'),
+        newAddressStream = excludeNullMap(form.saveOkStream,
+            '.responseData.feature.address_full'),
+    
+        getPlotUrlFromTreeUrl = _.compose(U.removeLastUrlSegment,
+            U.removeLastUrlSegment);
+    
+    // tree id is the sole datapoint used to determine the state
+    // of the plot to be acted upon.
+    // this *must be calculated dynamically* to handle the case
+    // in which a tree is added and then deleted without a
+    // page refresh in between.
+    // this information is used for:
+    // * deciding which warning message to show
+    // * The url to post a delete verb to
+    // * the url to redirect to
+    function getTreeId() {
+        return $(dom.treeIdColumn).attr('data-tree-id');
+    }
+    
+    function getUrls() {
+        var deleteUrl = document.URL,
+            afterDeleteUrl = reverse.map(config.instance.url_name),
+            currentlyOnTreeUrl = _.contains(U.getUrlSegments(document.URL), "trees");
+    
+        if (getTreeId() !== '' && currentlyOnTreeUrl) {
+            afterDeleteUrl = getPlotUrlFromTreeUrl(document.URL);
+        } else if (getTreeId() !== '') {
+            deleteUrl = 'trees/' + getTreeId() + '/';
+            afterDeleteUrl = document.URL;
         }
+        return {
+            deleteUrl: deleteUrl,
+            afterDeleteUrl: afterDeleteUrl
+        };
     }
-});
-
-function initializeTreeIdSection(id) {
-    var $section = $(dom.treeIdColumn);
-    $section.attr('data-tree-id', id);
-    $section.html(format('<a href="trees/%s/">%s</a>', id, id));
-    $(dom.treePresenceSection).hide();
-}
-
-otmTypeahead.create({
-    name: "species",
-    url: reverse.species_list_view(config.instance.url_name),
-    input: "#plot-species-typeahead",
-    template: "#species-element-template",
-    hidden: "#plot-species-hidden",
-    reverse: "id",
-    forceMatch: true
-});
-
-diameterCalculator({
-    formSelector: dom.form,
-    cancelStream: form.cancelStream,
-    saveOkStream: form.saveOkStream
-});
-
-mapFeatureUdf.init(form);
-
-newTreeIdStream.onValue(initializeTreeIdSection);
-newTitleStream.onValue($('#map-feature-title'), 'html');
-newAddressStream.onValue($('#map-feature-address'), 'html');
-
-var beginAddStream = plotAddTree.init({
-    form: form,
-    addTreeControls: dom.addTreeControls,
-    beginAddTree: dom.beginAddTree,
-    plotId: window.otm.mapFeature.featureId
-});
-beginAddStream.onValue($treeSection, 'show');
-
-form.cancelStream
-    .skipUntil(beginAddStream)
-    .takeUntil(newTreeIdStream)
-    .onValue($treeSection, 'hide');
+    
+    mapFeatureDelete.init({
+        getUrls: getUrls,
+        resetUIState: function () {
+            if (getTreeId() === '') {
+                $('#delete-plot-warning').show();
+                $('#delete-tree-warning').hide();
+            } else {
+                $('#delete-tree-warning').show();
+                $('#delete-plot-warning').hide();
+            }
+        }
+    });
+    
+    function initializeTreeIdSection(id) {
+        var $section = $(dom.treeIdColumn);
+        $section.attr('data-tree-id', id);
+        $section.html(format('<a href="trees/%s/">%s</a>', id, id));
+        $(dom.treePresenceSection).hide();
+    }
+    
+    otmTypeahead.create({
+        name: "species",
+        url: reverse.species_list_view(config.instance.url_name),
+        input: "#plot-species-typeahead",
+        template: "#species-element-template",
+        hidden: "#plot-species-hidden",
+        reverse: "id",
+        forceMatch: true
+    });
+    
+    diameterCalculator({
+        formSelector: dom.form,
+        cancelStream: form.cancelStream,
+        saveOkStream: form.saveOkStream
+    });
+    
+    mapFeatureUdf.init(form);
+    
+    newTreeIdStream.onValue(initializeTreeIdSection);
+    newTitleStream.onValue($('#map-feature-title'), 'html');
+    newAddressStream.onValue($('#map-feature-address'), 'html');
+    
+    var beginAddStream = plotAddTree.init({
+        form: form,
+        addTreeControls: dom.addTreeControls,
+        beginAddTree: dom.beginAddTree,
+        plotId: window.otm.mapFeature.featureId
+    });
+    beginAddStream.onValue($treeSection, 'show');
+    
+    form.cancelStream
+        .skipUntil(beginAddStream)
+        .takeUntil(newTreeIdStream)
+        .onValue($treeSection, 'hide');
 };

--- a/opentreemap/treemap/js/src/lib/plotDetail.js
+++ b/opentreemap/treemap/js/src/lib/plotDetail.js
@@ -7,7 +7,6 @@ var $ = require('jquery'),
     format = require('util').format,
     otmTypeahead = require('treemap/lib/otmTypeahead.js'),
     FH = require('treemap/lib/fieldHelpers.js'),
-    mapFeature = require('treemap/lib/mapFeature.js'),
     mapFeatureDelete = require('treemap/lib/mapFeatureDelete.js'),
     diameterCalculator = require('treemap/lib/diameterCalculator.js'),
     mapFeatureUdf = require('treemap/lib/mapFeatureUdf.js'),
@@ -15,9 +14,6 @@ var $ = require('jquery'),
     moment = require('moment'),
     config = require('treemap/lib/config.js'),
     reverse = require('reverse');
-
-// Placed onto the jquery object
-require('bootstrap-datepicker');
 
 var dom = {
     form: '#map-feature-form',
@@ -29,24 +25,23 @@ var dom = {
     treeSection: '#tree-details',
 };
 
-function excludeNullMap (obs, fn) {
+exports.init = function(form) {
+function excludeNullMap(obs, fn) {
     return obs.map(fn)
         .filter(R.not(_.isUndefined))
         .filter(R.not(_.isNull));
 }
 
-var form = mapFeature.init().inlineEditForm,
-    $treeSection = $(dom.treeSection),
+var $treeSection = $(dom.treeSection),
     newTreeIdStream = excludeNullMap(form.saveOkStream,
-                                        '.responseData.treeId'),
+        '.responseData.treeId'),
     newTitleStream = excludeNullMap(form.saveOkStream,
-                                    '.responseData.feature.title'),
+        '.responseData.feature.title'),
     newAddressStream = excludeNullMap(form.saveOkStream,
-                                        '.responseData.feature.address_full'),
+        '.responseData.feature.address_full'),
 
     getPlotUrlFromTreeUrl = _.compose(U.removeLastUrlSegment,
-                                        U.removeLastUrlSegment);
-
+        U.removeLastUrlSegment);
 
 // tree id is the sole datapoint used to determine the state
 // of the plot to be acted upon.
@@ -72,13 +67,15 @@ function getUrls() {
         deleteUrl = 'trees/' + getTreeId() + '/';
         afterDeleteUrl = document.URL;
     }
-    return {deleteUrl: deleteUrl,
-            afterDeleteUrl: afterDeleteUrl};
+    return {
+        deleteUrl: deleteUrl,
+        afterDeleteUrl: afterDeleteUrl
+    };
 }
 
 mapFeatureDelete.init({
     getUrls: getUrls,
-    resetUIState: function() {
+    resetUIState: function () {
         if (getTreeId() === '') {
             $('#delete-plot-warning').show();
             $('#delete-tree-warning').hide();
@@ -89,7 +86,7 @@ mapFeatureDelete.init({
     }
 });
 
-function initializeTreeIdSection (id) {
+function initializeTreeIdSection(id) {
     var $section = $(dom.treeIdColumn);
     $section.attr('data-tree-id', id);
     $section.html(format('<a href="trees/%s/">%s</a>', id, id));
@@ -106,8 +103,6 @@ otmTypeahead.create({
     forceMatch: true
 });
 
-$('[data-date-format]').datepicker();
-
 diameterCalculator({
     formSelector: dom.form,
     cancelStream: form.cancelStream,
@@ -120,12 +115,11 @@ newTreeIdStream.onValue(initializeTreeIdSection);
 newTitleStream.onValue($('#map-feature-title'), 'html');
 newAddressStream.onValue($('#map-feature-address'), 'html');
 
-
 var beginAddStream = plotAddTree.init({
     form: form,
     addTreeControls: dom.addTreeControls,
     beginAddTree: dom.beginAddTree,
-    plotId: window.otm.mapFeature.plotId
+    plotId: window.otm.mapFeature.featureId
 });
 beginAddStream.onValue($treeSection, 'show');
 
@@ -133,3 +127,4 @@ form.cancelStream
     .skipUntil(beginAddStream)
     .takeUntil(newTreeIdStream)
     .onValue($treeSection, 'hide');
+};

--- a/opentreemap/treemap/js/src/lib/resourceDetail.js
+++ b/opentreemap/treemap/js/src/lib/resourceDetail.js
@@ -5,6 +5,6 @@ var $ = require('jquery'),
     mapFeatureUdf = require('treemap/lib/mapFeatureUdf.js');
 
 exports.init = function(form) {
-mapFeatureUdf.init(form);
-mapFeatureDelete.init();
+    mapFeatureUdf.init(form);
+    mapFeatureDelete.init();
 };

--- a/opentreemap/treemap/js/src/lib/resourceDetail.js
+++ b/opentreemap/treemap/js/src/lib/resourceDetail.js
@@ -1,14 +1,10 @@
 "use strict";
 
 var $ = require('jquery'),
-    mapFeature = require('treemap/lib/mapFeature.js'),
     mapFeatureDelete = require('treemap/lib/mapFeatureDelete.js'),
     mapFeatureUdf = require('treemap/lib/mapFeatureUdf.js');
 
-// Placed onto the jquery object
-require('bootstrap-datepicker');
-
-var form = mapFeature.init().inlineEditForm;
+exports.init = function(form) {
 mapFeatureUdf.init(form);
 mapFeatureDelete.init();
-$('[data-date-format]').datepicker();
+};

--- a/opentreemap/treemap/js/src/mapFeatureDetail.js
+++ b/opentreemap/treemap/js/src/mapFeatureDetail.js
@@ -11,6 +11,7 @@ var $ = require('jquery'),
     BU = require('treemap/lib/baconUtils.js'),
     Bacon = require('baconjs'),
     U = require('treemap/lib/utility.js'),
+    FH = require('treemap/lib/fieldHelpers.js'),
     geometryMover = require('treemap/lib/geometryMover.js'),
     plotMarker = require('treemap/lib/plotMarker.js'),
     statePrompter = require('treemap/lib/statePrompter.js'),
@@ -23,6 +24,7 @@ var $ = require('jquery'),
     config = require('treemap/lib/config.js'),
     reverse = require('reverse'),
     alerts = require('treemap/lib/alerts.js'),
+    buttonEnabler = require('treemap/lib/buttonEnabler.js'),
     comments = require('otm_comments/lib/comments.js');
 
 // Placed onto the jquery object
@@ -31,7 +33,7 @@ require('bootstrap-datepicker');
 var dom = {
         favoriteLink: '#favorite-link',
         favoriteIcon: '#favorite-star',
-        ecoBenefits: '#ecobenefits',
+        detail: '#mapFeaturePartial',
         sidebar: '#sidebar',
         form: '#map-feature-form',
         streetView: '#street-view',
@@ -42,8 +44,7 @@ var dom = {
     };
 
 function init() {
-    var $ecoBenefits = $(dom.ecoBenefits),
-        detailUrl = window.location.href;
+    var detailUrl = window.location.href;
 
     if (U.getLastUrlSegment(detailUrl) == 'edit') {
         detailUrl = U.removeLastUrlSegment(detailUrl);
@@ -85,30 +86,39 @@ function init() {
         shouldBeInEditModeStream: shouldBeInEditModeStream,
         errorCallback: alerts.errorCallback,
         onSaveBefore: function (data) { currentMover.onSaveBefore(data); },
-        onSaveAfter: function (data) { currentMover.onSaveAfter(data); }
+        onSaveAfter: function (data) { currentMover.onSaveAfter(data); },
+        dontUpdateOnSaveOk: true
     });
 
-    if (window.otm.mapFeature.isPlot) {
-        plotDetail.init(form);
-    } else {
-        resourceDetail.init(form);
+    function initDetailAfterRefresh() {
+        buttonEnabler.run();
+        FH.renderMultiChoices($('[data-class="display"]').filter('[data-type="multichoice"]'));
+        initDetail();
     }
 
-    if (config.instance.supportsEcobenefits) {
-        var updateEcoUrl = reverse.plot_eco({
+    function initDetail() {
+        if (window.otm.mapFeature.isPlot) {
+            plotDetail.init(form);
+        } else {
+            resourceDetail.init(form);
+        }
+    }
+
+    initDetail(form);
+
+    var refreshDetailUrl = reverse.map_feature_detail_partial({
+            instance_url_name: config.instance.url_name,
+            feature_id: window.otm.mapFeature.featureId
+        }),
+        refreshSidebarUrl = reverse.map_feature_sidebar({
             instance_url_name: config.instance.url_name,
             feature_id: window.otm.mapFeature.featureId
         });
-        form.saveOkStream
-            .map($ecoBenefits)
-            .onValue('.load', updateEcoUrl);
-    }
-
-    var sidebarUpdate = form.saveOkStream.merge(imageFinishedStream),
-        updateSidebarUrl = U.appendSegmentToUrl('sidebar', detailUrl);
-    sidebarUpdate
-        .map($(dom.sidebar))
-        .onValue('.load', updateSidebarUrl);
+    form.saveOkStream.merge(imageFinishedStream)
+        .onValue(function () {
+            $(dom.detail).load(refreshDetailUrl, initDetailAfterRefresh);
+            $(dom.sidebar).load(refreshSidebarUrl);
+        });
 
     form.inEditModeProperty.onValue(function(inEditMode) {
         var hrefHasEdit = U.getLastUrlSegment() === 'edit';

--- a/opentreemap/treemap/js/src/mapFeatureDetail.js
+++ b/opentreemap/treemap/js/src/mapFeatureDetail.js
@@ -3,6 +3,8 @@
 var $ = require('jquery'),
     _ = require('lodash'),
     toastr = require('toastr'),
+    plotDetail = require('treemap/lib/plotDetail.js'),
+    resourceDetail = require('treemap/lib/resourceDetail.js'),
     inlineEditForm = require('treemap/lib/inlineEditForm.js'),
     MapManager = require('treemap/lib/MapManager.js'),
     R = require('ramda'),
@@ -21,9 +23,12 @@ var $ = require('jquery'),
     config = require('treemap/lib/config.js'),
     reverse = require('reverse'),
     alerts = require('treemap/lib/alerts.js'),
-    comments = require('otm_comments/lib/comments.js'),
+    comments = require('otm_comments/lib/comments.js');
 
-    dom = {
+// Placed onto the jquery object
+require('bootstrap-datepicker');
+
+var dom = {
         favoriteLink: '#favorite-link',
         favoriteIcon: '#favorite-star',
         ecoBenefits: '#ecobenefits',
@@ -36,7 +41,7 @@ var $ = require('jquery'),
         },
     };
 
-exports.init = function() {
+function init() {
     var $ecoBenefits = $(dom.ecoBenefits),
         detailUrl = window.location.href;
 
@@ -82,6 +87,12 @@ exports.init = function() {
         onSaveBefore: function (data) { currentMover.onSaveBefore(data); },
         onSaveAfter: function (data) { currentMover.onSaveAfter(data); }
     });
+
+    if (window.otm.mapFeature.isPlot) {
+        plotDetail.init(form);
+    } else {
+        resourceDetail.init(form);
+    }
 
     if (config.instance.supportsEcobenefits) {
         var updateEcoUrl = reverse.plot_eco({
@@ -209,9 +220,9 @@ exports.init = function() {
         });
     }
 
-    socialMediaSharing.init({imageFinishedStream: imageFinishedStream});
+    $('[data-date-format]').datepicker();
 
-    return {
-        inlineEditForm: form
-    };
-};
+    socialMediaSharing.init({imageFinishedStream: imageFinishedStream});
+}
+
+init();

--- a/opentreemap/treemap/routes.py
+++ b/opentreemap/treemap/routes.py
@@ -126,6 +126,11 @@ map_feature_detail = do(
                 PUT=feature_views.update_map_feature_detail,
                 DELETE=feature_views.delete_map_feature))))
 
+map_feature_detail_partial = do(
+    instance_request,
+    require_http_method('GET'),
+    feature_views.render_map_feature_detail_partial)
+
 map_feature_accordion = do(
     instance_request,
     render_template('treemap/partials/map_feature_accordion.html'),

--- a/opentreemap/treemap/templates/treemap/map_feature_detail.html
+++ b/opentreemap/treemap/templates/treemap/map_feature_detail.html
@@ -1,9 +1,13 @@
 {% extends "instance_base.html" %}
+{% load render_bundle from webpack_loader %}
 {% load threadedcomments_tags %}
 {% load instance_config %}
 {% load i18n %}
 {% load l10n %}
+{% load form_extras %}
 {% load util %}
+
+{% block page_title %} | {{ feature.terminology.singular }} {{ feature.pk }}{% endblock %}
 
 {% block head_extra %}
     {# Facebook & Google+ scrape these properties for their share dialogs #}
@@ -68,153 +72,10 @@
             </div>
 
             <div class="col-md-9">
-                <div class="detail-header">
-                    {% if request.instance.is_public %}
-                        <div class="js-container pull-right" style="display: none">
-                            <a target="_blank" href="http://www.facebook.com/sharer/sharer.php?u={{ share.url }}">
-                                <img src="/static/img/facebook_32.png">
-                            </a>
-                            <a target="_blank" href="http://twitter.com/share?url={{ share.url }}&text={{ share.title }}">
-                                <img src="/static/img/twitter_32.png">
-                            </a>
-                            <a target="_blank" href="https://plus.google.com/share?url={{ share.url }}">
-                                <img src="/static/img/googleplus_32.png">
-                            </a>
-                        </div>
-                        <button class="btn share">Share</button>
-                    {% endif %}
-                    <h2 class="common-name" id="map-feature-title">
-                        {{ title }}
-                        <a id="favorite-link"
-                           data-href="{{ request.get_full_path }}"
-                           data-is-favorited="{{ favorited }}"
-                           data-always-enable="{{ request.user.is_authenticated }}"
-                           data-favorite-url="{% url 'favorite_map_feature' instance_url_name=request.instance.url_name feature_id=feature.pk %}"
-                           data-unfavorite-url="{% url 'unfavorite_map_feature' instance_url_name=request.instance.url_name feature_id=feature.pk %}">
-                            {% if favorited %}
-                                <i id="favorite-star" class="icon-star"></i>
-                            {% else %}
-                                <i id="favorite-star" class="icon-star-empty"></i>
-                            {% endif %}
-                        </a>
-                    </h2>
-                    <h4 class="address" id="map-feature-address">{{ feature.address_full }}</h4>
-                </div>
                 <div class="row">
-                    <div class="col-md-8">
-                        <p>
-                            {% if feature.is_plot or feature.is_editable %}
-                                <button id="edit-map-feature"
-                                        data-class="display"
-                                        disabled="disabled"
-                                        data-always-enable="{{ last_effective_instance_user|map_feature_is_writable:feature }}"
-                                        data-href="{{ request.get_full_path }}"
-                                        {% if feature.is_plot %}
-                                        data-disabled-title="{% trans "Editing of the tree details is not available to all users" %}"
-                                        {% else %}
-                                            {# TODO: what kind of text do want to put here? Do we want to put this on the model? #}
-                                        data-disabled-title="{% trans "Editing of the resource's details is not available to all users" %}"
-                                        {% endif %}
-                                        class="btn btn-sm btn-info">{% trans "Edit" %}</button>
-                                <button id="save-edit-map-feature" data-class="edit" class="btn btn-sm btn-primary" style="display: none;">{% trans "Save" %}</button>
-                                <button id="cancel-edit-map-feature" data-class="edit" class="btn btn-sm" style="display: none;">{% trans "Cancel" %}</button>
-                            {% endif %}
-                            <button id="delete-object"
-                                    data-class="display"
-                                    disabled="disabled"
-                                    {% if has_tree %}
-                                        {# TODO: this will not work quite right when a user adds a tree without refreshing #}
-                                    data-always-enable="{{ last_effective_instance_user|is_deletable:tree }}"
-                                    data-disabled-title="{% trans "Deleting of trees is not available to all users" %}"
-                                    {% else %}
-                                    data-always-enable="{{ last_effective_instance_user|is_deletable:feature }}"
-                                        {% if feature.is_plot %}
-                                    data-disabled-title="{% trans "Deleting of planting sites is not available to all users" %}"
-                                        {% else %}
-                                    data-disabled-title="{% blocktrans with resources=term.Resource.plural.lower %}Deleting of {{ resources }} is not available to all users{% endblocktrans %}"
-                                        {% endif %}
-                                    {% endif %}
-                                    data-href="{{ request.get_full_path }}"
-                                    class="btn btn-sm btn-danger">{% trans "Delete" %}</button>
-                        </p>
-
-                        <!-- Alerts -->
-                        <div id="delete-confirmation-box" data-class="delete" class="alert alert-danger" style="display: none;">
-                            {% block delete_confirmation_text %}
-                            {% endblock %}
-                            <button id="delete-confirm" class="btn btm-small btn-danger">{% trans "Confirm Deletion" %}</button>
-                            <button id="delete-cancel" class="btn btm-small">{% trans "Cancel" %}</button>
-                        </div>
-                        <hr>
-
-                        <!-- Map Feature Details -->
-                        <form id="map-feature-form">
-
-                            {# There isn't a field to show "inline" errors for geom fields, so just show it up top #}
-                            <div class="alert alert-warning" data-class="error" data-field="mapFeature.geom" style="display: none;"></div>
-                            {% block subclass_details %}
-                            {% endblock subclass_details %}
-
-                        </form>
-
-                        <!-- Commenting -->
-                        <h3>{% trans "Comments" %}</h3>
-                        <div id="comments-container">
-                            {% get_comment_list for feature as comments %}
-                            {% for comment in comments|fill_tree|annotate_tree %}
-                                {% ifchanged comment.parent_id %}{% else %}</li>{% endifchanged %}
-                                {% if not comment.open and not comment.close %}</li>{% endif %}
-                                {% if comment.open %}<ul>{% endif %}
-
-                            <li class="comment_li" id="c{{ comment.id|unlocalize }}">
-                                <div class="comment">
-                                    <div class="comment_info">
-                                        {% if comment.is_removed %}
-                                            <div class="comment_user deactive">[{% trans "Removed by Moderator" %}]</div>
-                                        {% else %}
-                                            <div class="comment_user">{{ comment.user_name }}</div>
-                                        {% endif %}
-                                        <div class="comment_data">
-                                            {{ comment.submit_date|date:"d M Y, H:i" }}
-                                            {% if request.user.is_authenticated and not comment.is_removed %}
-                                                | <a href="javascript:void(0);"  data-comment-id="{{ comment.id|unlocalize }}" class="comment_reply_link">Reply</a>
-                                                | <div data-class="comment-flag">{% include "otm_comments/partials/flagging.html" %}</div>
-                                            {% endif %}
-                                        </div>
-                                    </div>
-                                    <div class="comment_text">
-                                        {% if comment.is_removed %}
-                                            <div class="deactive">[{% trans "This comment has been removed by a moderator." %}]</div>
-                                        {% else %}
-                                            {{ comment.comment }}
-                                        {% endif %}
-                                    </div>
-                                </div>
-                                {% for close in comment.close %}</li></ul>{% endfor %}
-                            {% endfor %}
-                            {% if not request.user.is_authenticated %}
-                                <p><a href="{% url 'registration_register' %}">{% trans "Sign Up" %}</a>
-                                    {% trans "or" %} <a href="{% url 'auth_login' %}">{% trans "log in" %}</a>
-                                    {% trans "to add comments" %}</p>
-                            {% endif %}
-                        </div>
-
-                        <div id="comment_disclaimer">
-                            <p class="text-muted">
-                                <em>
-                                    {% if feature.is_plot %}
-                                        {% trans "The comment system does not serve as a way to report problems with a tree." %}
-                                    {% else %}
-                                        {% blocktrans with resource=term.Resource.singular.lower %}
-                                            The comment system does not serve as a way to report problems with a {{ resource }}.
-                                        {% endblocktrans %}
-                                    {% endif %}
-                                </em>
-                            </p>
-                        </div>
-
+                    <div id="mapFeaturePartial">
+                        {% include map_feature_partial %}
                     </div>
-
                     <!-- Maps -->
                     <div class="col-md-4">
                         <div id="map" class="map-small"
@@ -265,9 +126,7 @@
 
     <script>
         {% localize off %}
-            // Define options for mapFeature.init(), which will be called in the
-            // type-specific template inheriting from this one (e.g. plot_detail.html)
-            // This global variable is later used in the JS entry module as a simple way to pass in static data
+            // This global variable is used in the JS entry module as a simple way to pass in static data
             window.otm.mapFeature = {
                 startInEditMode: {% if editmode %}true{% else %}false{% endif %},
                 isEditablePolygon: {% if feature.polygon and feature.is_editable %}true{% else %}false{% endif %},
@@ -280,7 +139,12 @@
                         y: {{ feature.geom.y }}
                     }
                 },
+                isPlot: {% if feature.is_plot %}true{% else %}false{% endif %},
+                useTreeIcon: {% if feature.is_plot %}true{% else %}false{% endif %},
+                resourceType: "{{ feature.map_feature_type|to_object_name }}"
             };
+            Object.freeze(window.otm.mapFeature);
         {% endlocalize %}
     </script>
+    {% render_bundle 'js/treemap/mapFeatureDetail' %}
 {% endblock scripts %}

--- a/opentreemap/treemap/templates/treemap/map_feature_detail.html
+++ b/opentreemap/treemap/templates/treemap/map_feature_detail.html
@@ -6,281 +6,281 @@
 {% load util %}
 
 {% block head_extra %}
-{# Facebook & Google+ scrape these properties for their share dialogs #}
-<meta property="og:url" content="{{ share.url }}" />
-<meta property="og:title" content="{{ share.title }}" />
-<meta property="og:description" content="{{ share.description }}" />
-<meta property="og:image" content="{{ share.image }}" />
-<meta property="og:type" content="article" />
-<meta property="og:site_name" content="{{ request.instance.name }}" />
+    {# Facebook & Google+ scrape these properties for their share dialogs #}
+    <meta property="og:url" content="{{ share.url }}" />
+    <meta property="og:title" content="{{ share.title }}" />
+    <meta property="og:description" content="{{ share.description }}" />
+    <meta property="og:image" content="{{ share.image }}" />
+    <meta property="og:type" content="article" />
+    <meta property="og:site_name" content="{{ request.instance.name }}" />
 {% endblock head_extra %}
 
 {% block subhead_exports %}
-{# Exporting is not available from the detail page #}
+    {# Exporting is not available from the detail page #}
 {% endblock subhead_exports %}
 
 {% block content %}
-{% include "treemap/partials/upload_image.html" with panel_id="add-photo-modal" title="Add a Photo" %}
-{% include "treemap/partials/photo_social_media_sharing.html" %}
+    {% include "treemap/partials/upload_image.html" with panel_id="add-photo-modal" title="Add a Photo" %}
+    {% include "treemap/partials/photo_social_media_sharing.html" %}
 
-{# Modal for viewing and rotating photos, used by imageUploadPanel.js #}
-<div id="photo-lightbox" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content lightbox">
-      <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-      <img data-photo-image src="">
-      <div class="lightbox-caption">
-        <a class="btn btn-small pull-right" data-class="view" data-photo-edit>{% trans "Edit" %}</a>
-        <a class="btn btn-small pull-left btn-rotate" data-class="edit" data-photo-rotate="-90"><i class="icon-ccw"></i></a>
-        <a class="btn btn-small pull-left btn-rotate" data-class="edit" data-photo-rotate="90"><i class="icon-cw"></i></a>
-        <button data-class="edit" disabled="disabled" class="btn btn-small pull-right"
-            data-photo-save="">{% trans "Save" %}</button>
-      </div>
-    </div>
-  </div>
-</div>
-
-<div class="image-background"></div>
-<div class="container contained topper tree-details">
-  <div class="row">
-    <div class="col-md-3">
-      <div class="photo-container">
-        <div id="photo-carousel" class="carousel slide" data-interval="">
-            {% include "treemap/partials/photo_carousel.html" %}
+    {# Modal for viewing and rotating photos, used by imageUploadPanel.js #}
+    <div id="photo-lightbox" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content lightbox">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <img data-photo-image src="">
+                <div class="lightbox-caption">
+                    <a class="btn btn-small pull-right" data-class="view" data-photo-edit>{% trans "Edit" %}</a>
+                    <a class="btn btn-small pull-left btn-rotate" data-class="edit" data-photo-rotate="-90"><i class="icon-ccw"></i></a>
+                    <a class="btn btn-small pull-left btn-rotate" data-class="edit" data-photo-rotate="90"><i class="icon-cw"></i></a>
+                    <button data-class="edit" disabled="disabled" class="btn btn-small pull-right"
+                            data-photo-save="">{% trans "Save" %}</button>
+                </div>
+            </div>
         </div>
-        <button id="toggle-add-photo-modal"
-                data-toggle="modal"
-                data-target="#add-photo-modal"
-                data-href="{{ request.get_full_path }}"
-                disabled="disabled"
-                {% if feature.is_plot %}
-                data-disabled-title="{% trans "Adding tree photos is not available to all users" %}"
-                data-always-enable="{{ last_effective_instance_user|treephoto_is_writable }}"
-                {% else %}
-                data-disabled-title="{% trans "Adding resource photos is not available to all users" %}"
-                data-always-enable="{{ last_effective_instance_user|mapfeaturephoto_is_writable }}"
-                {% endif %}
-                class="btn btn-xs add-photos">{% trans "Add Photo" %}</button>
-      </div>
-      <div id="sidebar">
-        {% include "treemap/partials/sidebar.html" %}
-      </div>
     </div>
 
-    <div class="col-md-9">
-      <div class="detail-header">
-        {% if request.instance.is_public %}
-        <div class="js-container pull-right" style="display: none">
-          <a target="_blank" href="http://www.facebook.com/sharer/sharer.php?u={{ share.url }}">
-            <img src="/static/img/facebook_32.png">
-          </a>
-          <a target="_blank" href="http://twitter.com/share?url={{ share.url }}&text={{ share.title }}">
-            <img src="/static/img/twitter_32.png">
-          </a>
-          <a target="_blank" href="https://plus.google.com/share?url={{ share.url }}">
-            <img src="/static/img/googleplus_32.png">
-          </a>
-        </div>
-        <button class="btn share">Share</button>
-        {% endif %}
-        <h2 class="common-name" id="map-feature-title">
-          {{ title }}
-          <a id="favorite-link"
-            data-href="{{ request.get_full_path }}"
-            data-is-favorited="{{ favorited }}"
-            data-always-enable="{{ request.user.is_authenticated }}"
-            data-favorite-url="{% url 'favorite_map_feature' instance_url_name=request.instance.url_name feature_id=feature.pk %}"
-            data-unfavorite-url="{% url 'unfavorite_map_feature' instance_url_name=request.instance.url_name feature_id=feature.pk %}">
-            {% if favorited %}
-              <i id="favorite-star" class="icon-star"></i>
-            {% else %}
-              <i id="favorite-star" class="icon-star-empty"></i>
-            {% endif %}
-          </a>
-        </h2>
-        <h4 class="address" id="map-feature-address">{{ feature.address_full }}</h4>
-      </div>
-      <div class="row">
-        <div class="col-md-8">
-          <p>
-{% if feature.is_plot or feature.is_editable %}
-            <button id="edit-map-feature"
-                    data-class="display"
-                    disabled="disabled"
-                    data-always-enable="{{ last_effective_instance_user|map_feature_is_writable:feature }}"
-                    data-href="{{ request.get_full_path }}"
-                    {% if feature.is_plot %}
-                    data-disabled-title="{% trans "Editing of the tree details is not available to all users" %}"
-                    {% else %}
-                    {# TODO: what kind of text do want to put here? Do we want to put this on the model? #}
-                    data-disabled-title="{% trans "Editing of the resource's details is not available to all users" %}"
+    <div class="image-background"></div>
+    <div class="container contained topper tree-details">
+        <div class="row">
+            <div class="col-md-3">
+                <div class="photo-container">
+                    <div id="photo-carousel" class="carousel slide" data-interval="">
+                        {% include "treemap/partials/photo_carousel.html" %}
+                    </div>
+                    <button id="toggle-add-photo-modal"
+                            data-toggle="modal"
+                            data-target="#add-photo-modal"
+                            data-href="{{ request.get_full_path }}"
+                            disabled="disabled"
+                            {% if feature.is_plot %}
+                            data-disabled-title="{% trans "Adding tree photos is not available to all users" %}"
+                            data-always-enable="{{ last_effective_instance_user|treephoto_is_writable }}"
+                            {% else %}
+                            data-disabled-title="{% trans "Adding resource photos is not available to all users" %}"
+                            data-always-enable="{{ last_effective_instance_user|mapfeaturephoto_is_writable }}"
+                            {% endif %}
+                            class="btn btn-xs add-photos">{% trans "Add Photo" %}</button>
+                </div>
+                <div id="sidebar">
+                    {% include "treemap/partials/sidebar.html" %}
+                </div>
+            </div>
+
+            <div class="col-md-9">
+                <div class="detail-header">
+                    {% if request.instance.is_public %}
+                        <div class="js-container pull-right" style="display: none">
+                            <a target="_blank" href="http://www.facebook.com/sharer/sharer.php?u={{ share.url }}">
+                                <img src="/static/img/facebook_32.png">
+                            </a>
+                            <a target="_blank" href="http://twitter.com/share?url={{ share.url }}&text={{ share.title }}">
+                                <img src="/static/img/twitter_32.png">
+                            </a>
+                            <a target="_blank" href="https://plus.google.com/share?url={{ share.url }}">
+                                <img src="/static/img/googleplus_32.png">
+                            </a>
+                        </div>
+                        <button class="btn share">Share</button>
                     {% endif %}
-                    class="btn btn-sm btn-info">{% trans "Edit" %}</button>
-            <button id="save-edit-map-feature" data-class="edit" class="btn btn-sm btn-primary" style="display: none;">{% trans "Save" %}</button>
-            <button id="cancel-edit-map-feature" data-class="edit" class="btn btn-sm" style="display: none;">{% trans "Cancel" %}</button>
-{% endif %}
-            <button id="delete-object"
-                    data-class="display"
-                    disabled="disabled"
-                    {% if has_tree %}
-                    {# TODO: this will not work quite right when a user adds a tree without refreshing #}
-                    data-always-enable="{{ last_effective_instance_user|is_deletable:tree }}"
-                    data-disabled-title="{% trans "Deleting of trees is not available to all users" %}"
-                    {% else %}
-                    data-always-enable="{{ last_effective_instance_user|is_deletable:feature }}"
-                    {% if feature.is_plot %}
-                    data-disabled-title="{% trans "Deleting of planting sites is not available to all users" %}"
-                    {% else %}
-                    data-disabled-title="{% blocktrans with resources=term.Resource.plural.lower %}Deleting of {{ resources }} is not available to all users{% endblocktrans %}"
-                    {% endif %}
-                    {% endif %}
-                    data-href="{{ request.get_full_path }}"
-                    class="btn btn-sm btn-danger">{% trans "Delete" %}</button>
-          </p>
+                    <h2 class="common-name" id="map-feature-title">
+                        {{ title }}
+                        <a id="favorite-link"
+                           data-href="{{ request.get_full_path }}"
+                           data-is-favorited="{{ favorited }}"
+                           data-always-enable="{{ request.user.is_authenticated }}"
+                           data-favorite-url="{% url 'favorite_map_feature' instance_url_name=request.instance.url_name feature_id=feature.pk %}"
+                           data-unfavorite-url="{% url 'unfavorite_map_feature' instance_url_name=request.instance.url_name feature_id=feature.pk %}">
+                            {% if favorited %}
+                                <i id="favorite-star" class="icon-star"></i>
+                            {% else %}
+                                <i id="favorite-star" class="icon-star-empty"></i>
+                            {% endif %}
+                        </a>
+                    </h2>
+                    <h4 class="address" id="map-feature-address">{{ feature.address_full }}</h4>
+                </div>
+                <div class="row">
+                    <div class="col-md-8">
+                        <p>
+                            {% if feature.is_plot or feature.is_editable %}
+                                <button id="edit-map-feature"
+                                        data-class="display"
+                                        disabled="disabled"
+                                        data-always-enable="{{ last_effective_instance_user|map_feature_is_writable:feature }}"
+                                        data-href="{{ request.get_full_path }}"
+                                        {% if feature.is_plot %}
+                                        data-disabled-title="{% trans "Editing of the tree details is not available to all users" %}"
+                                        {% else %}
+                                            {# TODO: what kind of text do want to put here? Do we want to put this on the model? #}
+                                        data-disabled-title="{% trans "Editing of the resource's details is not available to all users" %}"
+                                        {% endif %}
+                                        class="btn btn-sm btn-info">{% trans "Edit" %}</button>
+                                <button id="save-edit-map-feature" data-class="edit" class="btn btn-sm btn-primary" style="display: none;">{% trans "Save" %}</button>
+                                <button id="cancel-edit-map-feature" data-class="edit" class="btn btn-sm" style="display: none;">{% trans "Cancel" %}</button>
+                            {% endif %}
+                            <button id="delete-object"
+                                    data-class="display"
+                                    disabled="disabled"
+                                    {% if has_tree %}
+                                        {# TODO: this will not work quite right when a user adds a tree without refreshing #}
+                                    data-always-enable="{{ last_effective_instance_user|is_deletable:tree }}"
+                                    data-disabled-title="{% trans "Deleting of trees is not available to all users" %}"
+                                    {% else %}
+                                    data-always-enable="{{ last_effective_instance_user|is_deletable:feature }}"
+                                        {% if feature.is_plot %}
+                                    data-disabled-title="{% trans "Deleting of planting sites is not available to all users" %}"
+                                        {% else %}
+                                    data-disabled-title="{% blocktrans with resources=term.Resource.plural.lower %}Deleting of {{ resources }} is not available to all users{% endblocktrans %}"
+                                        {% endif %}
+                                    {% endif %}
+                                    data-href="{{ request.get_full_path }}"
+                                    class="btn btn-sm btn-danger">{% trans "Delete" %}</button>
+                        </p>
 
-          <!-- Alerts -->
-          <div id="delete-confirmation-box" data-class="delete" class="alert alert-danger" style="display: none;">
-            {% block delete_confirmation_text %}
-            {% endblock %}
-            <button id="delete-confirm" class="btn btm-small btn-danger">{% trans "Confirm Deletion" %}</button>
-            <button id="delete-cancel" class="btn btm-small">{% trans "Cancel" %}</button>
-          </div>
-          <hr>
+                        <!-- Alerts -->
+                        <div id="delete-confirmation-box" data-class="delete" class="alert alert-danger" style="display: none;">
+                            {% block delete_confirmation_text %}
+                            {% endblock %}
+                            <button id="delete-confirm" class="btn btm-small btn-danger">{% trans "Confirm Deletion" %}</button>
+                            <button id="delete-cancel" class="btn btm-small">{% trans "Cancel" %}</button>
+                        </div>
+                        <hr>
 
-          <!-- Map Feature Details -->
-          <form id="map-feature-form">
+                        <!-- Map Feature Details -->
+                        <form id="map-feature-form">
 
-            {# There isn't a field to show "inline" errors for geom fields, so just show it up top #}
-            <div class="alert alert-warning" data-class="error" data-field="mapFeature.geom" style="display: none;"></div>
-            {% block subclass_details %}
-            {% endblock subclass_details %}
+                            {# There isn't a field to show "inline" errors for geom fields, so just show it up top #}
+                            <div class="alert alert-warning" data-class="error" data-field="mapFeature.geom" style="display: none;"></div>
+                            {% block subclass_details %}
+                            {% endblock subclass_details %}
 
-          </form>
+                        </form>
 
-          <!-- Commenting -->
-          <h3>{% trans "Comments" %}</h3>
-          <div id="comments-container">
-            {% get_comment_list for feature as comments %}
-            {% for comment in comments|fill_tree|annotate_tree %}
-               {% ifchanged comment.parent_id %}{% else %}</li>{% endifchanged %}
-               {% if not comment.open and not comment.close %}</li>{% endif %}
-               {% if comment.open %}<ul>{% endif %}
+                        <!-- Commenting -->
+                        <h3>{% trans "Comments" %}</h3>
+                        <div id="comments-container">
+                            {% get_comment_list for feature as comments %}
+                            {% for comment in comments|fill_tree|annotate_tree %}
+                                {% ifchanged comment.parent_id %}{% else %}</li>{% endifchanged %}
+                                {% if not comment.open and not comment.close %}</li>{% endif %}
+                                {% if comment.open %}<ul>{% endif %}
 
-               <li class="comment_li" id="c{{ comment.id|unlocalize }}">
-                 <div class="comment">
-                   <div class="comment_info">
-                     {% if comment.is_removed %}
-                     <div class="comment_user deactive">[{% trans "Removed by Moderator" %}]</div>
-                     {% else %}
-                     <div class="comment_user">{{ comment.user_name }}</div>
-                     {% endif %}
-                     <div class="comment_data">
-                       {{ comment.submit_date|date:"d M Y, H:i" }}
-                       {% if request.user.is_authenticated and not comment.is_removed %}
-                       | <a href="javascript:void(0);"  data-comment-id="{{ comment.id|unlocalize }}" class="comment_reply_link">Reply</a>
-                       | <div data-class="comment-flag">{% include "otm_comments/partials/flagging.html" %}</div>
-                       {% endif %}
-                     </div>
-                   </div>
-                   <div class="comment_text">
-                     {% if comment.is_removed %}
-                     <div class="deactive">[{% trans "This comment has been removed by a moderator." %}]</div>
-                     {% else %}
-                     {{ comment.comment }}
-                     {% endif %}
-                   </div>
-                 </div>
-               {% for close in comment.close %}</li></ul>{% endfor %}
-             {% endfor %}
-            {% if not request.user.is_authenticated %}
-              <p><a href="{% url 'registration_register' %}">{% trans "Sign Up" %}</a>
-                 {% trans "or" %} <a href="{% url 'auth_login' %}">{% trans "log in" %}</a>
-                 {% trans "to add comments" %}</p>
-            {% endif %}
-          </div>
+                            <li class="comment_li" id="c{{ comment.id|unlocalize }}">
+                                <div class="comment">
+                                    <div class="comment_info">
+                                        {% if comment.is_removed %}
+                                            <div class="comment_user deactive">[{% trans "Removed by Moderator" %}]</div>
+                                        {% else %}
+                                            <div class="comment_user">{{ comment.user_name }}</div>
+                                        {% endif %}
+                                        <div class="comment_data">
+                                            {{ comment.submit_date|date:"d M Y, H:i" }}
+                                            {% if request.user.is_authenticated and not comment.is_removed %}
+                                                | <a href="javascript:void(0);"  data-comment-id="{{ comment.id|unlocalize }}" class="comment_reply_link">Reply</a>
+                                                | <div data-class="comment-flag">{% include "otm_comments/partials/flagging.html" %}</div>
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                    <div class="comment_text">
+                                        {% if comment.is_removed %}
+                                            <div class="deactive">[{% trans "This comment has been removed by a moderator." %}]</div>
+                                        {% else %}
+                                            {{ comment.comment }}
+                                        {% endif %}
+                                    </div>
+                                </div>
+                                {% for close in comment.close %}</li></ul>{% endfor %}
+                            {% endfor %}
+                            {% if not request.user.is_authenticated %}
+                                <p><a href="{% url 'registration_register' %}">{% trans "Sign Up" %}</a>
+                                    {% trans "or" %} <a href="{% url 'auth_login' %}">{% trans "log in" %}</a>
+                                    {% trans "to add comments" %}</p>
+                            {% endif %}
+                        </div>
 
-          <div id="comment_disclaimer">
-            <p class="text-muted">
-              <em>
-                {% if feature.is_plot %}
-                {% trans "The comment system does not serve as a way to report problems with a tree." %}
-                {% else %}
-                {% blocktrans with resource=term.Resource.singular.lower %}
-                The comment system does not serve as a way to report problems with a {{ resource }}.
-                {% endblocktrans %}
-                {% endif %}
-              </em>
-            </p>
-          </div>
+                        <div id="comment_disclaimer">
+                            <p class="text-muted">
+                                <em>
+                                    {% if feature.is_plot %}
+                                        {% trans "The comment system does not serve as a way to report problems with a tree." %}
+                                    {% else %}
+                                        {% blocktrans with resource=term.Resource.singular.lower %}
+                                            The comment system does not serve as a way to report problems with a {{ resource }}.
+                                        {% endblocktrans %}
+                                    {% endif %}
+                                </em>
+                            </p>
+                        </div>
 
+                    </div>
+
+                    <!-- Maps -->
+                    <div class="col-md-4">
+                        <div id="map" class="map-small"
+                             data-has-boundaries="False"
+                             data-has-polygons="{{ has_polygons }}">
+                        </div>
+                        {% if feature.is_editable %}
+                            <button
+                                    disabled="disabled"
+                                    data-always-enable="{{ last_effective_instance_user|geom_is_writable:feature.feature_type }}"
+                                    data-disabled-title="{% trans "Editing location is not available to all users" %}"
+                                    data-href="{{ request.get_full_path }}"
+                                    style="display:none"
+                                    id="edit-location"
+                                    class="btn btn-block btn-sm btn-otmsecondary">{% trans "Move Location" %}</button>
+                            <button class="btn btn-block btn-sm btn-alert" style="display:none" id="cancel-edit-location">{% trans "Cancel Move Location" %}</button>
+                        {% endif %}
+                        <br>
+                        <div id="street-view" class="street-view-small" style="display: none;"></div>
+                    </div>
+                </div>
+            </div>
         </div>
-
-        <!-- Maps -->
-        <div class="col-md-4">
-          <div id="map" class="map-small"
-               data-has-boundaries="False"
-               data-has-polygons="{{ has_polygons }}">
-          </div>
-          {% if feature.is_editable %}
-          <button
-             disabled="disabled"
-             data-always-enable="{{ last_effective_instance_user|geom_is_writable:feature.feature_type }}"
-             data-disabled-title="{% trans "Editing location is not available to all users" %}"
-             data-href="{{ request.get_full_path }}"
-             style="display:none"
-             id="edit-location"
-             class="btn btn-block btn-sm btn-otmsecondary">{% trans "Move Location" %}</button>
-          <button class="btn btn-block btn-sm btn-alert" style="display:none" id="cancel-edit-location">{% trans "Cancel Move Location" %}</button>
-          {% endif %}
-          <br>
-          <div id="street-view" class="street-view-small" style="display: none;"></div>
-        </div>
-      </div>
     </div>
-  </div>
-</div>
 {% endblock content %}
 
 {% block scripts %}
-<script id="template-comment" type="template/underscore">
-  {% get_comment_form for feature as form %}
-  <form action="{% url 'comments-post-comment' %}" class="<%= classname %>" method="post">
-    {% csrf_token %}
-    {{ form.comment }}
-    <input style="display: none" id="id_honeypot" name="honeypot" type="text">
-    {{ form.content_type }}
-    {{ form.object_pk }}
-    {{ form.timestamp }}
-    {{ form.security_hash }}
-    <input type="hidden" name="parent" value="<%= parent %>">
+    <script id="template-comment" type="template/underscore">
+        {% get_comment_form for feature as form %}
+        <form action="{% url 'comments-post-comment' %}" class="<%= classname %>" method="post">
+            {% csrf_token %}
+            {{ form.comment }}
+            <input style="display: none" id="id_honeypot" name="honeypot" type="text">
+            {{ form.content_type }}
+            {{ form.object_pk }}
+            {{ form.timestamp }}
+            {{ form.security_hash }}
+            <input type="hidden" name="parent" value="<%= parent %>">
 
-    <input type="hidden" name="next" value="{{request.get_full_path}}" />
-    <input type="hidden" name="markup" value="5">
-    <div class="submit">
-      <input disabled="disabled" type="submit" name="post" class="submit-post btn btn-primary" value="Post" />
-    </div>
-  </form>
-</script>
-<script src="https://maps.googleapis.com/maps/api/js?key={{ settings.GOOGLE_MAPS_API_KEY }}"></script>
+            <input type="hidden" name="next" value="{{request.get_full_path}}" />
+            <input type="hidden" name="markup" value="5">
+            <div class="submit">
+                <input disabled="disabled" type="submit" name="post" class="submit-post btn btn-primary" value="Post" />
+            </div>
+        </form>
+    </script>
+    <script src="https://maps.googleapis.com/maps/api/js?key={{ settings.GOOGLE_MAPS_API_KEY }}"></script>
 
-<script>
-{% localize off %}
-// Define options for mapFeature.init(), which will be called in the
-// type-specific template inheriting from this one (e.g. plot_detail.html)
-// This global variable is later used in the JS entry module as a simple way to pass in static data
-window.otm.mapFeature = {
-    startInEditMode: {% if editmode %}true{% else %}false{% endif %},
-    isEditablePolygon: {% if feature.polygon and feature.is_editable %}true{% else %}false{% endif %},
-    featureId: {{ feature.pk }},
-    maxImageSize: {{ settings.MAXIMUM_IMAGE_SIZE }},
-    location: {
-        polygon: {{ feature.polygon|lat_lng_coordinates_json|safe }},
-        point: {
-            x: {{ feature.geom.x }},
-            y: {{ feature.geom.y }}
-        }
-    },
-};
-{% endlocalize %}
-</script>
+    <script>
+        {% localize off %}
+            // Define options for mapFeature.init(), which will be called in the
+            // type-specific template inheriting from this one (e.g. plot_detail.html)
+            // This global variable is later used in the JS entry module as a simple way to pass in static data
+            window.otm.mapFeature = {
+                startInEditMode: {% if editmode %}true{% else %}false{% endif %},
+                isEditablePolygon: {% if feature.polygon and feature.is_editable %}true{% else %}false{% endif %},
+                featureId: {{ feature.pk }},
+                maxImageSize: {{ settings.MAXIMUM_IMAGE_SIZE }},
+                location: {
+                    polygon: {{ feature.polygon|lat_lng_coordinates_json|safe }},
+                    point: {
+                        x: {{ feature.geom.x }},
+                        y: {{ feature.geom.y }}
+                    }
+                },
+            };
+        {% endlocalize %}
+    </script>
 {% endblock scripts %}

--- a/opentreemap/treemap/templates/treemap/partials/map_feature_detail_base.html
+++ b/opentreemap/treemap/templates/treemap/partials/map_feature_detail_base.html
@@ -1,0 +1,151 @@
+{% load threadedcomments_tags %}
+{% load instance_config %}
+{% load i18n %}
+{% load l10n %}
+{% load util %}
+
+<div class="detail-header">
+    {% if request.instance.is_public %}
+        <div class="js-container pull-right" style="display: none">
+            <a target="_blank" href="http://www.facebook.com/sharer/sharer.php?u={{ share.url }}">
+                <img src="/static/img/facebook_32.png">
+            </a>
+            <a target="_blank" href="http://twitter.com/share?url={{ share.url }}&text={{ share.title }}">
+                <img src="/static/img/twitter_32.png">
+            </a>
+            <a target="_blank" href="https://plus.google.com/share?url={{ share.url }}">
+                <img src="/static/img/googleplus_32.png">
+            </a>
+        </div>
+        <button class="btn share">Share</button>
+    {% endif %}
+    <h2 class="common-name" id="map-feature-title">
+        {{ title }}
+        <a id="favorite-link"
+           data-href="{{ request.get_full_path }}"
+           data-is-favorited="{{ favorited }}"
+           data-always-enable="{{ request.user.is_authenticated }}"
+           data-favorite-url="{% url 'favorite_map_feature' instance_url_name=request.instance.url_name feature_id=feature.pk %}"
+           data-unfavorite-url="{% url 'unfavorite_map_feature' instance_url_name=request.instance.url_name feature_id=feature.pk %}">
+            {% if favorited %}
+                <i id="favorite-star" class="icon-star"></i>
+            {% else %}
+                <i id="favorite-star" class="icon-star-empty"></i>
+            {% endif %}
+        </a>
+    </h2>
+    <h4 class="address" id="map-feature-address">{{ feature.address_full }}</h4>
+</div>
+<div class="col-md-8">
+    <p>
+        {% if feature.is_plot or feature.is_editable %}
+            <button id="edit-map-feature"
+                    data-class="display"
+                    disabled="disabled"
+                    data-always-enable="{{ last_effective_instance_user|map_feature_is_writable:feature }}"
+                    data-href="{{ request.get_full_path }}"
+                    {% if feature.is_plot %}
+                    data-disabled-title="{% trans "Editing of the tree details is not available to all users" %}"
+                    {% else %}
+                        {# TODO: what kind of text do want to put here? Do we want to put this on the model? #}
+                    data-disabled-title="{% trans "Editing of the resource's details is not available to all users" %}"
+                    {% endif %}
+                    class="btn btn-sm btn-info">{% trans "Edit" %}</button>
+            <button id="save-edit-map-feature" data-class="edit" class="btn btn-sm btn-primary" style="display: none;">{% trans "Save" %}</button>
+            <button id="cancel-edit-map-feature" data-class="edit" class="btn btn-sm" style="display: none;">{% trans "Cancel" %}</button>
+        {% endif %}
+        <button id="delete-object"
+                data-class="display"
+                disabled="disabled"
+                {% if has_tree %}
+                    {# TODO: this will not work quite right when a user adds a tree without refreshing #}
+                data-always-enable="{{ last_effective_instance_user|is_deletable:tree }}"
+                data-disabled-title="{% trans "Deleting of trees is not available to all users" %}"
+                {% else %}
+                data-always-enable="{{ last_effective_instance_user|is_deletable:feature }}"
+                    {% if feature.is_plot %}
+                data-disabled-title="{% trans "Deleting of planting sites is not available to all users" %}"
+                    {% else %}
+                data-disabled-title="{% blocktrans with resources=term.Resource.plural.lower %}Deleting of {{ resources }} is not available to all users{% endblocktrans %}"
+                    {% endif %}
+                {% endif %}
+                data-href="{{ request.get_full_path }}"
+                class="btn btn-sm btn-danger">{% trans "Delete" %}</button>
+    </p>
+
+    <!-- Alerts -->
+    <div id="delete-confirmation-box" data-class="delete" class="alert alert-danger" style="display: none;">
+        {% block delete_confirmation_text %}
+        {% endblock %}
+        <button id="delete-confirm" class="btn btm-small btn-danger">{% trans "Confirm Deletion" %}</button>
+        <button id="delete-cancel" class="btn btm-small">{% trans "Cancel" %}</button>
+    </div>
+    <hr>
+
+    <!-- Map Feature Details -->
+    <form id="map-feature-form">
+
+        {# There isn't a field to show "inline" errors for geom fields, so just show it up top #}
+        <div class="alert alert-warning" data-class="error" data-field="mapFeature.geom" style="display: none;"></div>
+        {% block subclass_details %}
+        {% endblock subclass_details %}
+
+    </form>
+
+    <!-- Commenting -->
+    <h3>{% trans "Comments" %}</h3>
+    <div id="comments-container">
+        {% get_comment_list for feature as comments %}
+        {% for comment in comments|fill_tree|annotate_tree %}
+            {% ifchanged comment.parent_id %}{% else %}</li>{% endifchanged %}
+            {% if not comment.open and not comment.close %}</li>{% endif %}
+            {% if comment.open %}<ul>{% endif %}
+
+        <li class="comment_li" id="c{{ comment.id|unlocalize }}">
+            <div class="comment">
+                <div class="comment_info">
+                    {% if comment.is_removed %}
+                        <div class="comment_user deactive">[{% trans "Removed by Moderator" %}]</div>
+                    {% else %}
+                        <div class="comment_user">{{ comment.user_name }}</div>
+                    {% endif %}
+                    <div class="comment_data">
+                        {{ comment.submit_date|date:"d M Y, H:i" }}
+                        {% if request.user.is_authenticated and not comment.is_removed %}
+                            | <a href="javascript:void(0);"  data-comment-id="{{ comment.id|unlocalize }}" class="comment_reply_link">Reply</a>
+                            | <div data-class="comment-flag">{% include "otm_comments/partials/flagging.html" %}</div>
+                        {% endif %}
+                    </div>
+                </div>
+                <div class="comment_text">
+                    {% if comment.is_removed %}
+                        <div class="deactive">[{% trans "This comment has been removed by a moderator." %}]</div>
+                    {% else %}
+                        {{ comment.comment }}
+                    {% endif %}
+                </div>
+            </div>
+            {% for close in comment.close %}</li></ul>{% endfor %}
+        {% endfor %}
+        {% if not request.user.is_authenticated %}
+            <p><a href="{% url 'registration_register' %}">{% trans "Sign Up" %}</a>
+                {% trans "or" %} <a href="{% url 'auth_login' %}">{% trans "log in" %}</a>
+                {% trans "to add comments" %}</p>
+        {% endif %}
+    </div>
+
+    <div id="comment_disclaimer">
+        <p class="text-muted">
+            <em>
+                {% if feature.is_plot %}
+                    {% trans "The comment system does not serve as a way to report problems with a tree." %}
+                {% else %}
+                    {% blocktrans with resource=term.Resource.singular.lower %}
+                        The comment system does not serve as a way to report problems with a {{ resource }}.
+                    {% endblocktrans %}
+                {% endif %}
+            </em>
+        </p>
+    </div>
+
+</div>

--- a/opentreemap/treemap/templates/treemap/partials/map_feature_detail_base.html
+++ b/opentreemap/treemap/templates/treemap/partials/map_feature_detail_base.html
@@ -3,6 +3,7 @@
 {% load i18n %}
 {% load l10n %}
 {% load util %}
+{% load staticfiles %}
 
 <div class="detail-header">
     {% if request.instance.is_public %}
@@ -71,6 +72,7 @@
                 {% endif %}
                 data-href="{{ request.get_full_path }}"
                 class="btn btn-sm btn-danger">{% trans "Delete" %}</button>
+        <img class="spinner" src="{% static "img/spinner.gif" %}" style="display: none;">
     </p>
 
     <!-- Alerts -->

--- a/opentreemap/treemap/templates/treemap/partials/plot_detail.html
+++ b/opentreemap/treemap/templates/treemap/partials/plot_detail.html
@@ -1,13 +1,10 @@
-{% extends "treemap/map_feature_detail.html" %}
-{% load render_bundle from webpack_loader %}
+{% extends "treemap/partials/map_feature_detail_base.html" %}
 {% load i18n %}
 {% load l10n %}
 {% load auth_extras %}
 {% load form_extras %}
 {% load udf %}
 {% load util %}
-
-{% block page_title %} | {% trans "Planting Site" %} {{plot.pk}}{% endblock %}
 
 {% block subclass_details %}
 
@@ -135,20 +132,3 @@
         {% trans "You are about to delete this planting site. Once deleted, it will not be possible to view the details of this planting site or the trees it has contained in the past. Are you sure you want to continue?" %}
     </p>
 {% endblock %}
-
-
-{% block scripts %}
-
-    {{ block.super }}
-
-    <script>
-        {% localize off %}
-            // mapFeature is defined in a script block of the super-template
-            window.otm.mapFeature.useTreeIcon = true;
-            window.otm.mapFeature.plotId = {{ plot.id }};
-            Object.freeze(window.otm.mapFeature);
-        {% endlocalize %}
-    </script>
-    {% render_bundle 'js/treemap/plot' %}
-
-{% endblock scripts %}

--- a/opentreemap/treemap/templates/treemap/partials/plot_detail.html
+++ b/opentreemap/treemap/templates/treemap/partials/plot_detail.html
@@ -123,12 +123,12 @@
 {% endblock subclass_details %}
 
 {% block delete_confirmation_text %}
-    <p id="delete-tree-warning" style="display: none;">
+    <p>
         <strong>{% trans "Warning!" %}</strong>
-        {% trans "You are about to delete this tree. Do you want to continue?" %}
-    </p>
-    <p id="delete-plot-warning" style="display: none;">
-        <strong>{% trans "Warning!" %}</strong>
-        {% trans "You are about to delete this planting site. Once deleted, it will not be possible to view the details of this planting site or the trees it has contained in the past. Are you sure you want to continue?" %}
+        {% if has_tree %}
+            {% trans "You are about to delete this tree. Do you want to continue?" %}
+        {% else %}
+            {% trans "You are about to delete this planting site. Once deleted, it will not be possible to view the details of this planting site or the trees it has contained in the past. Are you sure you want to continue?" %}
+        {% endif %}
     </p>
 {% endblock %}

--- a/opentreemap/treemap/templates/treemap/partials/resource_detail.html
+++ b/opentreemap/treemap/templates/treemap/partials/resource_detail.html
@@ -1,13 +1,10 @@
-{% extends "treemap/map_feature_detail.html" %}
-{% load render_bundle from webpack_loader %}
+{% extends "treemap/partials/map_feature_detail_base.html" %}
 {% load i18n %}
 {% load l10n %}
 {% load auth_extras %}
 {% load form_extras %}
 {% load udf %}
 {% load util %}
-
-{% block page_title %} | {{ feature.terminology.singular }} {{ feature.pk }}{% endblock %}
 
 {% block subclass_details %}
 
@@ -107,19 +104,3 @@
         {% endblocktrans %}
     </p>
 {% endblock delete_confirmation_text %}
-
-{% block scripts %}
-
-    {{ block.super }}
-
-    <script>
-        {% localize off %}
-            // mapFeature is defined in a script block of the super-template
-            window.otm.mapFeature.useTreeIcon = false;
-            window.otm.mapFeature.resourceType = "{{ feature.map_feature_type|to_object_name }}";
-            Object.freeze(window.otm.mapFeature);
-            </script>
-            {% render_bundle 'js/treemap/resource' %}
-        {% endlocalize %}
-
-{% endblock scripts %}

--- a/opentreemap/treemap/templates/treemap/plot_detail.html
+++ b/opentreemap/treemap/templates/treemap/plot_detail.html
@@ -11,144 +11,144 @@
 
 {% block subclass_details %}
 
-<h3>{% trans "Tree Information" %}</h3>
+    <h3>{% trans "Tree Information" %}</h3>
 
-<!-- Add a Tree Section -->
-{% include "treemap/partials/plot_detail_add_tree.html" %}
+    <!-- Add a Tree Section -->
+    {% include "treemap/partials/plot_detail_add_tree.html" %}
 
 
-<!-- Tree Information -->
-<div id="tree-details" {{ has_tree|yesno:",style=display:none;" }}>
-  <table class="table table-hover">
-    <tbody>
-      {% usercanread tree "id" as value %}
-      <tr>
-        <td>{% trans "Tree Number" %}</td>
-        <td id="tree-id-column"
-            data-tree-id="{% if has_tree %}{{ value|unlocalize }}{% endif %}">
-        {% if has_tree %}
-          <a href="{% url 'tree_detail' instance_url_name=request.instance.url_name feature_id=plot.pk tree_id=tree.pk %}">{{ value|unlocalize }}</a>
+    <!-- Tree Information -->
+    <div id="tree-details" {{ has_tree|yesno:",style=display:none;" }}>
+        <table class="table table-hover">
+            <tbody>
+            {% usercanread tree "id" as value %}
+                <tr>
+                    <td>{% trans "Tree Number" %}</td>
+                    <td id="tree-id-column"
+                        data-tree-id="{% if has_tree %}{{ value|unlocalize }}{% endif %}">
+                        {% if has_tree %}
+                            <a href="{% url 'tree_detail' instance_url_name=request.instance.url_name feature_id=plot.pk tree_id=tree.pk %}">{{ value|unlocalize }}</a>
+                        {% endif %}
+                    </td>
+                </tr>
+            {% endusercanread %}
+            {# The "plot-species" label is used as an id prefix in "field/species_tr.html" #}
+            {% field "plot-species" from "tree.species" for request.user withtemplate "treemap/field/species_tr.html" %}
+            {% trans "Trunk Diameter" as diameter %}
+            {% field diameter from "tree.diameter" for request.user withtemplate "treemap/field/diameter_tr.html" %}
+            {% trans "Tree Height" as height %}
+            {% field height from "tree.height" for request.user withtemplate "treemap/field/tr.html" %}
+            {% trans "Canopy Height" as canopy %}
+            {% field canopy from "tree.canopy_height" for request.user withtemplate "treemap/field/tr.html" %}
+            {% trans "Date Planted" as planted %}
+            {% field planted from "tree.date_planted" for request.user withtemplate "treemap/field/tr.html" %}
+            {% trans "Date Removed" as removed %}
+            {% field removed from "tree.date_removed" for request.user withtemplate "treemap/field/tr.html" %}
+            {% for label, udf in tree.scalar_udf_names_and_fields %}
+                {% field label from udf for request.user withtemplate "treemap/field/tr.html" %}
+            {% endfor %}
+            </tbody>
+        </table>
+
+        {% if not containing_polygonalmapfeature %}
+            {# Render collection UDF fields for the Tree #}
+            {% if tree %}
+                {% for udf in tree.collection_udfs %}
+                    {% with values=tree.udfs|get:udf.name title_prefix=udf.model_type|display_name %}
+                        {% include "treemap/partials/collectionudf.html" with udf=udf title_prefix=title_prefix model=tree values=values %}
+                    {% endwith %}
+                {% endfor %}
+            {% endif %}
         {% endif %}
-        </td>
-      </tr>
-      {% endusercanread %}
-      {# The "plot-species" label is used as an id prefix in "field/species_tr.html" #}
-      {% field "plot-species" from "tree.species" for request.user withtemplate "treemap/field/species_tr.html" %}
-      {% trans "Trunk Diameter" as diameter %}
-      {% field diameter from "tree.diameter" for request.user withtemplate "treemap/field/diameter_tr.html" %}
-      {% trans "Tree Height" as height %}
-      {% field height from "tree.height" for request.user withtemplate "treemap/field/tr.html" %}
-      {% trans "Canopy Height" as canopy %}
-      {% field canopy from "tree.canopy_height" for request.user withtemplate "treemap/field/tr.html" %}
-      {% trans "Date Planted" as planted %}
-      {% field planted from "tree.date_planted" for request.user withtemplate "treemap/field/tr.html" %}
-      {% trans "Date Removed" as removed %}
-      {% field removed from "tree.date_removed" for request.user withtemplate "treemap/field/tr.html" %}
-      {% for label, udf in tree.scalar_udf_names_and_fields %}
-        {% field label from udf for request.user withtemplate "treemap/field/tr.html" %}
-      {% endfor %}
-    </tbody>
-  </table>
+    </div>
 
-  {% if not containing_polygonalmapfeature %}
-  {# Render collection UDF fields for the Tree #}
-  {% if tree %}
-    {% for udf in tree.collection_udfs %}
-      {% with values=tree.udfs|get:udf.name title_prefix=udf.model_type|display_name %}
-          {% include "treemap/partials/collectionudf.html" with udf=udf title_prefix=title_prefix model=tree values=values %}
-        {% endwith %}
-    {% endfor %}
-  {% endif %}
-  {% endif %}
-</div>
+    <h3>{% trans "Planting Site Information" %}</h3>
+    {% if containing_polygonalmapfeature %}
+        <div class="well" id="containing-polygonalmapfeature">
+            {% with pmf_id=containing_polygonalmapfeature.pk|unlocalize %}
+                {% url 'map_feature_detail' instance_url_name=request.instance.url_name feature_id=pmf_id as polygonal_url %}
+                {% blocktrans with display_name=containing_polygonalmapfeature.terminology.singular %}
+                    This tree is part of <a href="{{ polygonal_url }}">{{ display_name }} #{{ pmf_id }}.</a> For stewardship actions, please <a href="{{ polygonal_url }}">go to the {{ display_name }} detail page.</a>
+                {% endblocktrans %}
+            {% endwith %}
+        </div>
+    {% else %}
+        <table class="table table-hover">
+            <tbody>
+            {% trans "Width" as width %}
+            {% field width from "plot.width" for request.user withtemplate "treemap/field/tr.html" %}
+            {% trans "Length" as len %}
+            {% field len from "plot.length" for request.user withtemplate "treemap/field/tr.html" %}
+            {% trans "Address" as street %}
+            {% field street from "plot.address_street" for request.user withtemplate "treemap/field/tr.html" %}
+            {% trans "City" as city %}
+            {% field city from "plot.address_city" for request.user withtemplate "treemap/field/tr.html" %}
+            {% trans "Postal Code" as zip %}
+            {% field zip from "plot.address_zip" for request.user withtemplate "treemap/field/tr.html" %}
+            {% trans "Original Owner Id" as oid %}
+            {% field oid from "plot.owner_orig_id" for request.user withtemplate "treemap/field/tr.html" %}
+            <!-- Hiding readonly field temporarily -->
+            <!-- See github #379 and #772 for more details -->
+            <!-- {% trans "Read Only" as readonly %} -->
+            <!-- {% field readonly from "plot.readonly" for request.user withtemplate "treemap/field/tr.html" with extra='style="display:none"' %} -->
+            {% for label, udf in plot.scalar_udf_names_and_fields %}
+                {% field label from udf for request.user withtemplate "treemap/field/tr.html" %}
+            {% endfor %}
+            </tbody>
+        </table>
 
-<h3>{% trans "Planting Site Information" %}</h3>
-{% if containing_polygonalmapfeature %}
-<div class="well" id="containing-polygonalmapfeature">
-  {% with pmf_id=containing_polygonalmapfeature.pk|unlocalize %}
-  {% url 'map_feature_detail' instance_url_name=request.instance.url_name feature_id=pmf_id as polygonal_url %}
-  {% blocktrans with display_name=containing_polygonalmapfeature.terminology.singular %}
-  This tree is part of <a href="{{ polygonal_url }}">{{ display_name }} #{{ pmf_id }}.</a> For stewardship actions, please <a href="{{ polygonal_url }}">go to the {{ display_name }} detail page.</a>
-  {% endblocktrans %}
-  {% endwith %}
-</div>
-{% else %}
-<table class="table table-hover">
-  <tbody>
-    {% trans "Width" as width %}
-    {% field width from "plot.width" for request.user withtemplate "treemap/field/tr.html" %}
-    {% trans "Length" as len %}
-    {% field len from "plot.length" for request.user withtemplate "treemap/field/tr.html" %}
-    {% trans "Address" as street %}
-    {% field street from "plot.address_street" for request.user withtemplate "treemap/field/tr.html" %}
-    {% trans "City" as city %}
-    {% field city from "plot.address_city" for request.user withtemplate "treemap/field/tr.html" %}
-    {% trans "Postal Code" as zip %}
-    {% field zip from "plot.address_zip" for request.user withtemplate "treemap/field/tr.html" %}
-    {% trans "Original Owner Id" as oid %}
-    {% field oid from "plot.owner_orig_id" for request.user withtemplate "treemap/field/tr.html" %}
-    <!-- Hiding readonly field temporarily -->
-    <!-- See github #379 and #772 for more details -->
-    <!-- {% trans "Read Only" as readonly %} -->
-    <!-- {% field readonly from "plot.readonly" for request.user withtemplate "treemap/field/tr.html" with extra='style="display:none"' %} -->
-    {% for label, udf in plot.scalar_udf_names_and_fields %}
-      {% field label from udf for request.user withtemplate "treemap/field/tr.html" %}
-    {% endfor %}
-  </tbody>
-</table>
+        {# Render collection UDF fields for the Plot  #}
+        {% for udf in plot.collection_udfs %}
+            {% with values=plot.udfs|get:udf.name title_prefix=udf.model_type|display_name %}
+                {% include "treemap/partials/collectionudf.html" with udf=udf title_prefix=title_prefix model=plot values=values %}
+            {% endwith %}
+        {% endfor %}
 
-{# Render collection UDF fields for the Plot  #}
-{% for udf in plot.collection_udfs %}
-  {% with values=plot.udfs|get:udf.name title_prefix=udf.model_type|display_name %}
-    {% include "treemap/partials/collectionudf.html" with udf=udf title_prefix=title_prefix model=plot values=values %}
-  {% endwith %}
-{% endfor %}
+    {% endif %}
 
-{% endif %}
-
-<!-- Ecosystem Benefits -->
-<div id="ecobenefits">
-<h3>{% trans "Yearly Ecosystem Services" %}</h3>
-{% if request.instance_supports_ecobenefits %}
-  {% include "treemap/partials/plot_eco.html" %}
-{% else %}
-  <div class="alert alert-info">
-    <p>
-      {% blocktrans %}
-      Ecosystem benefits are not available for tree maps in locations outside the
-      United States. More info is available on the <a href="https://opentreemap.org/faq/#03">OpenTreeMap FAQ page.</a>
-      {% endblocktrans %}
-    </p>
-  </div>
-{% endif %}
-</div>
+    <!-- Ecosystem Benefits -->
+    <div id="ecobenefits">
+        <h3>{% trans "Yearly Ecosystem Services" %}</h3>
+        {% if request.instance_supports_ecobenefits %}
+            {% include "treemap/partials/plot_eco.html" %}
+        {% else %}
+            <div class="alert alert-info">
+                <p>
+                    {% blocktrans %}
+                        Ecosystem benefits are not available for tree maps in locations outside the
+                        United States. More info is available on the <a href="https://opentreemap.org/faq/#03">OpenTreeMap FAQ page.</a>
+                    {% endblocktrans %}
+                </p>
+            </div>
+        {% endif %}
+    </div>
 
 {% endblock subclass_details %}
 
 {% block delete_confirmation_text %}
-<p id="delete-tree-warning" style="display: none;">
-  <strong>{% trans "Warning!" %}</strong>
-  {% trans "You are about to delete this tree. Do you want to continue?" %}
-</p>
-<p id="delete-plot-warning" style="display: none;">
-  <strong>{% trans "Warning!" %}</strong>
-  {% trans "You are about to delete this planting site. Once deleted, it will not be possible to view the details of this planting site or the trees it has contained in the past. Are you sure you want to continue?" %}
-</p>
+    <p id="delete-tree-warning" style="display: none;">
+        <strong>{% trans "Warning!" %}</strong>
+        {% trans "You are about to delete this tree. Do you want to continue?" %}
+    </p>
+    <p id="delete-plot-warning" style="display: none;">
+        <strong>{% trans "Warning!" %}</strong>
+        {% trans "You are about to delete this planting site. Once deleted, it will not be possible to view the details of this planting site or the trees it has contained in the past. Are you sure you want to continue?" %}
+    </p>
 {% endblock %}
 
 
 {% block scripts %}
 
-{{ block.super }}
+    {{ block.super }}
 
-<script>
-{% localize off %}
-// mapFeature is defined in a script block of the super-template
-window.otm.mapFeature.useTreeIcon = true;
-window.otm.mapFeature.plotId = {{ plot.id }};
-Object.freeze(window.otm.mapFeature);
-{% endlocalize %}
-</script>
-{% render_bundle 'js/treemap/plot' %}
+    <script>
+        {% localize off %}
+            // mapFeature is defined in a script block of the super-template
+            window.otm.mapFeature.useTreeIcon = true;
+            window.otm.mapFeature.plotId = {{ plot.id }};
+            Object.freeze(window.otm.mapFeature);
+        {% endlocalize %}
+    </script>
+    {% render_bundle 'js/treemap/plot' %}
 
 {% endblock scripts %}

--- a/opentreemap/treemap/templates/treemap/resource_detail.html
+++ b/opentreemap/treemap/templates/treemap/resource_detail.html
@@ -11,115 +11,115 @@
 
 {% block subclass_details %}
 
-<h3>{{ term.Resource.singular }} {% trans "Information" %}</h3>
+    <h3>{{ term.Resource.singular }} {% trans "Information" %}</h3>
 
-<table class="table table-hover">
-    <tbody>
-    <tr>
-        <td>{{ term.Resource.singular }} {% trans "number" %}</td>
-        <td>{{ feature.pk|unlocalize }}</td>
-    </tr>
-
-    {% if area %}
-    <tr>
-        <td>{% trans "Area" %}</td>
-        <td>{{ area }}</td>
-    </tr>
-    {% endif %}
-
-    {% block resource_details %}
-    {% endblock resource_details %}
-
-    {% for label, udf in feature.scalar_udf_names_and_fields %}
-        {% field label from udf for request.user withtemplate "treemap/field/tr.html" %}
-    {% endfor %}
-    </tbody>
-</table>
-
-{% for udf in feature.collection_udfs %}
-    {% with values=feature.udfs|get:udf.name %}
-        {% include "treemap/partials/collectionudf.html" with udf=udf model=feature values=values %}
-    {% endwith %}
-{% endfor %}
-
-<!-- Ecosystem Benefits -->
-{% with stormbenefits=benefits.resource %}
-{% if stormbenefits %}
-    <div id="ecobenefits">
-        <h3>{{ term.Resource.singular }} {% trans "Ecosystem Services" %}</h3>
-        <table class="table table-hover">
-            <tbody>
-            {% for key, benefit in stormbenefits.items %}
-            <tr>
-                <td>{{ benefit.label }}</td>
-                <td>{{ benefit.value }} {{ benefit.unit}}</td>
-                <td>{{ benefit.currency_saved }}</td>
-            </tr>
-            {% endfor %}
-            </tbody>
-        </table>
-    </div>
-{% endif %}
-{% endwith %}
-
-{% if feature.area_field_name %}
-<h3>{% trans "Associated Trees" %}</h3>
-{% with plots=contained_plots %}
-{% if plots %}
-    <table class="table table-hover" id="contained-plots">
+    <table class="table table-hover">
         <tbody>
-        {% for plot in plots %}
         <tr>
-            <td>
-                <a href="{% url 'map_feature_detail' instance_url_name=request.instance.url_name feature_id=plot.pk %}">
-                {% with tree=plot.current_tree %}
-                {% if plot.current_tree %}
-                    {{ plot.title }}
-                    {% field from "tree.diameter" for request.user withtemplate "treemap/field/resource_tree.html" %}
-                {% else %}
-                    {{ plot.title }}
-                {% endif %}
-                {% endwith %}
-                </a>
-            </td>
+            <td>{{ term.Resource.singular }} {% trans "number" %}</td>
+            <td>{{ feature.pk|unlocalize }}</td>
         </tr>
+
+        {% if area %}
+            <tr>
+                <td>{% trans "Area" %}</td>
+                <td>{{ area }}</td>
+            </tr>
+        {% endif %}
+
+        {% block resource_details %}
+        {% endblock resource_details %}
+
+        {% for label, udf in feature.scalar_udf_names_and_fields %}
+            {% field label from udf for request.user withtemplate "treemap/field/tr.html" %}
         {% endfor %}
         </tbody>
     </table>
-{% else %}
-    <div class="well">
-    {% blocktrans with resource=term.Resource.singular %}
-        This {{ resource }} does not contain any trees.
-    {% endblocktrans %}
-    </div>
-{% endif %}
-{% endwith %}
-{% endif %}
+
+    {% for udf in feature.collection_udfs %}
+        {% with values=feature.udfs|get:udf.name %}
+            {% include "treemap/partials/collectionudf.html" with udf=udf model=feature values=values %}
+        {% endwith %}
+    {% endfor %}
+
+    <!-- Ecosystem Benefits -->
+    {% with stormbenefits=benefits.resource %}
+        {% if stormbenefits %}
+            <div id="ecobenefits">
+                <h3>{{ term.Resource.singular }} {% trans "Ecosystem Services" %}</h3>
+                <table class="table table-hover">
+                    <tbody>
+                    {% for key, benefit in stormbenefits.items %}
+                        <tr>
+                            <td>{{ benefit.label }}</td>
+                            <td>{{ benefit.value }} {{ benefit.unit}}</td>
+                            <td>{{ benefit.currency_saved }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% endif %}
+    {% endwith %}
+
+    {% if feature.area_field_name %}
+        <h3>{% trans "Associated Trees" %}</h3>
+        {% with plots=contained_plots %}
+            {% if plots %}
+                <table class="table table-hover" id="contained-plots">
+                    <tbody>
+                    {% for plot in plots %}
+                        <tr>
+                            <td>
+                                <a href="{% url 'map_feature_detail' instance_url_name=request.instance.url_name feature_id=plot.pk %}">
+                                    {% with tree=plot.current_tree %}
+                                        {% if plot.current_tree %}
+                                            {{ plot.title }}
+                                            {% field from "tree.diameter" for request.user withtemplate "treemap/field/resource_tree.html" %}
+                                        {% else %}
+                                            {{ plot.title }}
+                                        {% endif %}
+                                    {% endwith %}
+                                </a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            {% else %}
+                <div class="well">
+                    {% blocktrans with resource=term.Resource.singular %}
+                        This {{ resource }} does not contain any trees.
+                    {% endblocktrans %}
+                </div>
+            {% endif %}
+        {% endwith %}
+    {% endif %}
 
 {% endblock subclass_details %}
 
 
 {% block delete_confirmation_text %}
-<p>
-    <strong>{% trans "Warning!" %}</strong>
-    {% blocktrans with resource=term.Resource.singular.lower %}
-    You are about to delete this {{ resource }}. Do you want to continue?
-    {% endblocktrans %}
-</p>
+    <p>
+        <strong>{% trans "Warning!" %}</strong>
+        {% blocktrans with resource=term.Resource.singular.lower %}
+            You are about to delete this {{ resource }}. Do you want to continue?
+        {% endblocktrans %}
+    </p>
 {% endblock delete_confirmation_text %}
 
 {% block scripts %}
 
-{{ block.super }}
+    {{ block.super }}
 
-<script>
-{% localize off %}
-// mapFeature is defined in a script block of the super-template
-window.otm.mapFeature.useTreeIcon = false;
-window.otm.mapFeature.resourceType = "{{ feature.map_feature_type|to_object_name }}";
-Object.freeze(window.otm.mapFeature);
-</script>
-{% render_bundle 'js/treemap/resource' %}
-{% endlocalize %}
+    <script>
+        {% localize off %}
+            // mapFeature is defined in a script block of the super-template
+            window.otm.mapFeature.useTreeIcon = false;
+            window.otm.mapFeature.resourceType = "{{ feature.map_feature_type|to_object_name }}";
+            Object.freeze(window.otm.mapFeature);
+            </script>
+            {% render_bundle 'js/treemap/resource' %}
+        {% endlocalize %}
 
 {% endblock scripts %}

--- a/opentreemap/treemap/tests/test_urls.py
+++ b/opentreemap/treemap/tests/test_urls.py
@@ -189,7 +189,7 @@ class TreemapUrlTests(UrlTestCase):
     def test_plot_detail(self):
         plot = self.make_plot()
         url = self.prefix + 'features/%s/' % plot.id
-        self.assert_template(url, 'treemap/plot_detail.html')
+        self.assert_template(url, 'treemap/partials/plot_detail.html')
         self.assert_template(url, 'treemap/map_feature_detail.html')
 
     def test_plot_detail_invalid(self):
@@ -218,7 +218,7 @@ class TreemapUrlTests(UrlTestCase):
     def test_map_feature_accordion(self):
         plot = self.make_plot()
         self.assert_template(
-            self.prefix + 'features/%s/detail' % plot.id,
+            self.prefix + 'features/%s/accordion' % plot.id,
             'treemap/partials/map_feature_accordion.html')
 
     def test_map_feature_accordion_invalid(self):

--- a/opentreemap/treemap/tests/ui/__init__.py
+++ b/opentreemap/treemap/tests/ui/__init__.py
@@ -114,7 +114,7 @@ class UITestCase(StaticLiveServerTestCase):
 
         def is_present(driver):
             element[0] = self.find(selector)
-            return element[0] is not None
+            return element[0] is not None and element[0].is_displayed()
 
         WebDriverWait(self.driver, timeout).until(is_present)
         return element[0]

--- a/opentreemap/treemap/tests/ui/plot_detail/uitest_add.py
+++ b/opentreemap/treemap/tests/ui/plot_detail/uitest_add.py
@@ -68,7 +68,7 @@ class PlotAddTest(PlotDetailUITestCase):
         self.begin_add_tree.click()
         self.find('input[name="tree.height"]').send_keys('11')
         self.save_edit.click()
-        self.wait_until_visible(self.edit_plot)
+        self.wait_until_present('#edit-map-feature')
         self.assertEqual(Tree.objects.filter(plot=self.plot).count(), 1)
 
         self.assertEqual(self.find_id('map-feature-title').text,

--- a/opentreemap/treemap/tests/ui/plot_detail/uitest_delete.py
+++ b/opentreemap/treemap/tests/ui/plot_detail/uitest_delete.py
@@ -19,7 +19,7 @@ class PlotEditDeleteTest(PlotDetailDeleteUITestCase):
         self.diameter_input.clear()
         self.diameter_input.send_keys('11')
         self.save_edit.click()
-        self.wait_until_visible(self.edit_plot)
+        self.wait_until_present('#edit-map-feature')
 
         self.assertEqual(Tree.objects.count(), 1)
 

--- a/opentreemap/treemap/tests/ui/plot_detail/uitest_edit.py
+++ b/opentreemap/treemap/tests/ui/plot_detail/uitest_edit.py
@@ -14,7 +14,7 @@ class PlotEditTest(PlotDetailUITestCase):
         self._select_elements()
         self.edit_plot.click()
         self.save_edit.click()
-        self.wait_until_visible(self.edit_plot)
+        self.wait_until_present('#edit-map-feature')
         self.assertEqual(Tree.objects.count(), 0)
 
     def test_edit_empty_plot_from_map(self):
@@ -36,7 +36,7 @@ class PlotEditTest(PlotDetailUITestCase):
         plot_width_field.send_keys('5')
 
         self.click('#save-edit-map-feature')
-        self.wait_until_visible('#edit-map-feature')
+        self.wait_until_present('#edit-map-feature')
 
         plot = Plot.objects.get(pk=plot.pk)
 

--- a/opentreemap/treemap/urls.py
+++ b/opentreemap/treemap/urls.py
@@ -42,7 +42,7 @@ urlpatterns = patterns(
         routes.map_feature_popup, name='map_feature_popup'),
     url(r'^/canopy-popup$', routes.canopy_popup, name='canopy_popup'),
     url(r'^features/(?P<feature_id>\d+)/trees/(?P<tree_id>\d+)/$',
-        routes.delete_tree),
+        routes.delete_tree, name='delete_tree'),
     url(r'^features/(?P<feature_id>\d+)/sidebar$',
         routes.get_map_feature_sidebar, name='map_feature_sidebar'),
     url(r'^features/(?P<feature_id>\d+)/photo$',

--- a/opentreemap/treemap/urls.py
+++ b/opentreemap/treemap/urls.py
@@ -32,6 +32,8 @@ urlpatterns = patterns(
 
     url(r'^features/(?P<feature_id>\d+)/$',
         routes.map_feature_detail, name='map_feature_detail'),
+    url(r'^features/(?P<feature_id>\d+)/detail$',
+        routes.map_feature_detail_partial, name='map_feature_detail_partial'),
     url(r'^features/(?P<type>\w+)/$',
         routes.add_map_feature, name='add_map_feature'),
     url(r'^features/(?P<feature_id>\d+)/(?P<edit>edit)$',
@@ -45,7 +47,7 @@ urlpatterns = patterns(
         routes.get_map_feature_sidebar, name='map_feature_sidebar'),
     url(r'^features/(?P<feature_id>\d+)/photo$',
         routes.add_map_feature_photo, name='add_photo_to_map_feature'),
-    url(r'^features/(?P<feature_id>\d+)/detail$',
+    url(r'^features/(?P<feature_id>\d+)/accordion$',
         routes.map_feature_accordion, name='map_feature_accordion'),
     url('^features/(?P<feature_id>\d+)/photo/(?P<photo_id>\d+)/detail$',
         routes.map_feature_photo_detail, name='map_feature_photo_detail'),
@@ -57,10 +59,6 @@ urlpatterns = patterns(
         routes.unfavorite_map_feature, name='unfavorite_map_feature'),
 
     url(r'^plots/$', routes.add_map_feature, name='add_plot'),
-    url(r'^plots/(?P<feature_id>\d+)/eco$',
-        routes.get_plot_eco, name='plot_eco'),
-    url(r'^plots/(?P<feature_id>\d+)/trees/(?P<tree_id>\d+)/eco$',
-        routes.get_plot_eco, name='tree_eco'),
     url(r'^plots/(?P<feature_id>\d+)/trees/(?P<tree_id>\d+)/$',
         routes.tree_detail, name='tree_detail'),
 

--- a/opentreemap/treemap/views/map_feature.py
+++ b/opentreemap/treemap/views/map_feature.py
@@ -8,7 +8,7 @@ import hashlib
 from functools import wraps
 
 from django.http import HttpResponse
-from django.template import RequestContext, TemplateDoesNotExist
+from django.template import RequestContext
 from django.template.loader import get_template
 from django.shortcuts import get_object_or_404, render_to_response
 from django.core.exceptions import ValidationError
@@ -88,17 +88,14 @@ def map_feature_detail(request, instance, feature_id,
     add_map_info_to_context(context, instance)
 
     if render:
+        template = 'treemap/map_feature_detail.html'
         if feature.is_plot:
-            template = 'treemap/plot_detail.html'
+            partial = 'treemap/partials/plot_detail.html'
         else:
             app = feature.__module__.split('.')[0]
-            try:
-                template = '%s/%s_detail.html' % (app, feature.feature_type)
-                get_template(template)
-            except TemplateDoesNotExist:
-                template = 'treemap/resource_detail.html'
-        return render_to_response(template, context,
-                                  RequestContext(request))
+            partial = '%s/%s_detail.html' % (app, feature.feature_type)
+        context['map_feature_partial'] = partial
+        return render_to_response(template, context, RequestContext(request))
     else:
         return context
 

--- a/opentreemap/treemap/views/map_feature.py
+++ b/opentreemap/treemap/views/map_feature.py
@@ -80,24 +80,37 @@ def get_photo_context_and_errors(fn):
 
 def map_feature_detail(request, instance, feature_id,
                        render=False, edit=False):
-    feature = get_map_feature_or_404(feature_id, instance)
-
-    ctx_fn = (context_dict_for_plot if feature.is_plot
-              else context_dict_for_resource)
-    context = ctx_fn(request, feature, edit=edit)
+    context, partial = _map_feature_detail_context(
+        request, instance, feature_id, edit)
     add_map_info_to_context(context, instance)
 
     if render:
         template = 'treemap/map_feature_detail.html'
-        if feature.is_plot:
-            partial = 'treemap/partials/plot_detail.html'
-        else:
-            app = feature.__module__.split('.')[0]
-            partial = '%s/%s_detail.html' % (app, feature.feature_type)
         context['map_feature_partial'] = partial
         return render_to_response(template, context, RequestContext(request))
     else:
         return context
+
+
+def _map_feature_detail_context(request, instance, feature_id, edit=False):
+    feature = get_map_feature_or_404(feature_id, instance)
+    ctx_fn = (context_dict_for_plot if feature.is_plot
+              else context_dict_for_resource)
+    context = ctx_fn(request, feature, edit=edit)
+
+    if feature.is_plot:
+        partial = 'treemap/partials/plot_detail.html'
+    else:
+        app = feature.__module__.split('.')[0]
+        partial = '%s/%s_detail.html' % (app, feature.feature_type)
+
+    return context, partial
+
+
+def render_map_feature_detail_partial(request, instance, feature_id, **kwargs):
+    context, partial = _map_feature_detail_context(
+        request, instance, feature_id)
+    return render_to_response(partial, context, RequestContext(request))
 
 
 def render_map_feature_detail(request, instance, feature_id, **kwargs):


### PR DESCRIPTION
* Refactor templates and JS to allow reloading map feature details as a partial
* The partials (which extend `partials/map_feature_detail_base.html`) include the title area, action buttons, and detail area.
* The partials do not include the mini map and streetview, since that would cause an obvious flash
* Detail page tells inline edit form not to update on successful save (we'll wait for refresh)
* Show spinner on both "Save" and "Delete"
* Simplify code that was directly updating details

NOTE - looking at individual commits will make it easier to review the code, since there were a couple of re-indentation steps

Depends on OpenTreeMap/otm-addons#1230

Connects #2667
Connects #2664
Connects #1719
Connects #975

Testing
* Verify that the above open bugs are fixed
* Verify that these closed bugs are still fixed
  * #1585
  * #861
  * #627
  * #596
  * #396
* Verify that you can still add and delete a tree many times in succession
* Verify that after saving you can still edit and save everything
