### PR TITLE
Header login link preserves current page

### DIFF
--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -535,7 +535,11 @@ class InstanceUser(Auditable, models.Model):
         self.save_with_user(system_user, *args, **kwargs)
 
     def __unicode__(self):
-        return '%s/%s' % (self.user.get_username(), self.instance.name)
+        # protect against not being logged in
+        username = ''
+        if getattr(self, 'user', None) is not None:
+            username = self.user.get_username() + '/'
+        return '%s%s' % (username, self.instance.name)
 
 post_save.connect(invalidate_adjuncts, sender=InstanceUser)
 post_delete.connect(invalidate_adjuncts, sender=InstanceUser)

--- a/opentreemap/treemap/templates/base.html
+++ b/opentreemap/treemap/templates/base.html
@@ -1,4 +1,5 @@
 {% load i18n %}
+{% load auth_extras %}
 {% load render_bundle from webpack_loader %}
 {% load instance_config %}
 {% load js_reverse %}
@@ -110,7 +111,7 @@
                 </ul>
               </li>
             {% else %}
-              <li class="hidden-xs"><a id="login" href="{% url 'auth_login' %}">{% trans "Login" %}</a></li>
+              <li class="hidden-xs"><a id="login" href="{% url 'auth_login' %}?{% login_forward %}">{% trans "Login" %}</a></li>
               {% block signup %}
               <li class="hidden-xs"><a href="{% url 'registration_register' %}">{% trans "Sign Up" %}</a></li>
               {% endblock signup %}
@@ -119,7 +120,7 @@
                   <i class="icon-cog"></i>
                 </a>
                 <ul class="dropdown-menu dropdown-pull-left">
-                  <li><a id="login" href="{% url 'auth_login' %}">{% trans "Login" %}</a></li>
+                  <li><a id="login" href="{% url 'auth_login' %}?{% login_forward %}">{% trans "Login" %}</a></li>
                   {% block signup_small %}
                   <li><a href="{% url 'registration_register' %}">{% trans "Sign Up" %}</a></li>
                   {% endblock signup_small %}

--- a/opentreemap/treemap/templates/base.html
+++ b/opentreemap/treemap/templates/base.html
@@ -111,7 +111,7 @@
                 </ul>
               </li>
             {% else %}
-              <li class="hidden-xs"><a id="login" href="{% url 'auth_login' %}?{% login_forward %}">{% trans "Login" %}</a></li>
+              <li class="hidden-xs"><a id="login" href="{% url 'auth_login' %}{% login_forward %}">{% trans "Login" %}</a></li>
               {% block signup %}
               <li class="hidden-xs"><a href="{% url 'registration_register' %}">{% trans "Sign Up" %}</a></li>
               {% endblock signup %}
@@ -120,7 +120,7 @@
                   <i class="icon-cog"></i>
                 </a>
                 <ul class="dropdown-menu dropdown-pull-left">
-                  <li><a id="login" href="{% url 'auth_login' %}?{% login_forward %}">{% trans "Login" %}</a></li>
+                  <li><a id="login" href="{% url 'auth_login' %}{% login_forward %}">{% trans "Login" %}</a></li>
                   {% block signup_small %}
                   <li><a href="{% url 'registration_register' %}">{% trans "Sign Up" %}</a></li>
                   {% endblock signup_small %}

--- a/opentreemap/treemap/templates/treemap/partials/map_feature_detail_base.html
+++ b/opentreemap/treemap/templates/treemap/partials/map_feature_detail_base.html
@@ -4,6 +4,7 @@
 {% load l10n %}
 {% load util %}
 {% load staticfiles %}
+{% load auth_extras %}
 
 <div class="detail-header">
     {% if request.instance.is_public %}
@@ -131,7 +132,7 @@
         {% endfor %}
         {% if not request.user.is_authenticated %}
             <p><a href="{% url 'registration_register' %}">{% trans "Sign Up" %}</a>
-                {% trans "or" %} <a href="{% url 'auth_login' %}">{% trans "log in" %}</a>
+                {% trans "or" %} <a href="{% url 'auth_login' %}?{% login_forward %}">{% trans "log in" %}</a>
                 {% trans "to add comments" %}</p>
         {% endif %}
     </div>

--- a/opentreemap/treemap/templates/treemap/partials/map_feature_detail_base.html
+++ b/opentreemap/treemap/templates/treemap/partials/map_feature_detail_base.html
@@ -132,7 +132,7 @@
         {% endfor %}
         {% if not request.user.is_authenticated %}
             <p><a href="{% url 'registration_register' %}">{% trans "Sign Up" %}</a>
-                {% trans "or" %} <a href="{% url 'auth_login' %}?{% login_forward %}">{% trans "log in" %}</a>
+                {% trans "or" %} <a href="{% url 'auth_login' %}{% login_forward %}">{% trans "log in" %}</a>
                 {% trans "to add comments" %}</p>
         {% endif %}
     </div>

--- a/opentreemap/treemap/tests/__init__.py
+++ b/opentreemap/treemap/tests/__init__.py
@@ -300,7 +300,8 @@ def create_mock_system_user():
 
 
 def make_request(params={}, user=None, instance=None,
-                 method='GET', body=None, file=None):
+                 method='GET', body=None, file=None,
+                 path='hello/world'):
     if user is None:
         user = AnonymousUser()
 
@@ -312,9 +313,9 @@ def make_request(params={}, user=None, instance=None,
 
     if file:
         post_data = {'file': file}
-        req = RequestFactory().post("hello/world", post_data, **extra)
+        req = RequestFactory().post(path, post_data, **extra)
     else:
-        req = RequestFactory().get("hello/world", params, **extra)
+        req = RequestFactory().get(path, params, **extra)
         req.method = method
 
     setattr(req, 'user', user)

--- a/opentreemap/treemap/util.py
+++ b/opentreemap/treemap/util.py
@@ -97,12 +97,9 @@ def get_last_visited_instance(request):
     return instance
 
 
-def login_redirect(request):
+def get_login_redirect_path(request, resolved_login_url):
     # Reference: django/contrib/auth/decorators.py
     path = request.build_absolute_uri()
-    # urlparse chokes on lazy objects in Python 3, force to str
-    resolved_login_url = force_str(
-        resolve_url(settings.LOGIN_URL))
     # If the login url is the same scheme and net location then just
     # use the path as the "next" url.
     login_scheme, login_netloc = urlparse(resolved_login_url)[:2]
@@ -110,6 +107,14 @@ def login_redirect(request):
     if (not login_scheme or login_scheme == current_scheme)\
     and (not login_netloc or login_netloc == current_netloc):  # NOQA
         path = request.get_full_path()
+    return path
+
+
+def login_redirect(request):
+    # urlparse chokes on lazy objects in Python 3, force to str
+    resolved_login_url = force_str(
+        resolve_url(settings.LOGIN_URL))
+    path = get_login_redirect_path(request, resolved_login_url)
     from django.contrib.auth.views import redirect_to_login
     return redirect_to_login(
         path, resolved_login_url, REDIRECT_FIELD_NAME)


### PR DESCRIPTION
The header login link href now specifies the login page,
with the urlencoded current page in the `?next=` query string param.

Also changed the `InstanceUser` `__unicode__` method to do something
sensible when there is no logged in user.
Needed that for the django debug toolbar templates tab,
which was crashing in `InstanceUser.__unicode__`.

--

Connects to #2239
Connects to #2185 