### PR TITLE
[requires.io] dependency update

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
-django-debug-toolbar==1.5
-django-extensions==1.6.1
+django-debug-toolbar==1.5     # https://django-debug-toolbar.readthedocs.io/en/stable/changes.html
+django-extensions==1.7.4
 six==1.10.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,3 @@
+django-debug-toolbar==1.5
 django-extensions==1.6.1
 six==1.10.0
-django-debug-toolbar==1.5

--- a/opentreemap/registration_backend/views.py
+++ b/opentreemap/registration_backend/views.py
@@ -79,11 +79,12 @@ class RegistrationView(DefaultRegistrationView):
 
     def dispatch(self, request, instance_url_name=None, *args, **kwargs):
         if instance_url_name:
-            request.instance = get_instance_or_404(url_name=instance_url_name)
+            self.request.instance = get_instance_or_404(
+                url_name=instance_url_name)
         return super(RegistrationView, self).dispatch(
-            request, *args, **kwargs)
+            self.request, *args, **kwargs)
 
-    def get_success_url(self, request, new_user):
+    def get_success_url(self, new_user):
         """
         If a user already belongs to an instance (i.e. was invited)
         and they have been activated, redirect to that map page
@@ -95,9 +96,9 @@ class RegistrationView(DefaultRegistrationView):
             url = reverse('map', kwargs={'instance_url_name':
                                          instance.url_name})
             return (url, [], {})
-        return super(RegistrationView, self).get_success_url(request, new_user)
+        return super(RegistrationView, self).get_success_url(new_user)
 
-    def register(self, request, form):
+    def register(self, form):
         """
         Register a new user account, inactive user account with the specified
         username, email, and password.
@@ -128,6 +129,7 @@ class RegistrationView(DefaultRegistrationView):
         # if Site._meta.installed:
         #     site = Site.objects.get_current()
         # else:
