### PR TITLE
Remove duplicate keys from object literal in test

### DIFF
--- a/opentreemap/exporter/tests.py
+++ b/opentreemap/exporter/tests.py
@@ -310,16 +310,12 @@ class UserExportsTest(UserExportsTestCase):
                              'created': str(self.user1.created)})
 
         self.assertUserJSON(user2data,
-                            {'last_edit_model': 'Plot',
-                             'last_edit_model_id': str(self.plot.pk),
-                             'last_edit_instance_id': str(self.instance.pk),
-                             'last_edit_user_id': str(self.user1.pk),
-                             'email': 'genly@example.com',
-                             'email_hash': self.user2.email_hash,
-                             'last_edit_model': 'Tree',
+                            {'last_edit_model': 'Tree',
                              'last_edit_model_id': str(self.tree.pk),
                              'last_edit_instance_id': str(self.instance.pk),
-                             'last_edit_user_id': str(self.user2.pk)})
+                             'last_edit_user_id': str(self.user2.pk),
+                             'email': 'genly@example.com',
+                             'email_hash': self.user2.email_hash})
 
     def test_min_edit_date(self):
         last_week = now() - datetime.timedelta(days=7)


### PR DESCRIPTION
The object literal confusingly defines keys twice. Based on the content of the `setUp` function and the assert statement

```python
    self.assertUserJSON(user2data, ...
```

it is clear that the intention was to assert `user2` values.

Connects to #2761 