### PR TITLE
Enable search by Custom ID & missing Custom ID

### DIFF
--- a/opentreemap/treemap/DotDict.py
+++ b/opentreemap/treemap/DotDict.py
@@ -62,7 +62,7 @@ class DotDict(dict):
         if '.' not in key:
             return dict.__contains__(self, key)
         myKey, restOfKey = key.split('.', 1)
-        target = dict.__getitem__(self, myKey)
+        target = dict.get(self, myKey)
         if not isinstance(target, DotDict):
             return False
         return restOfKey in target

--- a/opentreemap/treemap/migrations/0031_add_custom_id_to_default_search_fields.py
+++ b/opentreemap/treemap/migrations/0031_add_custom_id_to_default_search_fields.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from copy import deepcopy
+
+from django.db import migrations
+
+from treemap.DotDict import DotDict
+
+
+identifier = u'plot.owner_orig_id'
+
+
+def update_config_property(apps, update_fn, prop_name, *categories):
+    Instance = apps.get_model("treemap", "Instance")
+    filter_pattern = '\"{}\":'.format(prop_name)
+    for instance in Instance.objects.filter(config__contains=filter_pattern):
+        instance.config = update_fn(instance.config, prop_name, *categories)
+        instance.save()
+
+
+def is_in_values(specs, pattern):
+    values = [spec.values() for spec in specs]
+    return True in [pattern in v for v in values]
+
+
+def add_to_config(config, prop_name, *categories):
+    config = deepcopy(config or DotDict({}))
+    for category in categories:
+        lookup = '.'.join([prop_name, category])
+        specs = config.setdefault(lookup, [])
+        if not is_in_values(specs, identifier):
+            # mutates config[lookup]
+            specs.append({u'identifier': identifier})
+
+    return config
+
+
+def add_custom_id_forward(apps, schema_editor):
+    update_config_property(apps, add_to_config, 'search_config',
+                           'Plot', 'missing')
+    update_config_property(apps, add_to_config, 'mobile_search_fields',
+                           'standard', 'missing')
+
+
+def remove_from_config(config, prop_name, *categories):
+    config = deepcopy(config or DotDict({}))
+    for category in categories:
+        lookup = '.'.join([prop_name, category])
+        specs = config.get(lookup)
+        if specs:
+            for index, spec in enumerate(specs):
+                if identifier in spec.values():
+                    break
+            if index < len(specs):
+                specs.pop(index)
+
+    return config
+
+
+def add_custom_id_backward(apps, schema_editor):
+    update_config_property(apps, remove_from_config, 'search_config',
+                           'Plot', 'missing')
+    update_config_property(apps, remove_from_config, 'mobile_search_fields',
+                           'standard', 'missing')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0030_add_verbose_name_to_owner_orig_id'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_custom_id_forward, add_custom_id_backward),
+    ]

--- a/opentreemap/treemap/search_fields.py
+++ b/opentreemap/treemap/search_fields.py
@@ -13,33 +13,39 @@ import re
 from treemap.DotDict import DotDict
 from treemap.lib.object_caches import udf_defs
 
-DEFAULT_MOBILE_SEARCH_FIELDS = {
+DEFAULT_MOBILE_SEARCH_FIELDS = DotDict({
     'standard': [
         {'identifier': 'species.id'},
         {'identifier': 'tree.diameter'},
-        {'identifier': 'tree.height'}
+        {'identifier': 'tree.height'},
+        {'identifier': 'plot.owner_orig_id'}
     ],
     'missing': [
         {'identifier': 'species.id'},
         {'identifier': 'tree.diameter'},
-        {'identifier': 'mapFeaturePhoto.id'}
+        {'identifier': 'mapFeaturePhoto.id'},
+        {'identifier': 'plot.owner_orig_id'}
     ]
-}
+})
 
-DEFAULT_SEARCH_FIELDS = {
+DEFAULT_SEARCH_FIELDS = DotDict({
     'general': [
         {'identifier': 'mapFeature.updated_at'}
     ],
     'missing': [
         {'identifier': 'species.id'},
         {'identifier': 'tree.diameter'},
+        {'identifier': 'plot.owner_orig_id'},
         {'identifier': 'mapFeaturePhoto.id'}
+    ],
+    'Plot': [
+        {'identifier': 'plot.owner_orig_id'}
     ],
     'Tree': [
         {'identifier': 'tree.diameter'},
-        {'identifier': 'tree.date_planted'},
+        {'identifier': 'tree.date_planted'}
     ]
-}
+})
 
 DEFAULT_MOBILE_API_FIELDS = (
     {'header': ugettext_noop('Tree Information'),

--- a/opentreemap/treemap/search_fields.py
+++ b/opentreemap/treemap/search_fields.py
@@ -17,14 +17,12 @@ DEFAULT_MOBILE_SEARCH_FIELDS = DotDict({
     'standard': [
         {'identifier': 'species.id'},
         {'identifier': 'tree.diameter'},
-        {'identifier': 'tree.height'},
-        {'identifier': 'plot.owner_orig_id'}
+        {'identifier': 'tree.height'}
     ],
     'missing': [
         {'identifier': 'species.id'},
         {'identifier': 'tree.diameter'},
-        {'identifier': 'mapFeaturePhoto.id'},
-        {'identifier': 'plot.owner_orig_id'}
+        {'identifier': 'mapFeaturePhoto.id'}
     ]
 })
 


### PR DESCRIPTION
Search by Custom ID and by missing Custom ID should be enabled
by default, for all treemap instances.

Changes
=======

## 0031_add_custom_id_to_default_search_fields.py
   Data migration to add the Custom ID internal identifier (`plot.owner_orig_id`) to every instance that already has a `search_config` or `mobile_search_fields` config property, with its reverse.

## treemap.search_fields.py
   Add `plot.owner_orig_id` to default search fields, and make default search fields `DotDict`s so that `instance.search_config` and `instance.mobile_search_fields` return the same type whether explicitly configured or not.

## treemap.DotDict.py
   Fix `DotDict().setdefault` to work for dotted keys.

--

Connects to #2769