+        request = self.request
         site = RequestSite(request)
 
         should_email = should_send_user_activation(
@@ -160,7 +162,7 @@ class RegistrationView(DefaultRegistrationView):
 
 
 class ActivationView(DefaultActivationView):
-    def get_success_url(self, request, user):
+    def get_success_url(self, user):
         instanceusers = InstanceUser.objects.filter(user=user)
 
         if instanceusers.exists():
@@ -168,4 +170,4 @@ class ActivationView(DefaultActivationView):
             url = reverse('map', kwargs={'instance_url_name':
                                          instance.url_name})
             return (url, [], {})
-        return super(ActivationView, self).get_success_url(request, user)
+        return super(ActivationView, self).get_success_url(user)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,33 +1,31 @@
 boto==2.38.0
-django-storages==1.1.8
 Django==1.8.8  # rq.filter: >=1.8,<1.9
-Pillow==3.1.0
-gunicorn==19.4.5
-psycopg2==2.6.1
-django-hstore==1.4.1
-wsgiref==0.1.2
-pep8==1.4.6 # rq.filter: ==1.4.6
-flake8==2.0 # rq.filter: ==2.0
-python-omgeo==1.7.2
-django-registration-redux==1.3
-# Modgrammar-py2 has a 0.9.2 release on PyPi, but no artifacts for the release
-modgrammar-py2==0.9.1 # rq.filter: !=0.9.2
-django-celery-with-redis==3.0
-libsass==0.11.1
-# Django comments are no longer bundled with django in
-# 1.6 so we include them here
-django-contrib-comments==1.6.2
-django-threadedcomments==1.0.1
 django-apptemplates==1.0
+django-celery-with-redis==3.0
+django-contrib-comments==1.6.2
+django-hstore==1.4.1
+django-js-reverse==0.7.2
 django-queryset-csv==0.3.2
-python-dateutil==2.4.2
-pytz==2015.7
+django-redis==4.3.0
+django-registration-redux==1.3
+django-statsd-mozilla==0.3.16
+django-storages==1.1.8
+django-threadedcomments==1.0.1
 django-tinsel==0.1.1
 django-url-tools==0.0.8
-django-redis==4.3.0
-hiredis==0.2.0
-rollbar==0.12.1
-django-statsd-mozilla==0.3.16
-django-js-reverse==0.7.2
 django-webpack-loader==0.3.0
+flake8==2.0 # rq.filter: ==2.0
+gunicorn==19.4.5
+hiredis==0.2.0
+libsass==0.11.1
+# Modgrammar-py2 has a 0.9.2 release on PyPi, but no artifacts for the release
+modgrammar-py2==0.9.1 # rq.filter: !=0.9.2
+pep8==1.4.6 # rq.filter: ==1.4.6
+Pillow==3.1.0
+psycopg2==2.6.1
+python-dateutil==2.4.2
+python-omgeo==1.7.2
+pytz==2015.7
+rollbar==0.12.1
 statsd==3.2.1
+wsgiref==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,31 +1,34 @@
-boto==2.38.0
-Django==1.8.8  # rq.filter: >=1.8,<1.9
-django-apptemplates==1.0
+# For outdated module report see https://requires.io/github/OpenTreeMap/otm-core/requirements/?branch=develop
+# Changelog URL shown below if not linked on above page
+
+boto==2.42.0                             # http://docs.pythonboto.org/en/latest/releasenotes/v2.39.0.html
+Django==1.8.14  # rq.filter: >=1.8,<1.9  # https://docs.djangoproject.com/en/1.10/releases/#id2
+django-apptemplates==1.2
 django-celery-with-redis==3.0
-django-contrib-comments==1.6.2
-django-hstore==1.4.1
+django-contrib-comments==1.7.3
+django-hstore==1.4.2
 django-js-reverse==0.7.2
-django-queryset-csv==0.3.2
-django-redis==4.3.0
-django-registration-redux==1.3
+django-queryset-csv==0.3.3               # https://github.com/azavea/django-queryset-csv/commits/master
+django-redis==4.4.4
+django-registration-redux==1.4
 django-statsd-mozilla==0.3.16
-django-storages==1.1.8
+django-storages==1.5.1
 django-threadedcomments==1.0.1
 django-tinsel==0.1.1
 django-url-tools==0.0.8
-django-webpack-loader==0.3.0
+django-webpack-loader==0.3.3             # https://github.com/owais/django-webpack-loader/releases
 flake8==2.0 # rq.filter: ==2.0
-gunicorn==19.4.5
+gunicorn==19.6.0                         # http://docs.gunicorn.org/en/stable/news.html
 hiredis==0.2.0
 libsass==0.11.1
 # Modgrammar-py2 has a 0.9.2 release on PyPi, but no artifacts for the release
 modgrammar-py2==0.9.1 # rq.filter: !=0.9.2
 pep8==1.4.6 # rq.filter: ==1.4.6
-Pillow==3.1.0
-psycopg2==2.6.1
-python-dateutil==2.4.2
-python-omgeo==1.7.2
-pytz==2015.7
-rollbar==0.12.1
+Pillow==3.3.1
+psycopg2==2.6.2                          # http://initd.org/psycopg/docs/news.html
+python-dateutil==2.5.3                   # https://github.com/dateutil/dateutil/blob/master/NEWS
+python-omgeo==1.9.0
+pytz==2016.6.1                           # https://launchpad.net/pytz/+announcements
+rollbar==0.13.3                          # https://github.com/rollbar/pyrollbar/blob/master/CHANGELOG.md
 statsd==3.2.1
 wsgiref==0.1.2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
+coverage==4.0.3
 PyVirtualDisplay==0.1.5
 selenium>=2.53.6,<3.0.0
-coverage==4.0.3

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
-coverage==4.0.3
-PyVirtualDisplay==0.1.5
-selenium>=2.53.6,<3.0.0
+coverage==4.2                # https://coverage.readthedocs.io/en/coverage-4.2/changes.html
+PyVirtualDisplay==0.2        # https://github.com/ponty/PyVirtualDisplay/releases
+selenium>=2.53.6,<3.0.0      # https://github.com/SeleniumHQ/selenium/blob/master/py/CHANGES


### PR DESCRIPTION
Incorporate module updates flagged by `requires.io`. Summary below, and at https://requires.io/github/OpenTreeMap/otm-core/requirements/?branch=develop

Other `requirements.txt` updates:
* Alphabetize (note this is in a separate commit from actual changes)
* Record changelog in comment if not linked by requires.io

Also adjust for breaking change in `django-registration-redux`

Testing as noted below.

Connects #2770
Depends on https://github.com/OpenTreeMap/otm-addons/pull/1241

Module | Old | New | Changes | Comments | Testing
------ | --- | --- | ------- | -------- | -------
boto | 2.38.0 | 2.42.0 | [changes](http://docs.pythonboto.org/en/latest/releasenotes/v2.39.0.html) | Bug fixes and small features | deploy to staging will test
coverage | 4.0.3 | 4.2 | [changes](https://coverage.readthedocs.io/en/coverage-4.2/changes.html) | Significant changes but appear OK and not on our critical path | Coveralls works in PR builder
Django | 1.8.8 | 1.8.14 | [changes](https://docs.djangoproject.com/en/1.10/releases/#id2) | All bug fixes | passive
django-apptemplates | 1.0 | 1.2 | [changes](https://pypi.python.org/pypi/django-apptemplates/) | Changes appear minor | passive
django-contrib-comments | 1.6.2 | 1.7.3 | [changes](https://pypi.python.org/pypi/django-contrib-comments) | Bug fixes, small features, and a change that shouldn't affect us | comments work
django-debug-toolbar | 1.4 | 1.5 | [changes](https://django-debug-toolbar.readthedocs.io/en/stable/changes.html) | Appears safe | toolbar works
django-extensions | 1.6.1 | 1.7.4 | [changes](https://github.com/django-extensions/django-extensions/blob/master/CHANGELOG.md) | Dev tools | `shell_plus` works
django-hstore | 1.4.1 | 1.4.2 | [changes](https://github.com/djangonauts/django-hstore/blob/master/CHANGES.rst) | A few bug fixes  | Edited custom fields and entered stewardship
django-queryset-csv | 0.3.2 | 0.3.3 | [commits](https://github.com/azavea/django-queryset-csv/commits/master) | @steventlamb says it's safe | tree export works
django-redis | 4.3.0 | 4.4.4 | [changes](https://github.com/niwinz/django-redis/blob/master/CHANGES.txt) | One breaking change, to "compression support" which we don't use. | eco cache works
django-registration-redux | 1.3 | 1.4 | [changes](https://django-registration-redux.readthedocs.io/en/latest/upgrade.html) | Breaking change to subclassed views -- updates needed | all registration operations work
django-storages | 1.1.8 | 1.5.1 | [changes](https://pypi.python.org/pypi/django-storages) | Some AWS changes, none breaking | will test image upload on staging
django-webpack-loader | 0.3.0 | 0.3.3 | [notes](https://github.com/owais/django-webpack-loader/releases) | Changes appear minor | passive
gunicorn | 19.4.5 | 19.6.0 | [changes](http://docs.gunicorn.org/en/stable/news.html) | Many fixes, should be safe | passive
Pillow | 3.1.0 | 3.3.1 | [changes](https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst) | Many fixes and additions, but easy to test our limited use | rotation works
psycopg2 | 2.6.1 | 2.6.2 | [changes](http://initd.org/psycopg/docs/news.html) | Bug fixes | passive
python-dateutil | 2.4.2 | 2.5.3 | [changes](https://github.com/dateutil/dateutil/blob/master/NEWS) | Changes appear safe for our limited use (`relativedelta`, `parse` in otm1 migrator) ... worth testing subscription expiration dates | suspend / cancel works
python-omgeo | 1.7.2 | 1.9.0 | [changes](https://github.com/azavea/python-omgeo/blob/master/CHANGES.rst) | no fixes, 2 new features | choosing autocompleted address works
pytz | 2015.7 | 2016.6.1 | [changes](https://launchpad.net/pytz/+announcements) | Couldn't find applicable change doc, but recent changes are minor | passive
PyVirtualDisplay | 0.1.5 | 0.2 | [releases](https://github.com/ponty/PyVirtualDisplay/releases) | Appears safe | UI tests pass
rollbar | 0.11.1 | 0.13.3 | [changes](https://github.com/rollbar/pyrollbar/blob/master/CHANGELOG.md) | Changes appear safe. Verify it still works. | dev exceptions logged correctly
selenium | 2.49.0 | 2.53.6 | [changes](https://github.com/SeleniumHQ/selenium/blob/master/py/CHANGES) | Try UI tests | UI tests pass
