### PR TITLE
Add missing stormwater migration

### DIFF
--- a/opentreemap/stormwater/migrations/0010_stormwater_blank_true.py
+++ b/opentreemap/stormwater/migrations/0010_stormwater_blank_true.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('stormwater', '0009_drainage_area_imperial_units'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='bioswale',
+            name='drainage_area',
+            field=models.FloatField(blank=True, null=True, verbose_name='Adjacent Drainage Area', error_messages={'invalid': 'Please enter a number.'}),
+        ),
+        migrations.AlterField(
+            model_name='raingarden',
+            name='drainage_area',
+            field=models.FloatField(blank=True, null=True, verbose_name='Adjacent Drainage Area', error_messages={'invalid': 'Please enter a number.'}),
+        ),
+    ]


### PR DESCRIPTION
Note: This is targeted at the `release/2.11.0` branch.

Running `./scripts/manage.sh migrate` in development was printing a "Your models have changes that are not yet reflected in a migration..." message.

I ran `./scripts/manage.sh makemigrations` to generate the missing migration. The two fields were added in stormwater migration 0006. The migration is missing the `blank=True` keyword argument, but the changes to `models.py` in c805dc8 include the `blank=True` keyword argument. I am not sure how this mismatch occurred.

---

##### Testing

Migrations should be applied without any warning messages.

---

Connects to #2747