### PR TITLE
Refactor stats bar to be more responsive on small-medium screen sizes

### DIFF
--- a/assets/css/sass/partials/_header.scss
+++ b/assets/css/sass/partials/_header.scss
@@ -157,3 +157,30 @@
 .udfc {
     right: 0;
 }
+
+// Disabled links get wrapped in labels, and we need to override
+// the styling for them to behave like an anchor tag
+.btn-group > label {
+    position: relative;
+    float: left;
+
+    &:first-child {
+        margin-left: 0;
+
+        &:not(:last-child) > .btn:not(.dropdown-toggle) {
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0
+        }
+    }
+}
+.dropdown-menu li > label {
+    display: block;
+    clear: both;
+
+    > a {
+        padding: 3px 20px;
+        font-weight: normal;
+        line-height: 1.42857143;
+        color: #333;
+    }
+}

--- a/assets/css/sass/partials/_layout.scss
+++ b/assets/css/sass/partials/_layout.scss
@@ -46,15 +46,8 @@ body {
         right: 350px;
         bottom: 40px;
 
-        @media(min-width: 990px){
-            top: 196px;
-        }
-
         @media #{$screen-gtxs} {
-            .embed & {
-                bottom: 0;
-                top: 147px;
-            }
+            top: 196px;
         }
 
         @media #{$screen-xs} {
@@ -63,8 +56,8 @@ body {
             overflow: auto;
 
             .embed & {
-                bottom: 0;
-                top: 98px;
+                bottom: 0 !important;
+                top: 98px !important;
             }
 
             .map {

--- a/assets/css/sass/partials/_layout.scss
+++ b/assets/css/sass/partials/_layout.scss
@@ -39,15 +39,16 @@ body {
         position: absolute;
         overflow: hidden;
         margin: 0;
-        top: 244px;
+        top: 196px;
         width: 100%;
 
         left: 0;
         right: 350px;
         bottom: 40px;
 
-        @media #{$screen-gtxs} {
-            top: 196px;
+        .embed & {
+            bottom: 0;
+            top: 141px;
         }
 
         @media #{$screen-xs} {
@@ -56,18 +57,13 @@ body {
             overflow: auto;
 
             .embed & {
-                bottom: 0 !important;
-                top: 98px !important;
+                bottom: 0;
+                top: 98px;
             }
 
             .map {
                 height: 300px;
             }
-        }
-
-        .embed & {
-            bottom: 0;
-            top: 141px;
         }
     }
 }

--- a/assets/css/sass/partials/_navbar.scss
+++ b/assets/css/sass/partials/_navbar.scss
@@ -78,10 +78,6 @@
                                     color: $primary-color;
                                 }
                             }
-                            &:first-child {
-                                border-bottom: 1px solid #EEE;
-                            }
-
                             > i {
                                 margin-right: 5px;
                                 top: 2px;

--- a/assets/css/sass/partials/_subheader.scss
+++ b/assets/css/sass/partials/_subheader.scss
@@ -187,32 +187,32 @@
         span {
             font-weight: bold;
         }
-
-        .half{
-            display: inline;
-            width: inherit;
+        .stats-list {
+            display: block;
+            width: 100%;
             padding: 0px;
 
-            label{
-                float: right;
+            .exportBtn {
+                margin-left: 10px;
+                margin-top: -12px;
+                width: 135px;
+                display: inline-block;
+            }
+            #tree-and-planting-site-counts {
+                height: 22px;
+                // 305px is approximately the size of the export button + the add tree button group + margins
+                // as determined from trial-and-error.
+                max-width: calc(100% - 305px);
+                display: inline-block;
+                overflow: hidden;
+                white-space: nowrap;
+                text-overflow: ellipsis;
             }
         }
-
-        .exportBtn {
-            margin-left: 10px;
-            margin-top: -2px;
-        }
-
         .addBtn {
+            display: inline;
             float: right;
-            margin-top: -6px;
-            margin-left: 8px;
-
-            i {
-                position: relative;
-                left: -4px;
-                top: 0;
-            }
+            margin-top: -33px;
         }
     }
 }

