### PR TITLE
Display polygonal map feature popups

### DIFF
--- a/opentreemap/treemap/js/src/lib/MapManager.js
+++ b/opentreemap/treemap/js/src/lib/MapManager.js
@@ -89,7 +89,9 @@ MapManager.prototype = {
 
                 map.utfEvents = Bacon.mergeAll(
                     plotUtfEventStream,
-                    polygonDataStream
+                    emptyUtfEventStream.zip(polygonDataStream, function(utf, polygon) {
+                        return _.merge({}, utf, polygon);
+                    })
                 );
             } else {
                 map.utfEvents = baseUtfEventStream;

--- a/opentreemap/treemap/js/src/lib/browseTreesMode.js
+++ b/opentreemap/treemap/js/src/lib/browseTreesMode.js
@@ -130,7 +130,7 @@ function makePopup(latLon, html) {
         var popup = L.popup(popupOptions)
             .setLatLng(latLon)
             .setContent(html);
-        
+
         var mapFeatureType = $(html).data('mapfeature-type');
         popup.isMapFeature = mapFeatureType !== undefined;
         popup.isPlot = mapFeatureType === 'Plot';


### PR DESCRIPTION
The map returned by MapManager.js createTreeMap needs to have
utfEvents that merge the plotUtfEventStream with a zip
that combines fields from the emptyUtfEventStream with
the fields returned byt the polygonDataStream.

Using lodash's merge rather than assign to make a deep copy,
because I don't know the potential side effects of different stream
elements sharing descendant objects.

Let me know if you think _.assign would be sufficient.

--

Connects to #2652