### PR TITLE
Allow MapManager clients to handle save/load of zoom/lat/lng

### DIFF
--- a/assets/css/sass/partials/pages/_modeling.scss
+++ b/assets/css/sass/partials/pages/_modeling.scss
@@ -56,6 +56,11 @@ $blue-to-red: #2791c3 10%,
             .private {
                 color: lighten($main-text-color, 70%);
             }
+
+            #autosave-message {
+                font-size: 1.2rem;
+                color: lighten($main-text-color, 70%);
+            }
         }
 
         .search-block-wrapper {

--- a/opentreemap/treemap/js/src/lib/mapPage.js
+++ b/opentreemap/treemap/js/src/lib/mapPage.js
@@ -19,7 +19,7 @@ $.ajaxSetup(require('treemap/lib/csrf.js').jqueryAjaxSetupOptions);
 
 module.exports.init = function (options) {
     // init mapManager before searchBar so that .setCenterWM is set
-    mapManager.createTreeMap(options);
+    var zoomLatLngOutputStream = mapManager.createTreeMap(options);
 
     // When there is a single geocode result (either by an exact match
     // or the user selects a candidate) move the map to it and zoom
@@ -71,6 +71,7 @@ module.exports.init = function (options) {
         builtSearchEvents: builtSearchEvents,
         getMapStateSearch: urlState.getSearch,
         mapStateChangeStream: urlState.stateChangeStream,
+        zoomLatLngOutputStream: zoomLatLngOutputStream,
         initMapState: urlState.init
     };
 };

--- a/opentreemap/treemap/js/src/lib/urlState.js
+++ b/opentreemap/treemap/js/src/lib/urlState.js
@@ -172,12 +172,13 @@ module.exports = {
         });
     },
 
-    setZoomLatLng: function (zoom, center) {
-        var zoomLatLng = makeZoomLatLng(zoom, center.lat, center.lng);
-        set('zoomLatLng', zoomLatLng, {
-            silent: true,
-            replaceState: true
-        });
+    setZoomLatLng: function (zoomLatLng) {
+        if (!_.isEmpty(zoomLatLng)) {
+            set('zoomLatLng', zoomLatLng, {
+                silent: true,
+                replaceState: true
+            });
+        }
     },
 
     setSearch: function (otmSearch) {

--- a/opentreemap/treemap/js/test/urlState.js
+++ b/opentreemap/treemap/js/test/urlState.js
@@ -98,7 +98,7 @@ var urlStateTests = {
         var context = createContext();
         urlState.init(context);
 
-        urlState.setZoomLatLng(1, {lat: 2, lng: 3});
+        urlState.setZoomLatLng({zoom: 1, lat: 2, lng: 3});
         urlState.setModeName('scenarios');
         urlState.set('foo', 'bar');
 


### PR DESCRIPTION
As before, calling `createMap` with `options.trackZoomLatLng` causes `MapManager` to save/load zoom/lat/lng to the `urlState`.

Now, specifying `options.zoomLatLngInputStream` as well signals that, instead, the calling page will handle save/load of zoom/lat/lng:
* The calling page provides loaded zoom/lat/lng values via `options.zoomLatLngInputStream`, and `MapManager` updates the map accordingly.
* `createMap` now returns `zoomLatLngOutputStream` (with updated zoom/lat/lng values as the user zooms and pans the map), and the calling page uses it to save zoom/lat/lng values.

(This PR also contains a style update missed in a previous commit.)

Connects #1252