### PR TITLE
Tree detail error message vs. diameter field

### DIFF
--- a/assets/css/sass/partials/pages/_treedetails.scss
+++ b/assets/css/sass/partials/pages/_treedetails.scss
@@ -46,7 +46,7 @@
     table {
         > tbody {
             > tr {
-                > td:first-child {
+                > td:not([colspan]):first-child {
                     width: 45%;
                     vertical-align: middle;
                 }
@@ -55,6 +55,11 @@
                     td:first-child {
                         vertical-align: top;
                     }
+                }
+            }
+            > tr.error {
+                >td {
+                    border-top: 0 none;
                 }
             }
         }

--- a/opentreemap/treemap/js/src/lib/inlineEditForm.js
+++ b/opentreemap/treemap/js/src/lib/inlineEditForm.js
@@ -150,6 +150,7 @@ exports.init = function(options) {
                 if ($field.length > 0) {
                     $field.html(errorList.join(','));
                     $field.show();
+                    $field.parents('.error').show();
                 } else {
                     console.log('Field error returned from server, ' +
                                 'but no dom element bound from client.',

--- a/opentreemap/treemap/templates/treemap/field/diameter_tr.html
+++ b/opentreemap/treemap/templates/treemap/field/diameter_tr.html
@@ -14,8 +14,14 @@
         </div>
         {% include "treemap/partials/diameter_calculator.html" %}
       </td>
-    <td style="display:none;"
-        {% include "treemap/field/attrs.html" with class="error" %}></td>
   {% endif %}
   </tr>
+  {% if field.is_editable %}
+  <tr class="error" style="display:none">
+    <td colspan="2">
+      <div class="alert alert-danger text-danger"
+           {% include "treemap/field/attrs.html" with class="error" %}></div>
+    </td>
+  </tr>
+  {% endif %}
 {% endif %}

--- a/opentreemap/treemap/templates/treemap/field/diameter_tr.html
+++ b/opentreemap/treemap/templates/treemap/field/diameter_tr.html
@@ -19,7 +19,7 @@
   {% if field.is_editable %}
   <tr class="error" style="display:none">
     <td colspan="2">
-      <div class="alert alert-danger text-danger"
+      <div class="alert alert-danger"
            {% include "treemap/field/attrs.html" with class="error" %}></div>
     </td>
   </tr>

--- a/opentreemap/treemap/templates/treemap/field/species_tr.html
+++ b/opentreemap/treemap/templates/treemap/field/species_tr.html
@@ -20,9 +20,12 @@
     <td>
       {% include "treemap/field/species_typeahead.html" %}
     </td>
-    <td class="text-danger"
-        style="display: none;"
-        {% include "treemap/field/attrs.html" with class="error"%}></td>
+  <tr class="error" style="display:none">
+    <td colspan="2">
+      <div class="alert alert-danger text-danger"
+           {% include "treemap/field/attrs.html" with class="error" %}></div>
+    </td>
+  </tr>
   </tr>
   {% endif %}
 {% endif %}

--- a/opentreemap/treemap/templates/treemap/field/species_tr.html
+++ b/opentreemap/treemap/templates/treemap/field/species_tr.html
@@ -22,7 +22,7 @@
     </td>
   <tr class="error" style="display:none">
     <td colspan="2">
-      <div class="alert alert-danger text-danger"
+      <div class="alert alert-danger"
            {% include "treemap/field/attrs.html" with class="error" %}></div>
     </td>
   </tr>

--- a/opentreemap/treemap/templates/treemap/field/tr.html
+++ b/opentreemap/treemap/templates/treemap/field/tr.html
@@ -15,7 +15,7 @@
   {% if field.is_editable %}
   <tr class="error" style="display:none">
     <td colspan="2">
-      <div class="alert alert-danger text-danger"
+      <div class="alert alert-danger"
            {% include "treemap/field/attrs.html" with class="error" %}></div>
     </td>
   </tr>

--- a/opentreemap/treemap/templates/treemap/field/tr.html
+++ b/opentreemap/treemap/templates/treemap/field/tr.html
@@ -10,8 +10,14 @@
           {% include "treemap/field/attrs.html" with class="edit" %}>
         {% include "treemap/field/inputs.html" %}
       </td>
-      <td style="display:none;"
-          {% include "treemap/field/attrs.html" with class="error" %}></td>
     {% endif %}
   </tr>
+  {% if field.is_editable %}
+  <tr class="error" style="display:none">
+    <td colspan="2">
+      <div class="alert alert-danger text-danger"
+           {% include "treemap/field/attrs.html" with class="error" %}></div>
+    </td>
+  </tr>
+  {% endif %}
 {% endif %}


### PR DESCRIPTION
When there was a tree detail error, it was displayed in a new third table column. This caused the
diameter/circumference edit widget to get so narrow you couldn't see the values.

Changes: 1. Show the message in a new <tr>. 2. Show/hide the <tr>. 3. Show the message in a
colspan="2" <td> in the <tr>,
  so it fills the width of the row. 4. Show the message in a div inside the <td colspan="2">
  to get the styling right. 5. Style it.

The styling problem is that bootstrap.css orders
.table > tbody > tr > td later than .alert-danger, resulting in a td-looking top border, instead of 
4 alert-danger borders, which looks awful.

The alternative would have been to specify the border-top in the td[colspan="2"] style, but then we
have to copy-paste from bootstrap, which has maintainability problems.

--

Connects to #2754 