### PR TITLE
Isolate UDF choice renaming

### DIFF
--- a/opentreemap/treemap/udf.py
+++ b/opentreemap/treemap/udf.py
@@ -369,7 +369,8 @@ class UserDefinedFieldDefinition(models.Model):
 
         if self.datatype_dict['type'] == 'choice':
             for model in Model.objects\
-                              .filter(**{self.canonical_name:
+                              .filter(**{'instance': self.instance,
+                                         self.canonical_name:
                                          old_choice_value}):
                 model.udfs[self.name] = new_choice_value
                 model.save_base()


### PR DESCRIPTION
UDF choices were being renamed across instances.

---

##### Testing

If you revert the change to `opentreemap/treemap/udf.py` then run `./scripts/manage.sh test treemap.tests.test_udfs.ScalarUDFInstanceIsolationTest` you should see an assertion fail toward the bottom of the test case.

You can also interactively reproduce the bug after reverting the change to `opentreemap/treemap/udf.py` 

* Create two instances
* Add a single choice field with the same name and same choices to both instances
* Add a tree to both instances and set the same choice value on both trees.
* Rename the choice on one instance, then load the tree detail page on the unchanged instance.