### PR TITLE
Fix advanced search category highlighting

### DIFF
--- a/opentreemap/treemap/js/src/lib/searchBar.js
+++ b/opentreemap/treemap/js/src/lib/searchBar.js
@@ -181,13 +181,15 @@ function updateActiveSearchIndicators(search) {
             var featureName = key.split('.')[0],
                 featureCategories = ['tree', 'plot', 'mapFeature'],
                 simpleSearchKeys = ['species.id', 'mapFeature.geom'],
-                displayedFeatures = _.map(search.display, R.toLower);
+                displayedFeatures = _.map(search.display, function (s) {
+                    return s.toLowerCase();
+                });
             if (_.contains(simpleSearchKeys, key)) {
                 // do not add filter categories for search fields that are not
                 // part of the advanced search.
                 return false;
             } else if (_.contains(featureCategories, featureName)) {
-                if (!hasDisplayFilters(search) || _.contains(displayedFeatures, featureName)) {
+                if (!hasDisplayFilters(search) || _.contains(displayedFeatures, featureName) || featureName === 'mapFeature') {
                     return featureName;
                 } else {
                     return false; // feature filter is disabled by display filter


### PR DESCRIPTION
The "Tree" category wasn't being highlighted because the expression `_.map(search.display, R.toLower)` should have said `R.toLowerCase`, however after making that change it still failed so I wrote it using the native JS `toLowerCase`.

The "General" category wasn't being highlighted because the "Last Updated" filter has a `featureName` of `mapFeature` which wasn't accounted for in the comparison to display filters. (There is no display filter for `maspFeature` since everything is a `mapFeature`). I added a case for that.

Connects #2433