### PR TITLE
Message makes tree diameter too narrow to use

### DIFF
--- a/assets/css/sass/partials/pages/_treedetails.scss
+++ b/assets/css/sass/partials/pages/_treedetails.scss
@@ -43,17 +43,24 @@
 #map-feature-form {
     margin-top: 0;
 
-    table {
+    table.can-inline-edit {
         > tbody {
             > tr {
                 > td:first-child {
                     width: 45%;
-                    vertical-align: middle;
+                    > .alert {
+                        margin-top: 8px;
+                    }
                 }
-
-                &.diameter-row {
-                    td:first-child {
-                        vertical-align: top;
+            }
+        }
+    }
+    &[data-mode="edit"] {
+        table.can-inline-edit {
+            > tbody {
+                > tr.editable {
+                    > td:first-child {
+                        padding-top: 16px;
                     }
                 }
             }

--- a/opentreemap/treemap/js/src/lib/editableForm.js
+++ b/opentreemap/treemap/js/src/lib/editableForm.js
@@ -142,7 +142,9 @@ exports.init = function(options) {
             typeaheadToDisplayValues();
         },
 
-        hideAndShowElements = function (fields, actions, action) {
+        hideAndShowElements = function (mode, fields, actions, action) {
+            var $modeEl = $(fields).parents('[data-mode]');
+            $modeEl.attr('data-mode', mode);
             if (_.contains(actions, action)) {
                 $(fields).show();
             } else {

--- a/opentreemap/treemap/js/src/lib/inlineEditForm.js
+++ b/opentreemap/treemap/js/src/lib/inlineEditForm.js
@@ -277,14 +277,14 @@ exports.init = function(options) {
     actionStream.plug(saveOkStream.map('save:ok'));
     actionStream.plug(responseErrorStream.map('save:error'));
     actionStream.plug(modeChangeStream);
-    actionStream.onValue(hideAndShowElements, editFields, eventsLandingInEditMode);
-    actionStream.onValue(hideAndShowElements, displayFields, eventsLandingInDisplayMode);
-    actionStream.onValue(editForm.hideAndShowElements, validationFields, ['save:error']);
+    actionStream.onValue(hideAndShowElements, 'edit', editFields, eventsLandingInEditMode);
+    actionStream.onValue(hideAndShowElements, 'display', displayFields, eventsLandingInDisplayMode);
+    actionStream.onValue(editForm.hideAndShowElements, 'edit', validationFields, ['save:error']);
 
-    function hideAndShowElements(fields, actions, action) {
+    function hideAndShowElements(mode, fields, actions, action) {
         var shouldHideAndShow = !(dontUpdateOnSaveOk && action === 'save:ok');
         if (shouldHideAndShow) {
-            editForm.hideAndShowElements(fields, actions, action);
+            editForm.hideAndShowElements(mode, fields, actions, action);
         }
     }
 

--- a/opentreemap/treemap/js/src/lib/simpleEditForm.js
+++ b/opentreemap/treemap/js/src/lib/simpleEditForm.js
@@ -36,8 +36,8 @@ exports.init = function(options) {
     actionStream.plug(editStream);
     actionStream.plug(saveOkStream);
     actionStream.plug(cancelStream);
-    actionStream.onValue(editForm.hideAndShowElements, editFields, eventsLandingInEditMode);
-    actionStream.onValue(editForm.hideAndShowElements, displayFields, eventsLandingInDisplayMode);
+    actionStream.onValue(editForm.hideAndShowElements, 'edit', editFields, eventsLandingInEditMode);
+    actionStream.onValue(editForm.hideAndShowElements, 'display' , displayFields, eventsLandingInDisplayMode);
 
     saveOkStream.onValue(editForm.formFieldsToDisplayValues);
 

--- a/opentreemap/treemap/templates/treemap/field/attrs.html
+++ b/opentreemap/treemap/templates/treemap/field/attrs.html
@@ -1,4 +1,7 @@
 {% load l10n %}
+{% if css_class %}
+class="{{ css_class }}"
+{% endif %}
 data-field="{{ field.identifier }}"
 data-class="{{ class }}"
 data-value="{{ field.value|default_if_none:""|unlocalize }}"

--- a/opentreemap/treemap/templates/treemap/field/diameter_tr.html
+++ b/opentreemap/treemap/templates/treemap/field/diameter_tr.html
@@ -2,7 +2,13 @@
 
 {% if field.is_visible %}
   <tr class="diameter-row">
-    <td>{{ field.label }}</td>
+    <td>
+      <div>{{ field.label }}</div>
+      {% if field.is_editable %}
+        <div style="display:none;"
+             {% include "treemap/field/attrs.html" with class="error" css_class="alert alert-danger" %}></div>
+      {% endif %}
+    </td>
     <td {% include "treemap/field/attrs.html" with class="display" %}>
       {{ field.display_value|default_if_none:"" }}
     </td>
@@ -14,8 +20,6 @@
         </div>
         {% include "treemap/partials/diameter_calculator.html" %}
       </td>
-    <td style="display:none;"
-        {% include "treemap/field/attrs.html" with class="error" %}></td>
   {% endif %}
   </tr>
 {% endif %}

--- a/opentreemap/treemap/templates/treemap/field/species_tr.html
+++ b/opentreemap/treemap/templates/treemap/field/species_tr.html
@@ -16,13 +16,14 @@
   <tr style="display: none;"
       data-field="{{ field.identifier }}"
       data-class="edit">
-    <td>{% trans "Species" %}</td>
+    <td>
+      <div>{% trans "Species" %}</div>
+      <div style="display:none;"
+           {% include "treemap/field/attrs.html" with class="error" css_class="alert alert-danger" %}></div>
+    </td>
     <td>
       {% include "treemap/field/species_typeahead.html" %}
     </td>
-    <td class="text-danger"
-        style="display: none;"
-        {% include "treemap/field/attrs.html" with class="error"%}></td>
   </tr>
   {% endif %}
 {% endif %}

--- a/opentreemap/treemap/templates/treemap/field/tr.html
+++ b/opentreemap/treemap/templates/treemap/field/tr.html
@@ -1,7 +1,13 @@
 {# vim: set filetype=htmldjango : #}
 {% if field.is_visible %}
-  <tr>
-    <td>{{ field.label }}</td>
+  <tr class="{% if field.is_editable %}editable{% endif %}">
+    <td>
+      <div>{{ field.label }}</div>
+      {% if field.is_editable %}
+        <div style="display:none;"
+             {% include "treemap/field/attrs.html" with class="error" css_class="alert alert-danger" %}></div>
+      {% endif %}
+    </td>
     <td {% include "treemap/field/attrs.html" with class="display" %}>
       {{ field.display_value|default_if_none:"" }}
     </td>
@@ -10,8 +16,6 @@
           {% include "treemap/field/attrs.html" with class="edit" %}>
         {% include "treemap/field/inputs.html" %}
       </td>
-      <td style="display:none;"
-          {% include "treemap/field/attrs.html" with class="error" %}></td>
     {% endif %}
   </tr>
 {% endif %}

--- a/opentreemap/treemap/templates/treemap/partials/map_feature_detail_base.html
+++ b/opentreemap/treemap/templates/treemap/partials/map_feature_detail_base.html
@@ -85,7 +85,7 @@
     <hr>
 
     <!-- Map Feature Details -->
-    <form id="map-feature-form">
+    <form id="map-feature-form" data-mode="display">
 
         {# There isn't a field to show "inline" errors for geom fields, so just show it up top #}
         <div class="alert alert-warning" data-class="error" data-field="mapFeature.geom" style="display: none;"></div>

--- a/opentreemap/treemap/templates/treemap/partials/plot_detail.html
+++ b/opentreemap/treemap/templates/treemap/partials/plot_detail.html
@@ -16,7 +16,7 @@
 
     <!-- Tree Information -->
     <div id="tree-details" {{ has_tree|yesno:",style=display:none;" }}>
-        <table class="table table-hover">
+        <table class="table table-hover can-inline-edit">
             <tbody>
             {% usercanread tree "id" as value %}
                 <tr>
@@ -70,7 +70,7 @@
             {% endwith %}
         </div>
     {% else %}
-        <table class="table table-hover">
+        <table class="table table-hover can-inline-edit">
             <tbody>
             {% trans "Width" as width %}
             {% field width from "plot.width" for request.user withtemplate "treemap/field/tr.html" %}

--- a/opentreemap/treemap/templates/treemap/partials/resource_detail.html
+++ b/opentreemap/treemap/templates/treemap/partials/resource_detail.html
@@ -10,7 +10,7 @@
 
     <h3>{{ term.Resource.singular }} {% trans "Information" %}</h3>
 
-    <table class="table table-hover">
+    <table class="table table-hover can-inline-edit">
         <tbody>
         <tr>
             <td>{{ term.Resource.singular }} {% trans "number" %}</td>


### PR DESCRIPTION
@lederer recommended we display the message beneath the field label because there is plenty of room there.

Also, the message should be in red, like the message in the add-a-tree sidebar wizard.

Also, the label should not be vertical-align middle. Its baseline should be even with the baseline of the text in the second table cell, whether it's in edit mode or not.

This needed to be done for all rows in the detail pages. Otherwise, the presence of a message on the right on any row would make the tree diameter too narrow to use.

Changes:

opentreemap/treemap/js/src/lib/
------------------------------------------
* editableForm.js
* inlineEditForm.js
* simpleEditForm.js

Manipulate a [data-mode] element to be either edit or display.

opentreemap/treemap/templates/treemap/partials/
------------------------------------------------------------------
* map_feature_detail_base.html

Set #map-feature-form to have a data-mode attribute

* plot_detail.html
* resource_detail.html

Add a can-inline-edit class to the tables to distinguish them from ordinary tables for styling purposes. Specifically, it distinguishes them from the diameter-circumference control, which uses table layout.

opentreemap/treemap/templates/treemap/field/
--------------------------------------------------------------
* attrs.html
* tr.html
* diameter_tr.html
* species_tr.html

Add a css_class variable to attrs.html to use in the class attribute, as distinct from the class variable already in use for the data-class attribute.

The *tr.html templates set css_class to `alert alert-danger` on the error elements to make them styled with red.

assets/css/sass/partials/pages/_treedetails.scss
------------------------------------------------

Remove the diameter-row style.
Style the first td in a row differently depending on whether
* the table is in edit mode
* the table contents can be edited inline
* the row the td is in is itself editable

Attention to whether the table contents can be edited allows the style to apply just to the desired table's cells, not to cells in child tables such as the diameter-circumference editor.

--

Connects to #2754