### PR TITLE
Honor embed query string parameter

### DIFF
--- a/assets/css/sass/partials/_header.scss
+++ b/assets/css/sass/partials/_header.scss
@@ -16,6 +16,13 @@
     }
 }
 
+.embed {
+    .header {
+        padding-top: 0;
+        height: 98px;
+    }
+}
+
 .logo {
     display: inline-block;
     vertical-align: middle;
@@ -38,6 +45,12 @@
     right: 15px;
     top: 60px;
     display: inline-block;
+}
+
+.embed {
+    .search-wrapper {
+        top: 15px;
+    }
 }
 
 .search-block-wrapper {
@@ -86,7 +99,7 @@
                 font-size: 1.8rem;
                 line-height: 1.6rem;
 
-                &.active, 
+                &.active,
                 &:hover {
                     color: $main-text-color;
                 }
@@ -129,8 +142,8 @@
 
     .btn-default {
 
-        &:hover, 
-        &:focus, 
+        &:hover,
+        &:focus,
         &:active, &.active {
             box-shadow: none;
             background: darken($button-default, 5%);

--- a/assets/css/sass/partials/_layout.scss
+++ b/assets/css/sass/partials/_layout.scss
@@ -7,13 +7,16 @@ body {
 }
 
 .wrapper {
-	min-height: 100%;
-	height: auto !important;
-	height: 100%;
-	margin-bottom: -40px;
+    min-height: 100%;
+    height: auto !important;
+    height: 100%;
+    margin-bottom: -40px;
+    &.embed {
+        margin-bottom: 0;
+    }
 
-	@include buttons;
-	@include links;
+    @include buttons;
+    @include links;
 }
 
 .image-background {
@@ -32,12 +35,15 @@ body {
     overflow: auto;
     margin-bottom: 40px;
 
-    &.map {
+    &.explore-map {
         position: absolute;
         overflow: hidden;
         margin: 0;
         top: 244px;
         width: 100%;
+
+        left: 0;
+        right: 350px;
         bottom: 40px;
 
         @media(min-width: 990px){
@@ -45,6 +51,7 @@ body {
         }
 
         @media #{$screen-xs} {
+            right: 0;
             top: 154px;
             overflow: auto;
 
@@ -52,6 +59,13 @@ body {
                 height: 300px;
             }
         }
+    }
+}
+
+.embed {
+    .content.explore-map {
+        bottom: 0;
+        top: 147px;
     }
 }
 

--- a/opentreemap/opentreemap/context_processors.py
+++ b/opentreemap/opentreemap/context_processors.py
@@ -50,6 +50,12 @@ def global_settings(request):
     except:
         header_comment = "Version information not available\n"
 
+    embed = False
+    try:
+        embed = request.GET.get('embed') is not None
+    except:
+        pass
+
     term = copy.copy(REPLACEABLE_TERMS)
     if hasattr(request, 'instance'):
         term.update(request.instance.config.get('terms', {}))
@@ -79,6 +85,7 @@ def global_settings(request):
         'logo_url': logo_url,
         'header_comment': header_comment,
         'term': term,
+        'embed': embed,
         'datepicker_start_date': datetime.min.replace(year=1900),
     }
 

--- a/opentreemap/treemap/decorators.py
+++ b/opentreemap/treemap/decorators.py
@@ -48,6 +48,9 @@ def instance_request(view_fn, redirect=True):
                 if request.user.is_authenticated():
                     return HttpResponseRedirect(
                         reverse('instance_not_available'))
+                elif request.GET.get('embed') is not None:
+                    return HttpResponseRedirect(
+                        reverse('instance_not_available') + '?embed=')
                 else:
                     return login_redirect(request)
             else:

--- a/opentreemap/treemap/js/src/lib/browseTreesMode.js
+++ b/opentreemap/treemap/js/src/lib/browseTreesMode.js
@@ -12,6 +12,7 @@ var $ = require('jquery'),
 
 var map,
     popup,  // Most recent popup (so it can be deleted)
+    embed,  // True if embed is in the query string
     plotMarker,
     $fullDetailsButton;
 
@@ -28,6 +29,7 @@ function idToPlotDetailUrl(id) {
 
 function init(options) {
     map = options.map;
+    embed = options.embed;
     plotMarker = options.plotMarker;
     $fullDetailsButton = options.$fullDetailsButton;
 
@@ -77,6 +79,9 @@ function init(options) {
         .assign($('#accordion-map-feature-detail-tab'), 'html');
 
     var showTreeDetailLink = $accordionSection.parent().find('a');
+    if (embed) {
+        showTreeDetailLink.filter('#full-details-button').attr('target', '_blank');
+    }
     showTreeDetailLink.on('click', function(event) {
         if ($('#map-feature-accordion').html().length === 0) {
             event.stopPropagation();
@@ -127,11 +132,16 @@ function makePopup(latLon, html) {
             maxHeight: 300
         };
 
+        var $popup = $(html);
+        if (embed) {
+            $popup.find('a').attr('target', '_blank');
+        }
+
         var popup = L.popup(popupOptions)
             .setLatLng(latLon)
-            .setContent(html);
+            .setContent($popup.html());
 
-        var mapFeatureType = $(html).data('mapfeature-type');
+        var mapFeatureType = $popup.data('mapfeature-type');
         popup.isMapFeature = mapFeatureType !== undefined;
         popup.isPlot = mapFeatureType === 'Plot';
 

--- a/opentreemap/treemap/js/src/lib/mapPage.js
+++ b/opentreemap/treemap/js/src/lib/mapPage.js
@@ -5,6 +5,7 @@
 var $ = require('jquery'),
     _ = require('lodash'),
     Bacon = require('baconjs'),
+    url = require('url'),
     L = require('leaflet'),
     U = require('treemap/lib/utility.js'),
     MapManager = require('treemap/lib/MapManager.js'),
@@ -60,9 +61,13 @@ module.exports.init = function (options) {
         }
     });
 
+    var queryObject = url.parse(location.href, true).query;
+    var embed = queryObject && queryObject.hasOwnProperty('embed');
+
     return {
         mapManager: mapManager,
         map: mapManager.map,
+        embed: !!embed,
         builtSearchEvents: builtSearchEvents,
         getMapStateSearch: urlState.getSearch,
         mapStateChangeStream: urlState.stateChangeStream,

--- a/opentreemap/treemap/js/src/lib/treeMapModes.js
+++ b/opentreemap/treemap/js/src/lib/treeMapModes.js
@@ -81,7 +81,7 @@ function inAddTreeMode()     { return currentMode === addTreeMode; }
 function inEditTreeMode()    { return currentMode === editTreeDetailsMode; }
 function inAddResourceMode() { return currentMode === addResourceMode; }
 
-function init(mapManager, triggerSearchBus) {
+function init(mapManager, triggerSearchBus, embed) {
     // browseTreesMode and editTreeDetailsMode share an inlineEditForm,
     // so initialize it here.
     var form = inlineEditForm.init({
@@ -115,6 +115,7 @@ function init(mapManager, triggerSearchBus) {
 
     browseTreesMode.init({
         map: mapManager.map,
+        embed: embed,
         inMyMode: inBrowseTreesMode,
         $treeDetailAccordionSection: $treeDetailAccordionSection,
         $fullDetailsButton: $fullDetailsButton,

--- a/opentreemap/treemap/js/src/treeMap.js
+++ b/opentreemap/treemap/js/src/treeMap.js
@@ -4,6 +4,7 @@ var $ = require('jquery'),
     _ = require('lodash'),
     Bootstrap = require('bootstrap'),  // for $(...).collapse()
     Bacon = require('baconjs'),
+    url = require('url'),
     addTreeModeName = require('treemap/lib/addTreeMode.js').name,
     addResourceModeName = require('treemap/lib/addResourceMode.js').name,
     BU = require('treemap/lib/baconUtils.js'),
@@ -42,14 +43,32 @@ var mapPage = MapPage.init({
 
 modeChangeStream.onValue(changeMode);
 
+var performAdd = function (e, addFn) {
+    if (!mapPage.embed) {
+        e.preventDefault();
+        addFn();
+    } else {
+        var btn = e.target,
+            href = btn.href,
+            parsedHref = url.parse(href, true),
+            currentLocation = url.parse(location.href, true),
+            adjustedQuery = _.chain({})
+                .assign(currentLocation.query, parsedHref.query)
+                .omit('embed')
+                .value();
+        parsedHref.search = null;
+        parsedHref.query = adjustedQuery;
+        btn.href = url.format(parsedHref);
+        // allow default
+    }
+};
+
 $('[data-action="addtree"]').click(function(e) {
-    e.preventDefault();
-    modes.activateAddTreeMode();
+    performAdd(e, modes.activateAddTreeMode);
 });
 
 $('[data-action="addresource"]').click(function(e) {
-    e.preventDefault();
-    modes.activateAddResourceMode();
+    performAdd(e, modes.activateAddResourceMode);
 });
 
 Search.init(
@@ -58,7 +77,7 @@ Search.init(
 
 buttonEnabler.run();
 
-modes.init(mapManager, triggerSearchFromSidebar);
+modes.init(mapManager, triggerSearchFromSidebar, mapPage.embed);
 
 // Read state from current URL, initializing zoom/lat/long/search/mode
 mapPage.initMapState();

--- a/opentreemap/treemap/templates/base.html
+++ b/opentreemap/treemap/templates/base.html
@@ -48,7 +48,8 @@
     {% endif %}
   </head>
   <body>
-    <div {% block outermost_atts %}{% endblock outermost_atts %} class="wrapper">
+    <div {% block outermost_atts %}{% endblock outermost_atts %} class="wrapper{% if embed %} embed{% endif %}">
+      {% if not embed %}
       {% block topnav %}
       <!-- Top Nav -->
       <div class="navbar navbar-inverse navbar-fixed-top">
@@ -129,6 +130,7 @@
         </div>
       </div>
       {% endblock topnav %}
+      {% endif %}
 
       {% block header %}
       <!-- Logo and Search -->
@@ -171,7 +173,9 @@
 
     </div>
 
-    <footer>{% block footer %}{% endblock footer %}</footer>
+    {% if not embed %}
+      <footer>{% block footer %}{% endblock footer %}</footer>
+    {% endif %}
 
     {% block config_scripts %}
       {% if request.instance %}

--- a/opentreemap/treemap/templates/instance_base.html
+++ b/opentreemap/treemap/templates/instance_base.html
@@ -137,19 +137,22 @@ ga('set', 'page', pathname);
     <div class="half">
       <div style="display: inline;" id="tree-and-planting-site-counts">
       </div>
-      {% block subhead_exports %}
-        {% if request.instance|export_enabled_for:request.user %}
-        <a href="javascript:;" class="btn btn-primary btn-xs exportBtn"
-           data-export-start-url="{% url 'begin_export' instance_url_name=request.instance.url_name model='tree' %}">
-          <i class="icon-export"></i> {% trans "Export Search Results" %}
-        </a>
-        {% endif %}
-      {% endblock subhead_exports %}
+      {% if not embed %}
+        {% block subhead_exports %}
+          {% if request.instance|export_enabled_for:request.user %}
+          <a href="javascript:;" class="btn btn-primary btn-xs exportBtn"
+             data-export-start-url="{% url 'begin_export' instance_url_name=request.instance.url_name model='tree' %}">
+            <i class="icon-export"></i> {% trans "Export Search Results" %}
+          </a>
+          {% endif %}
+        {% endblock subhead_exports %}
+      {% endif %}
     </div>
     <div class="half">
       {% if request.instance|feature_enabled:'add_plot' and last_effective_instance_user %}
         {% if request.instance.has_resources %}
         <a class="btn btn-primary addBtn"
+           {% if embed %}target="_blank"{% endif %}
            data-action='addresource'
            data-always-enable="{{ last_effective_instance_user|any_resource_is_creatable }}"
            data-disabled-title=
@@ -158,9 +161,14 @@ ga('set', 'page', pathname);
            disabled="disabled"><i class="icon-plus"></i> {% trans "Add a" %} {{ term.Resource.singular }}</a>
         {% endif %}
       <a class="btn btn-primary addBtn"
-         data-action='addtree'
+         {% if embed %}
+         target="_blank"
+         {% else %}
          data-feature="add_plot"
-         data-event-category="add-tree" data-event-action="start-add-tree"
+         data-event-category="add-tree"
+         data-event-action="start-add-tree"
+         {% endif %}
+         data-action='addtree'
          data-always-enable="{{ last_effective_instance_user|plot_is_creatable }}"
          data-disabled-title="{% trans "Adding trees is not available to all users" %}"
          data-href="{% url 'map' instance_url_name=request.instance.url_name %}?m=addTree"
@@ -171,9 +179,11 @@ ga('set', 'page', pathname);
 </div>
 {% endblock subhead %}
 
+{% if not embed %}
 {% block export %}
 {% include "treemap/partials/export.html" %}
 {% endblock export %}
+{% endif %}
 
 {% block search %}
 <div class="search-block-wrapper">

--- a/opentreemap/treemap/templates/treemap/map-browse-trees.html
+++ b/opentreemap/treemap/templates/treemap/map-browse-trees.html
@@ -9,6 +9,7 @@
     <div id="tree-detail" class="panel-body collapse">
       <div class="panel-body-buttons" id="map-plot-details-button" style="display: none;">
         <a class="btn" data-class="display" id="full-details-button">{% trans "Full Details" %}</a>
+        {% if not embed %}
         <button class="btn"
                 data-class="display"
                 id="quick-edit-button"
@@ -18,6 +19,7 @@
                 disabled="disabled">{% trans "Quick Edit" %}</button>
                 <button class="btn btn-success" data-class="edit" id="save-details-button" style="display:none">Save</button>
                 <button class="btn" data-class="edit" id="cancel-edit-details-button" style="display:none">Cancel</button>
+      {% endif %}
       </div>
       <div class="panel-inner" id="map-feature-accordion">
       </div>

--- a/opentreemap/treemap/templates/treemap/map.html
+++ b/opentreemap/treemap/templates/treemap/map.html
@@ -14,7 +14,7 @@
 {% endblock searchscripts %}
 
 {% block content %}
-<div class="content map">
+<div class="content explore-map">
   <div id="streetview" style="display: none">
   </div>
   <div id="map" class="map"

--- a/opentreemap/treemap/tests/test_urls.py
+++ b/opentreemap/treemap/tests/test_urls.py
@@ -258,6 +258,26 @@ class TreemapUrlTests(UrlTestCase):
             % (username, self.instance.id))
 
 
+@override_settings(FEATURE_BACKEND_FUNCTION=None)
+class TreemapPrivateUrlTests(UrlTestCase):
+    # Tests for URLs defined in treemap/urls.py
+    # All treemap URLs start with /<instance_url_name>/
+
+    def setUp(self):
+        self.instance = make_instance(is_public=False)
+        self.prefix = '/%s/' % self.instance.url_name
+
+    def test_instance(self):
+        desired_path = self.prefix + 'map/'
+        expected_path = '/accounts/login/?next=' + desired_path
+        self.assert_redirects(desired_path, expected_path, 302)
+
+    def test_embed(self):
+        desired_path = self.prefix + 'map/?embed='
+        expected_path = '/not-available?embed='
+        self.assert_redirects(desired_path, expected_path, 302)
+
+
 class InstanceUrlTests(RequestTestCase):
     def setUp(self):
         make_instance(name='The inztance', is_public=True,

--- a/opentreemap/treemap/tests/test_urls.py
+++ b/opentreemap/treemap/tests/test_urls.py
@@ -186,6 +186,9 @@ class TreemapUrlTests(UrlTestCase):
     def test_tree_list(self):
         self.assert_template(self.prefix + 'map/', 'treemap/map.html')
 
+    def test_tree_list_embed(self):
+        self.assert_template(self.prefix + 'map/?embed=', 'treemap/map.html')
+
     def test_plot_detail(self):
         plot = self.make_plot()
         url = self.prefix + 'features/%s/' % plot.id

--- a/opentreemap/treemap/views/misc.py
+++ b/opentreemap/treemap/views/misc.py
@@ -87,7 +87,6 @@ def get_map_view_context(request, instance):
         ],
         'resource_classes': resource_classes,
         'only_one_resource_class': len(resource_classes) == 1,
-        'embed': request.GET.get('embed') is not None,
     }
     add_map_info_to_context(context, instance)
     return context

--- a/opentreemap/treemap/views/misc.py
+++ b/opentreemap/treemap/views/misc.py
@@ -87,6 +87,7 @@ def get_map_view_context(request, instance):
         ],
         'resource_classes': resource_classes,
         'only_one_resource_class': len(resource_classes) == 1,
+        'embed': request.GET.get('embed') is not None,
     }
     add_map_info_to_context(context, instance)
     return context


### PR DESCRIPTION
On map page:
* Add embed context variable.
* Prune header and footer HTML if embed.
* Add an embed class to wrapper.
* Adjust data for Add a Tree or Resource buttons.
* Fix up button anchors
* For embed, don't include the quick edit button.

Style:
* Style adjustments for .wrapper.embed.
* Eliminated ambiguous "map" css class.

JavaScript:
* Save the embed query string parameter in the mapPage.
* If embed is true, fix up the add button's href,
  and let the browser do its thing.
* Change Add to open a new tab or window,
  and preserve zoom.
* Change details links to open a new tab or window.

Add a test to make sure we still get the page when
?embed= is in the query string.

--

Connects to #2736