--- a/opentreemap/treemap/js/src/lib/addResourceMode.js
+++ b/opentreemap/treemap/js/src/lib/addResourceMode.js
@@ -38,10 +38,10 @@ function init(options) {
     manager.addFeatureStream.onValue(initSteps);
     manager.deactivateStream.onValue(initSteps);
 
-    activateMode = function() {
+    activateMode = function(type) {
         manager.activate();
         plotMarker.useTreeIcon(false);
-        initSteps();
+        initSteps(type);
     };
 
     deactivateMode = function () {
@@ -120,11 +120,15 @@ function init(options) {
         U.$find('select', $form).on('change', enableFinalStep);
     }
 
-    function initSteps() {
+    function initSteps(type) {
         plotMarker.hide();
         editor.removeAreaPolygon();
         hideSubquestions();
-        if (onlyOneResourceType) {
+        var $type = _.isUndefined(type) ? $() : $resourceType.filter('[value="' + type + '"]');
+        if ($type.length === 1) {
+            $type.prop('checked', true);
+            onResourceTypeChosen();
+        } else if (onlyOneResourceType) {
             onResourceTypeChosen();
         } else {
             $resourceType.prop('checked', false);
@@ -188,8 +192,8 @@ function init(options) {
     }
 }
 
-function activate() {
-    activateMode();
+function activate(type) {
+    activateMode(type);
 }
 
 function deactivate() {

--- a/opentreemap/treemap/js/src/lib/baconUtils.js
+++ b/opentreemap/treemap/js/src/lib/baconUtils.js
@@ -48,6 +48,10 @@ exports.isPropertyUndefined = function(key) {
     return R.or(isUndefined, R.compose(isUndefined, getValueForKey(key)));
 };
 
+exports.isPropertyDefined = function(key) {
+    return R.and(isDefined, R.compose(isDefined, getValueForKey(key)));
+};
+
 exports.fetchFromIdStream = function (idStream, fetchFn, undefinedMapping, errorMapping) {
     return Bacon.mergeAll(
         idStream

--- a/opentreemap/treemap/js/src/lib/treeMapModes.js
+++ b/opentreemap/treemap/js/src/lib/treeMapModes.js
@@ -19,7 +19,7 @@ var $                   = require('jquery'),
     plotMarker          = require('treemap/lib/plotMarker.js'),
     statePrompter       = require('treemap/lib/statePrompter.js'),
     prompter,
-    currentMode;
+    currentMode, currentType;
 
 var sidebarBrowseTrees          = '#sidebar-browse-trees',
     sidebarAddTree              = '#sidebar-add-tree',
@@ -30,7 +30,7 @@ var sidebarBrowseTrees          = '#sidebar-browse-trees',
     $exploreMapHeaderLink       = U.$find('.navbar li.explore-map'),
     $addFeatureHeaderLink       = U.$find('.navbar li[data-feature=add_plot]');
 
-function activateMode(mode, sidebar, safeTransition) {
+function activateMode(mode, sidebar, safeTransition, type) {
 
     // each mode activator takes an argument that determines
     // whether or not to lock the prompter, or in other words,
@@ -39,7 +39,7 @@ function activateMode(mode, sidebar, safeTransition) {
     if (safeTransition === true) {
         prompter.unlock();
     }
-    if (mode !== currentMode &&
+    if ((mode !== currentMode || type !== currentType) &&
         prompter.canProceed()) {
         if (currentMode && currentMode.deactivate) {
             currentMode.deactivate();
@@ -47,7 +47,7 @@ function activateMode(mode, sidebar, safeTransition) {
         $(sidebar).siblings().hide();
         $(sidebar).show();
         if (mode.activate) {
-            mode.activate();
+            mode.activate(type);
         }
 
         // lockOnActivate will specify whether to leave the
@@ -59,7 +59,9 @@ function activateMode(mode, sidebar, safeTransition) {
             prompter.unlock();
         }
         urlState.setModeName(mode.name);
+        urlState.setModeType(type);
         currentMode = mode;
+        currentType = type;
     }
 }
 
@@ -72,8 +74,8 @@ function activateAddTreeMode(safeTranstion) {
 function activateEditTreeDetailsMode(safeTranstion) {
     activateMode(editTreeDetailsMode, sidebarBrowseTrees, safeTranstion);
 }
-function activateAddResourceMode(safeTranstion) {
-    activateMode(addResourceMode, sidebarAddResource, safeTranstion);
+function activateAddResourceMode(safeTranstion, type) {
+    activateMode(addResourceMode, sidebarAddResource, safeTranstion, type);
 }
 
 function inBrowseTreesMode() { return currentMode === browseTreesMode; }

--- a/opentreemap/treemap/js/src/lib/urlState.js
+++ b/opentreemap/treemap/js/src/lib/urlState.js
@@ -80,6 +80,12 @@ var serializers = {
         if (state.modeName) {
             query.m = state.modeName;
         }
+    },
+
+    modeType: function(state, query) {
+        if (state.modeType) {
+            query.t = state.modeType;
+        }
     }
 };
 
@@ -111,6 +117,10 @@ var deserializers = {
 
     m: function(newState, query) {
         newState.modeName = query.m || '';
+    },
+
+    t: function(newState, query) {
+        newState.modeType = query.t || '';
     }
 };
 
@@ -137,9 +147,9 @@ function set(key, value, options) {
         }
 
         if (options.replaceState) {
-            _history.replaceState(newState, document.title, getUrlFromState(newState));
+            _history.replaceState(newState, '', getUrlFromState(newState));
         } else {
-            _history.pushState(newState, document.title, getUrlFromState(newState));
+            _history.pushState(newState, '', getUrlFromState(newState));
         }
     }
 }
@@ -180,6 +190,13 @@ module.exports = {
     setModeName: function (modeName) {
         modeName = _.contains(modeNamesForUrl, modeName) ? modeName : '';
         set('modeName', modeName, {
+            silent: true,
+            replaceState: true
+        });
+    },
+
+    setModeType: function (modeType) {
+        set('modeType', modeType, {
             silent: true,
             replaceState: true
         });

--- a/opentreemap/treemap/js/src/treeMap.js
+++ b/opentreemap/treemap/js/src/treeMap.js
@@ -13,13 +13,16 @@ var $ = require('jquery'),
     modes = require('treemap/lib/treeMapModes.js'),
     Search = require('treemap/lib/search.js');
 
-function changeMode (modeName) {
+function changeMode (modeOptions) {
+    var modeName = modeOptions.modeName,
+        type = modeOptions.modeType;
+
     if (modeName === addTreeModeName) {
-        modes.activateAddTreeMode();
+        modes.activateAddTreeMode(false);
     } else if (modeName === addResourceModeName) {
-        modes.activateAddResourceMode();
+        modes.activateAddResourceMode(false, type);
     } else {
-        modes.activateBrowseTreesMode();
+        modes.activateBrowseTreesMode(false);
     }
 }
 
@@ -38,8 +41,7 @@ var mapPage = MapPage.init({
         ),
 
     modeChangeStream = mapPage.mapStateChangeStream
-        .map('.modeName')
-        .filter(BU.isDefined),
+        .filter(BU.isPropertyDefined('modeName')),
 
     completedEcobenefitsSearchStream = Search.init(
         ecoBenefitsSearchEvents,
@@ -49,12 +51,14 @@ var mapPage = MapPage.init({
 modeChangeStream.onValue(changeMode);
 
 var performAdd = function (e, addFn) {
+    var btn = e.target;
+
     if (!mapPage.embed) {
+        var type = $(btn).attr('data-class');
         e.preventDefault();
-        addFn();
+        addFn(false, type);
     } else {
-        var btn = e.target,
-            href = btn.href,
+        var href = btn.href,
             parsedHref = url.parse(href, true),
             currentLocation = url.parse(location.href, true),
             adjustedQuery = _.chain({})

--- a/opentreemap/treemap/templates/instance_base.html
+++ b/opentreemap/treemap/templates/instance_base.html
@@ -36,21 +36,7 @@ ga('set', 'page', pathname);
       <a class="dropdown-toggle" data-toggle="dropdown">
         <i class="icon-plus-circled"></i>
       </a>
-      <ul class="dropdown-menu">
-        <li>
-          <a data-href="{% url 'map' instance_url_name=request.instance.url_name %}?m=addTree"
-             data-always-enable="{{ last_effective_instance_user|plot_is_creatable }}"
-             data-disabled-title='{% trans "Adding trees is not available to all users" %}'
-             data-event-category="add-tree" data-event-action="start-add-tree"
-             data-action='addtree'>{% trans "Add a Tree" %}</a>
-        </li>
-        <li>
-          <a data-href="{% url 'map' instance_url_name=request.instance.url_name %}?m=addResource"
-             data-always-enable="{{ last_effective_instance_user|any_resource_is_creatable }}"
-             data-disabled-title='{% blocktrans with resources=term.Resource.plural %}Adding {{ resources }} is not available to all users{% endblocktrans %}'
-             data-action='addresource'>{% trans "Add a" %} {{ term.Resource.singular }}</a>
-        </li>
-      </ul>
+      {% include "treemap/partials/add_feature_menu.html" with dropdown_class="dropdown-menu-left" include_tree=True %}
     </li>
   {% else %}
     <li data-feature="add_plot">
@@ -134,8 +120,8 @@ ga('set', 'page', pathname);
   {% endif %}
 
   <div class="stats-bar hidden-xs">
-    <div class="half">
-      <div style="display: inline;" id="tree-and-planting-site-counts">
+    <div class="stats-list">
+      <div id="tree-and-planting-site-counts">
       </div>
       {% if not embed %}
         {% block subhead_exports %}
@@ -148,31 +134,20 @@ ga('set', 'page', pathname);
         {% endblock subhead_exports %}
       {% endif %}
     </div>
-    <div class="half">
+    <div class="addBtn">
       {% if request.instance|feature_enabled:'add_plot' and last_effective_instance_user %}
         {% if request.instance.has_resources %}
-        <a class="btn btn-primary addBtn"
-           {% if embed %}target="_blank"{% endif %}
-           data-action='addresource'
-           data-always-enable="{{ last_effective_instance_user|any_resource_is_creatable }}"
-           data-disabled-title=
-             "{% blocktrans with resources=term.Resource.plural.lower %}Adding {{ resources }} is not available to all users {% endblocktrans %}"
-           data-href="{% url 'map' instance_url_name=request.instance.url_name %}?m=addResource"
-           disabled="disabled"><i class="icon-plus"></i> {% trans "Add a" %} {{ term.Resource.singular }}</a>
+          <div class="btn-group">
+            {% include "treemap/partials/add_plot_btn.html" %}
+            <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <span class="caret"></span>
+              <span class="sr-only">Toggle Dropdown</span>
+            </button>
+            {% include "treemap/partials/add_feature_menu.html" with dropdown_class="dropdown-menu-right" %}
+          </div>
+        {% else %}
+          {% include "treemap/partials/add_plot_btn.html" %}
         {% endif %}
-      <a class="btn btn-primary addBtn"
-         {% if embed %}
-         target="_blank"
-         {% else %}
-         data-feature="add_plot"
-         data-event-category="add-tree"
-         data-event-action="start-add-tree"
-         {% endif %}
-         data-action='addtree'
-         data-always-enable="{{ last_effective_instance_user|plot_is_creatable }}"
-         data-disabled-title="{% trans "Adding trees is not available to all users" %}"
-         data-href="{% url 'map' instance_url_name=request.instance.url_name %}?m=addTree"
-         disabled="disabled"><i class="icon-plus"></i> {% trans "Add a Tree" %}</a>
       {% endif %}
     </div>
   </div>

--- a/opentreemap/treemap/templates/treemap/partials/add_feature_menu.html
+++ b/opentreemap/treemap/templates/treemap/partials/add_feature_menu.html
@@ -1,0 +1,38 @@
+{% load i18n %}
+{% load instance_config %}
+{% load util %}
+<ul class="dropdown-menu {{ dropdown_class }}">
+  {% if include_tree %}
+    <li>
+      <a data-always-enable="{{ last_effective_instance_user|plot_is_creatable }}"
+         data-disabled-title='{% trans "Adding trees is not available to all users" %}'
+         {% if embed %}
+         target="_blank"
+         {% else %}
+         data-event-category="add-tree" data-event-action="start-add-tree"
+         data-action='addtree'
+         {% endif %}
+         data-href="{% url 'map' instance_url_name=request.instance.url_name %}?m=addTree">
+          {% trans "Add a Tree" %}
+      </a>
+    </li>
+    <li role="separator" class="divider"></li>
+  {% endif %}
+  {% for Resource in request.instance.resource_classes %}
+    {% with res_term=Resource|terminology:request.instance %}
+      <li>
+        <a data-always-enable="{{ last_effective_instance_user|any_resource_is_creatable }}"
+           data-disabled-title='{% blocktrans with resources=res_term.plural %}Adding {{ resources }} is not available to all users{% endblocktrans %}'
+           {% if embed %}
+           target="_blank"
+           {% else %}
+           data-action='addresource'
+           data-class='{{ Resource.map_feature_type }}'
+           {% endif %}
+           data-href="{% url 'map' instance_url_name=request.instance.url_name %}?m=addResource&t={{ Resource.map_feature_type }}">
+            {% trans "Add a" %} {{ res_term.singular }}
+        </a>
+      </li>
+    {% endwith %}
+  {% endfor %}
+</ul>

--- a/opentreemap/treemap/templates/treemap/partials/add_plot_btn.html
+++ b/opentreemap/treemap/templates/treemap/partials/add_plot_btn.html
@@ -1,0 +1,15 @@
+{% load i18n %}
+{% load instance_config %}
+<a class="btn btn-primary"
+   {% if embed %}
+   target="_blank"
+   {% else %}
+   data-feature="add_plot"
+   data-event-category="add-tree"
+   data-event-action="start-add-tree"
+   {% endif %}
+   data-action='addtree'
+   data-always-enable="{{ last_effective_instance_user|plot_is_creatable }}"
+   data-disabled-title="{% trans "Adding trees is not available to all users" %}"
+   data-href="{% url 'map' instance_url_name=request.instance.url_name %}?m=addTree"
+   disabled="disabled"><i class="icon-plus"></i> {% trans "Add a Tree" %}</a>

--- a/opentreemap/treemap/tests/ui/__init__.py
+++ b/opentreemap/treemap/tests/ui/__init__.py
@@ -240,7 +240,7 @@ class TreemapUITestCase(UITestCase):
 
     def click_add_tree(self):
         # Enter add tree mode
-        self.click(".subhead .addBtn")
+        self.click('.subhead [data-feature="add_plot"]')
 
     def _click_add_tree_next_step(self, n):
         button = self.driver.find_elements_by_css_selector(


### PR DESCRIPTION
 -  Fixes responsive styling issue with gray bar on screens smaller than 990px
 -  Combines add tree and add resource buttons into a single button group

![screenshot](https://cloud.githubusercontent.com/assets/4432106/18687097/8dbef334-7f4c-11e6-8247-b19f02c3ab8c.png)

With these changes, it should not be possible for items to overlap or get pushed down in the header, no matter the screen size or the length of the "resources" terminology.

Connects to #2737