### PR TITLE
Unify JS on pages containing a simple form (fixing JS errors)

### DIFF
--- a/opentreemap/treemap/js/src/simpleForm.js
+++ b/opentreemap/treemap/js/src/simpleForm.js
@@ -3,5 +3,5 @@
 var $ = require('jquery');
 
 $(function () {
-    $('input[name="username"]').focus();
+    $('input[type!="hidden"]').first().focus();
 });

--- a/opentreemap/treemap/templates/registration/login.html
+++ b/opentreemap/treemap/templates/registration/login.html
@@ -49,5 +49,5 @@
 {% endblock content %}
 
 {% block scripts %}
-{% render_bundle 'js/treemap/login' %}
+    {% render_bundle 'js/treemap/simpleForm' %}
 {% endblock scripts %}

--- a/opentreemap/treemap/templates/registration/password_reset_confirm.html
+++ b/opentreemap/treemap/templates/registration/password_reset_confirm.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load render_bundle from webpack_loader %}
 {% load i18n %}
 
 {% block content %}
@@ -23,10 +24,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script>
-    (function (require) {
-        var $ = require('jquery')
-        $("input:password:visible:first").focus();
-    }(require))
-</script>
-{% endblock %}
+    {% render_bundle 'js/treemap/simpleForm' %}
+{% endblock scripts %}

--- a/opentreemap/treemap/templates/registration/password_reset_form.html
+++ b/opentreemap/treemap/templates/registration/password_reset_form.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load render_bundle from webpack_loader %}
 {% load i18n %}
 
 {% block content %}
@@ -17,10 +18,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script>
-    (function (require) {
-        var $ = require('jquery')
-        $("input:text:visible:first").addClass('form-control').focus();
-    }(require))
-</script>
+    {% render_bundle 'js/treemap/simpleForm' %}
 {% endblock %}

--- a/opentreemap/treemap/templates/registration/registration_form.html
+++ b/opentreemap/treemap/templates/registration/registration_form.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load render_bundle from webpack_loader %}
 {% load i18n %}
 
 {% block page_title %} | {% trans "Register" %}{% endblock %}
@@ -48,12 +49,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script>
-(function (require) {
-    var $ = require('jquery');
-    $(function () {
-        $('input[name="username"]').focus();
-    })
-})(require);
-</script>
+    {% render_bundle 'js/treemap/simpleForm' %}
 {% endblock scripts %}


### PR DESCRIPTION
We missed updating JS on a few pages when we switched to webpack. So:
* Create `simpleForm.js` which just focuses on the first non-hidden `input` element.
* Use it on pages for login, registration, and password reset.

Note that `password_reset_form.html` had been adding the class `form-control` to its input element.
Since that doesn't change its appearance significantly I've taken the simpler route of using the shared `simpleForm.js`.

Connects #2721