### PR TITLE
Add support for searching on the 'owner_orig_id' field.

### DIFF
--- a/opentreemap/importer/fields.py
+++ b/opentreemap/importer/fields.py
@@ -95,7 +95,7 @@ class trees(object):
     # READ_ONLY = 'read only'
 
     OPENTREEMAP_PLOT_ID = 'planting site id'
-    EXTERNAL_ID_NUMBER = 'owner original id'
+    EXTERNAL_ID_NUMBER = 'custom id'
 
     TREE_PRESENT = 'tree present'
 

--- a/opentreemap/importer/models/trees.py
+++ b/opentreemap/importer/models/trees.py
@@ -26,7 +26,7 @@ class TreeImportEvent(GenericImportEvent):
     tree/plot information
     """
 
-    import_schema_version = 1  # Update if any column header name changes
+    import_schema_version = 2  # Update if any column header name changes
     import_type = 'tree'
 
     plot_length_conversion_factor = models.FloatField(default=1.0)

--- a/opentreemap/importer/tests.py
+++ b/opentreemap/importer/tests.py
@@ -1400,8 +1400,8 @@ class TreeIntegrationTests(IntegrationTests):
         # self.assertEqual(plot.readonly, False)
 
         csv = """
-        | point x | point y | owner original id  | planting site id |
-        | 45.53   | 31.1    | 443                | %s               |
+        | point x | point y | custom id  | planting site id |
+        | 45.53   | 31.1    | 443        | %s               |
         """ % plot.id
 
         ieid = self.run_through_commit_views(csv)

--- a/opentreemap/treemap/migrations/0030_add_verbose_name_to_owner_orig_id.py
+++ b/opentreemap/treemap/migrations/0030_add_verbose_name_to_owner_orig_id.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0029_merge'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='plot',
+            name='owner_orig_id',
+            field=models.CharField(max_length=255, null=True, verbose_name='Custom ID', blank=True),
+        ),
+    ]

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -865,13 +865,18 @@ class Plot(MapFeature, ValidationMixin):
     length = models.FloatField(null=True, blank=True,
                                verbose_name=_("Planting Site Length"))
 
-    owner_orig_id = models.CharField(max_length=255, null=True, blank=True)
+    owner_orig_id = models.CharField(max_length=255, null=True, blank=True,
+                                     verbose_name=_("Custom ID"))
 
     objects = GeoHStoreUDFManager()
     is_editable = True
 
     _terminology = {'singular': _('Planting Site'),
                     'plural': _('Planting Sites')}
+
+    search_settings = {
+        'owner_orig_id': {'search_type': 'IS'}
+    }
 
     udf_settings = {
         'Stewardship': {

--- a/opentreemap/treemap/templates/treemap/partials/plot_detail.html
+++ b/opentreemap/treemap/templates/treemap/partials/plot_detail.html
@@ -82,7 +82,7 @@
             {% field city from "plot.address_city" for request.user withtemplate "treemap/field/tr.html" %}
             {% trans "Postal Code" as zip %}
             {% field zip from "plot.address_zip" for request.user withtemplate "treemap/field/tr.html" %}
-            {% trans "Original Owner Id" as oid %}
+            {% trans "Custom ID" as oid %}
             {% field oid from "plot.owner_orig_id" for request.user withtemplate "treemap/field/tr.html" %}
             <!-- Hiding readonly field temporarily -->
             <!-- See github #379 and #772 for more details -->


### PR DESCRIPTION
Also renamed the `owner_orig_id` field to be "Custom ID", and updates its name in the importer template.

With this change in place, "Custom ID" should be a search field option in the search fields management page under the planting site section, and "Missing Planting Site Custom ID" should be an option under the "Missing Data" section.

Connects to #2734