### PR TITLE
Select single search result, and show empty planting site count

### DIFF
--- a/opentreemap/treemap/ecobenefits.py
+++ b/opentreemap/treemap/ecobenefits.py
@@ -408,13 +408,9 @@ def _annotate_basis_with_extra_stats(basis):
 
 
 def get_benefits_for_filter(filter):
-    allowed_types = filter.instance.map_feature_types
     benefits, basis = {}, {}
 
-    for C in MapFeature.subclass_dict().values():
-        if C.__name__ not in allowed_types:
-            continue
-
+    for C in filter.instance.map_feature_classes:
         ft_benefit_groups, ft_basis = _benefits_for_class(C, filter)
 
         _combine_benefit_basis(basis, ft_basis)

--- a/opentreemap/treemap/ecobenefits.py
+++ b/opentreemap/treemap/ecobenefits.py
@@ -12,7 +12,6 @@ import itertools
 
 from treemap import ecobackend
 from treemap.ecocache import get_cached_benefits
-from treemap.models import MapFeature
 
 WATTS_PER_BTU = 0.29307107
 GAL_PER_CUBIC_M = 264.172052

--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -511,6 +511,18 @@ class Instance(models.Model):
 
         add_default_permissions(self, models=classes)
 
+    @property
+    def map_feature_classes(self):
+        from treemap.models import MapFeature
+        classes = {MapFeature.get_subclass(m)
+                   for m in self.map_feature_types}
+        return classes
+
+    @property
+    def resource_classes(self):
+        from treemap.models import Plot
+        return self.map_feature_classes - {Plot}
+
     def update_geo_rev(self):
         self.update_revs('geo_rev')
 

--- a/opentreemap/treemap/js/src/lib/search.js
+++ b/opentreemap/treemap/js/src/lib/search.js
@@ -230,7 +230,10 @@ exports.init = function(searchStream, applyFilter) {
     // Clear any previous search results
     searchStream.map('').onValue($('#search-results'), 'html');
 
-    searchStream
-        .flatMap(executeSearch)
-        .onValue(updateSearchResults);
+    var completedSearch = searchStream
+        .flatMap(executeSearch);
+
+    completedSearch.onValue(updateSearchResults);
+
+    return completedSearch;
 };

--- a/opentreemap/treemap/js/src/lib/treeMapModes.js
+++ b/opentreemap/treemap/js/src/lib/treeMapModes.js
@@ -81,7 +81,7 @@ function inAddTreeMode()     { return currentMode === addTreeMode; }
 function inEditTreeMode()    { return currentMode === editTreeDetailsMode; }
 function inAddResourceMode() { return currentMode === addResourceMode; }
 
