### PR TITLE
Add meta species lookup table for Tampa migration

### DIFF
--- a/opentreemap/otm1_migrator/migration_rules/tampa.py
+++ b/opentreemap/otm1_migrator/migration_rules/tampa.py
@@ -59,9 +59,9 @@ meta_species = {
 
 
 def create_override(species_obj, species_dict):
-    sci_name = species_dict['fields']['scientific_name'].lower()
     itree_code = species_dict['fields'].get('itree_code', None)
     if not itree_code:
+        sci_name = species_dict['fields'].get('scientific_name', '').lower()
         print('No itree_code for "%d: %s"' % (species_dict['pk'], sci_name))
         itree_code = meta_species.get(sci_name, '')
         print('Looked up meta species "%s"' % itree_code)


### PR DESCRIPTION
I added a static lookup table in the Tampa migration code to handle species that do not have an i-Tree code set in the species fixture. I opted to handle these 7 edge case species with a literal lookup rather than make the non-trivial changes to the migrator to properly handle the one-to-many relationship between species rows and resource rows. The migrator is reaching the end of its life and the cost of the changes does not justify the relatively small gain in general
correctness.

I created the table by running this query against the otm-legacy database:

```sql
SELECT lower(scientific_name), meta_species
FROM treemap_species s
JOIN treemap_species_resource sr ON s.id = sr.species_id
JOIN treemap_resource r ON sr.resource_id = r.id
WHERE itree_code = '';
```
---

##### Testing

After running a migration using this branch, trees that have a non-zero diameter and any one of the 7 affected species will have properly calculated eco benefits. 

yunnanensis
dactylifera
chrysotricha
rupicola
impetiginosa
unknown
sylvestris

---

Connects to https://github.com/OpenTreeMap/otm-clients/issues/276