### PR TITLE
Threaded comments migration

### DIFF
--- a/opentreemap/otm_comments/migrations/0003_auto_20160923_1413.py
+++ b/opentreemap/otm_comments/migrations/0003_auto_20160923_1413.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('otm_comments', '0002_auto_20150630_1556'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='enhancedthreadedcomment',
+            options={'ordering': ('submit_date',), 'verbose_name': 'comment', 'verbose_name_plural': 'comments', 'permissions': [('can_moderate', 'Can moderate comments')]},
+        ),
+    ]


### PR DESCRIPTION
New version of django module changed threaded comment metadata.
Update the schema for the subclass of the django model.
Necessary for release 2.12.0.

--

Connects to azavea/trees-team#85