### PR TITLE
Reduce top spacing in detail page sidebar bubbles

### DIFF
--- a/assets/css/sass/partials/pages/_treedetails.scss
+++ b/assets/css/sass/partials/pages/_treedetails.scss
@@ -6,7 +6,7 @@
         font-size: 2.4rem;
         font-weight: 300;
         line-height: 3rem;
-        margin: 25px 0 10px;
+        margin-bottom: 10px;
     }
 
     .detail-header {


### PR DESCRIPTION
A 25px top margin was introduced [here](https://github.com/OpenTreeMap/otm-core/commit/6c90967#diff-bf0bf7f1b303c2fd6c2d997a3726893eR9) as part of fixing spacing in nested comments for #1553.

Removing that margin makes the sidebar bubbles look right again, and nested comments still look fine.

Connects #2692