-function init(mapManager, triggerSearchBus, embed) {
+function init(mapManager, triggerSearchBus, embed, completedSearchStream) {
     // browseTreesMode and editTreeDetailsMode share an inlineEditForm,
     // so initialize it here.
     var form = inlineEditForm.init({
@@ -116,6 +116,7 @@ function init(mapManager, triggerSearchBus, embed) {
     browseTreesMode.init({
         map: mapManager.map,
         embed: embed,
+        completedSearchStream: completedSearchStream,
         inMyMode: inBrowseTreesMode,
         $treeDetailAccordionSection: $treeDetailAccordionSection,
         $fullDetailsButton: $fullDetailsButton,

--- a/opentreemap/treemap/js/src/treeMap.js
+++ b/opentreemap/treemap/js/src/treeMap.js
@@ -39,7 +39,12 @@ var mapPage = MapPage.init({
 
     modeChangeStream = mapPage.mapStateChangeStream
         .map('.modeName')
-        .filter(BU.isDefined);
+        .filter(BU.isDefined),
+
+    completedEcobenefitsSearchStream = Search.init(
+        ecoBenefitsSearchEvents,
+        _.bind(mapManager.setFilter, mapManager));
+
 
 modeChangeStream.onValue(changeMode);
 
@@ -71,13 +76,11 @@ $('[data-action="addresource"]').click(function(e) {
     performAdd(e, modes.activateAddResourceMode);
 });
 
-Search.init(
-    ecoBenefitsSearchEvents,
-    _.bind(mapManager.setFilter, mapManager));
-
 buttonEnabler.run();
 
-modes.init(mapManager, triggerSearchFromSidebar, mapPage.embed);
+modes.init(mapManager, triggerSearchFromSidebar, mapPage.embed,
+    completedEcobenefitsSearchStream);
 
-// Read state from current URL, initializing zoom/lat/long/search/mode
+// Read state from current URL, initializing
+// zoom/lat/long/search/mode/selection
 mapPage.initMapState();

--- a/opentreemap/treemap/lib/perms.py
+++ b/opentreemap/treemap/lib/perms.py
@@ -5,7 +5,7 @@ from __future__ import division
 from treemap.lib.object_caches import role_permissions
 
 from django.contrib.gis.db.models import Field
-from treemap.models import InstanceUser, Role, Plot, MapFeature
+from treemap.models import InstanceUser, Role, Plot
 
 """
 Tools to assist in resolving permissions, specifically when the type of

--- a/opentreemap/treemap/lib/perms.py
+++ b/opentreemap/treemap/lib/perms.py
@@ -211,11 +211,8 @@ def any_resource_is_creatable(role_related_obj):
     if role is None:
         return False
 
-    map_features = {MapFeature.get_subclass(m)
-                    for m in role.instance.map_feature_types}
-    resources = map_features - {Plot}
-
-    return any(map_feature_is_creatable(role, Model) for Model in resources)
+    return any(map_feature_is_creatable(role, Model)
+               for Model in role.instance.resource_classes)
 
 
 def geom_is_writable(instanceuser, model_name):

--- a/opentreemap/treemap/templates/treemap/partials/eco_benefits.html
+++ b/opentreemap/treemap/templates/treemap/partials/eco_benefits.html
@@ -2,60 +2,60 @@
 {% load l10n %}
 
 {% if request.instance_supports_ecobenefits %}
-<div {% if not hidecounts %}id="benefit-values"{% endif %} class="benefit-values panel-inner">
-    {% with plot_benefits=benefits.plot %}
-      {% include "treemap/partials/benefit_value_row.html" with benefit=plot_benefits.totals %}
-      {% if not hide_summary and plot_benefits %}
-        <div class="benefit-value-title">{% trans "Tree Benefits"%}</div>
-      {% endif %}
-      {% include "treemap/partials/benefit_value_row.html" with benefit=plot_benefits.energy icon='flash-1' %}
-      {% include "treemap/partials/benefit_value_row.html" with benefit=plot_benefits.stormwater icon='tint' %}
-      {% include "treemap/partials/benefit_value_row.html" with benefit=plot_benefits.airquality icon='cloud' %}
-      {% include "treemap/partials/benefit_value_row.html" with benefit=plot_benefits.co2 %}
-      {% include "treemap/partials/benefit_value_row.html" with benefit=plot_benefits.co2storage %}
-    {% endwith %}
+    <div {% if not hidecounts %}id="benefit-values"{% endif %} class="benefit-values panel-inner">
+        {% with plot_benefits=benefits.plot %}
+            {% include "treemap/partials/benefit_value_row.html" with benefit=plot_benefits.totals %}
+            {% if not hide_summary and plot_benefits %}
+                <div class="benefit-value-title">{% trans "Tree Benefits"%}</div>
+            {% endif %}
+            {% include "treemap/partials/benefit_value_row.html" with benefit=plot_benefits.energy icon='flash-1' %}
+            {% include "treemap/partials/benefit_value_row.html" with benefit=plot_benefits.stormwater icon='tint' %}
+            {% include "treemap/partials/benefit_value_row.html" with benefit=plot_benefits.airquality icon='cloud' %}
+            {% include "treemap/partials/benefit_value_row.html" with benefit=plot_benefits.co2 %}
+            {% include "treemap/partials/benefit_value_row.html" with benefit=plot_benefits.co2storage %}
+        {% endwith %}
 
-    {% with resource_benefits=benefits.resource %}
-      {% if not hide_summary and request.instance.has_resources and resource_benefits %}
-        <div class="benefit-value-title">{{ term.Resource.singular }} {% trans "Benefits" %}</div>
-      {% endif %}
-      {% include "treemap/partials/benefit_value_row.html" with benefit=resource_benefits.stormwater icon='tint' %}
-      {% include "treemap/partials/benefit_value_row.html" with benefit=resource_benefits.runoff_reduced icon='tint' %}
-      {% include "treemap/partials/benefit_value_row.html" with benefit=resource_benefits.usage_reduced icon='tint' %}
-    {% endwith %}
+        {% with resource_benefits=benefits.resource %}
+            {% if not hide_summary and request.instance.has_resources and resource_benefits %}
+                <div class="benefit-value-title">{{ term.Resource.singular }} {% trans "Benefits" %}</div>
+            {% endif %}
+            {% include "treemap/partials/benefit_value_row.html" with benefit=resource_benefits.stormwater icon='tint' %}
+            {% include "treemap/partials/benefit_value_row.html" with benefit=resource_benefits.runoff_reduced icon='tint' %}
+            {% include "treemap/partials/benefit_value_row.html" with benefit=resource_benefits.usage_reduced icon='tint' %}
+        {% endwith %}
 
-    {% if not hide_summary and not hidecounts %}
-    <div class="benefit-tree-count">
-      {% with has_resources=request.instance.has_resources plot_basis=basis.plot resource_basis=basis.resource %}
-        {% blocktrans with used=plot_basis.n_objects_used total=plot_basis.n_total %}
-        Based on {{ used }} out of {{ total }} total trees{% endblocktrans %}{% if not has_resources %}.{% endif %}
-        {% if has_resources %}
-          {% blocktrans with used=resource_basis.n_objects_used total=resource_basis.n_total resources=term.Resource.plural.lower %}
-            and {{ used }} out of {{ total }} total {{ resources }}.
-          {% endblocktrans %}
+        {% if not hide_summary and not hidecounts %}
+            <div class="benefit-tree-count">
+                {% with has_resources=request.instance.has_resources plot_basis=basis.plot resource_basis=basis.resource %}
+                    {% blocktrans with used=plot_basis.n_objects_used total=plot_basis.n_total %}
+                        Based on {{ used }} out of {{ total }} total trees{% endblocktrans %}{% if not has_resources %}.{% endif %}
+                    {% if has_resources %}
+                        {% blocktrans with used=resource_basis.n_objects_used total=resource_basis.n_total resources=term.Resource.plural.lower %}
+                            and {{ used }} out of {{ total }} total {{ resources }}.
+                        {% endblocktrans %}
+                    {% endif %}
+                {% endwith %}
+
+            </div>
         {% endif %}
-      {% endwith %}
-
     </div>
-    {% endif %}
-</div>
 {% endif %}
 {% if not hidecounts %}
-<div id="tree-and-planting-site-counts">
-  {% localize on %}
-  <span id="tree-count">{{ basis.plot.n_total }}</span> {{ tree_count_label }}
-  <span id="planting-site-count">{{ basis.plot.n_plots }}</span> {{ plot_count_label }}
-  {% if request.instance.has_resources and basis.resource %}
-    {% with resource_count=basis.resource.n_total %}
-      <span id="resource-count">{{ resource_count }}</span>
-      {% if resource_count == 1 %}
-        {{ term.Resource.singular.lower }}
-      {% else %}
-        {{ term.Resource.plural.lower }}
-      {% endif %}
-    {% endwith %}
-  {% endif %}
+    <div id="tree-and-planting-site-counts">
+        {% localize on %}
+            <span id="tree-count">{{ basis.plot.n_total }}</span> {{ tree_count_label }}
+            <span id="planting-site-count">{{ basis.plot.n_plots }}</span> {{ plot_count_label }}
+            {% if request.instance.has_resources and basis.resource %}
+                {% with resource_count=basis.resource.n_total %}
+                    <span id="resource-count">{{ resource_count }}</span>
+                    {% if resource_count == 1 %}
+                        {{ term.Resource.singular.lower }}
+                    {% else %}
+                        {{ term.Resource.plural.lower }}
+                    {% endif %}
+                {% endwith %}
+            {% endif %}
 
-  {% endlocalize %}
-</div>
+        {% endlocalize %}
+    </div>
 {% endif %}

--- a/opentreemap/treemap/templates/treemap/partials/eco_benefits.html
+++ b/opentreemap/treemap/templates/treemap/partials/eco_benefits.html
@@ -43,19 +43,16 @@
 {% if not hidecounts %}
     <div id="tree-and-planting-site-counts">
         {% localize on %}
-            <span id="tree-count">{{ basis.plot.n_total }}</span> {{ tree_count_label }}
-            <span id="planting-site-count">{{ basis.plot.n_plots }}</span> {{ plot_count_label }}
-            {% if request.instance.has_resources and basis.resource %}
-                {% with resource_count=basis.resource.n_total %}
-                    <span id="resource-count">{{ resource_count }}</span>
-                    {% if resource_count == 1 %}
-                        {{ term.Resource.singular.lower }}
-                    {% else %}
-                        {{ term.Resource.plural.lower }}
-                    {% endif %}
-                {% endwith %}
+            <span>{{ n_trees }}</span> {{ tree_count_label }}
+            <span>{{ n_empty_plots }}</span> {{ empty_plot_count_label }}
+            {% if has_resources %}
+                <span>{{ n_resources }}</span>
+                {% if n_resources == 1 %}
+                    {{ term.Resource.singular.lower }}
+                {% else %}
+                    {{ term.Resource.plural.lower }}
+                {% endif %}
             {% endif %}
-
         {% endlocalize %}
     </div>
 {% endif %}

--- a/opentreemap/treemap/templates/treemap/partials/eco_benefits.html
+++ b/opentreemap/treemap/templates/treemap/partials/eco_benefits.html
@@ -55,4 +55,14 @@
             {% endif %}
         {% endlocalize %}
     </div>
+
+    {% if single_result %}
+        {% localize off %}
+            <div id="single-result"
+                 data-id="{{ single_result.id }}"
+                 data-lat="{{ single_result.lat }}"
+                 data-lon="{{ single_result.lon }}"
+            ></div>
+        {% endlocalize %}
+    {% endif %}
 {% endif %}

--- a/opentreemap/treemap/tests/ui/uitest_map.py
+++ b/opentreemap/treemap/tests/ui/uitest_map.py
@@ -3,6 +3,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+from time import sleep
+
 from treemap.tests.ui import TreemapUITestCase, ui_test_urls
 from treemap.models import Tree, Plot
 
@@ -176,10 +178,12 @@ class MapTest(TreemapUITestCase):
             self.wait_until_present(
                 'img[src="/static/img/mapmarker_viewmode.png"]')
 
-            self.click_when_visible('#quick-edit-button')
-            self.wait_until_visible('#save-details-button')
+            # Not sure why, but this prevents an intermittent test failure
+            sleep(1)
 
-            diameter = self.driver.find_element_by_css_selector(
+            self.click_when_visible('#quick-edit-button')
+
+            diameter = self.wait_until_visible(
                 'input[data-class="diameter-input"]')
 
             diameter.clear()

--- a/opentreemap/treemap/views/misc.py
+++ b/opentreemap/treemap/views/misc.py
@@ -73,10 +73,7 @@ def index(request, instance):
 def get_map_view_context(request, instance):
     if request.user and not request.user.is_anonymous():
         iuser = request.user.get_instance_user(instance)
-        resource_names = [mfn for mfn in instance.map_feature_types
-                          if mfn != 'Plot']
-        resource_classes = [resource for resource in
-                            map(MapFeature.get_subclass, resource_names)
+        resource_classes = [resource for resource in instance.resource_classes
                             if map_feature_is_creatable(iuser, resource)]
     else:
         resource_classes = []

--- a/opentreemap/treemap/views/misc.py
+++ b/opentreemap/treemap/views/misc.py
@@ -18,7 +18,7 @@ from django.template import RequestContext
 
 from stormwater.models import PolygonalMapFeature
 
-from treemap.models import User, Species, StaticPage, MapFeature, Instance
+from treemap.models import User, Species, StaticPage, Instance
 
 from treemap.plugin import get_viewable_instances_filter
 

--- a/opentreemap/treemap/views/tree.py
+++ b/opentreemap/treemap/views/tree.py
@@ -7,7 +7,7 @@ import hashlib
 
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
-from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext as _, ungettext
 from django.shortcuts import get_object_or_404
 from django.db import transaction
 from django.http import HttpResponseRedirect
@@ -96,11 +96,9 @@ def search_tree_benefits(request, instance):
     n_empty_plots = n_plots - n_trees
     n_resources = 0
 
-    tree_count_label = _('tree') if n_trees == 1 else _('trees')
-    tree_count_label += ','
-    empty_plot_count_label = (
-        _('empty planting site') if n_empty_plots == 1 else
-        _('empty planting sites'))
+    tree_count_label = ungettext('tree', 'trees', n_trees) + ','
+    empty_plot_count_label = ungettext(
+        'empty planting site', 'empty planting sites', n_empty_plots)
     has_resources = instance.has_resources and 'resource' in basis
     if has_resources:
         n_resources = basis['resource']['n_total']
@@ -133,8 +131,6 @@ def _single_result_context(instance, n_plots, n_resources, filter):
                 qs = filter.get_objects(Resource)
                 if qs.count() == 1:
                     break
-        if qs.count() != 1:
-            raise Exception('Failed to retrieve single resource')
         feature = qs[0]
         latlon = feature.geom
         latlon.transform(4326)

--- a/opentreemap/treemap/views/tree.py
+++ b/opentreemap/treemap/views/tree.py
@@ -90,16 +90,33 @@ def search_tree_benefits(request, instance):
     }
 
     formatted = format_benefits(instance, benefits, basis, digits=0)
-    formatted['hide_summary'] = hide_summary
 
-    formatted['tree_count_label'] = (
-        'tree,' if basis['plot']['n_total'] == 1 else 'trees,')
-    formatted['plot_count_label'] = (
-        'planting site' if basis['plot']['n_plots'] == 1 else 'planting sites')
-    if instance.has_resources and 'resource' in basis:
-        formatted['plot_count_label'] += ','
+    n_trees = basis['plot']['n_total']
+    n_plots = basis['plot']['n_plots']
+    n_empty_plots = n_plots - n_trees
+    n_resources = 0
 
-    return formatted
+    tree_count_label = _('tree') if n_trees == 1 else _('trees')
+    tree_count_label += ','
+    empty_plot_count_label = (
+        _('empty planting site') if n_empty_plots == 1 else
+        _('empty planting sites'))
+    has_resources = instance.has_resources and 'resource' in basis
+    if has_resources:
+        n_resources = basis['resource']['n_total']
+        empty_plot_count_label += ','
+
+    context = {
+        'n_trees': n_trees,
+        'n_empty_plots': n_empty_plots,
+        'n_resources': n_resources,
+        'tree_count_label': tree_count_label,
+        'empty_plot_count_label': empty_plot_count_label,
+        'has_resources': has_resources,
+        'hide_summary': hide_summary
+    }
+    context.update(formatted)
+    return context
 
 
 def search_hash(request, instance):


### PR DESCRIPTION
* Show count of empty planting sites rather than total planting sites
* Add helper instance properties `map_feature_classes` and `resource_classes`
* If search returns a single result, select that result

Connects #2772 
Connects #2745