### PR TITLE
Fix intermittently-failing test

### DIFF
--- a/opentreemap/api/tests.py
+++ b/opentreemap/api/tests.py
@@ -1286,7 +1286,6 @@ class InstancesClosestToPoint(OTMTestCase):
 
         self.assertEqual(0, len(instance_infos['personal']))
 
-    @skip('nearby ordering randomly incorrect, unrelated to recent changes')
     def test_nearby_list_distance(self):
         request = sign_request_as_user(
             make_request({'distance': 100000}), self.user)
@@ -1296,14 +1295,6 @@ class InstancesClosestToPoint(OTMTestCase):
         self.assertEqual(2, len(instance_infos['nearby']))
         self.assertEqual(self.i1.pk, instance_infos['nearby'][0]['id'])
         self.assertEqual(self.i3.pk, instance_infos['nearby'][1]['id'])
-
-        i5 = make_instance(is_public=True, point=Point(200, 200))
-
-        instance_infos = instances_closest_to_point(request, 0, 0)
-        self.assertEqual(3, len(instance_infos['nearby']))
-        self.assertEqual(self.i1.pk, instance_infos['nearby'][0]['id'])
-        self.assertEqual(i5.pk, instance_infos['nearby'][1]['id'])
-        self.assertEqual(self.i3.pk, instance_infos['nearby'][2]['id'])
 
         self.assertEqual(0, len(instance_infos['personal']))
 


### PR DESCRIPTION
We were calling `instances_closest_to_point` with four instances, adding another instance, and calling `instances_closest_to_point` again. The second call was intermittently failing because the distance is 0 to two of the instances, making for an indeterminate ordering when sorting by distance. (The distance is computed to the instance bounds, and it's 0 for two instances because
the point is inside their bounds.)

I removed the second call because it does not appear to test any functionality not covered
by the first call. The results of the first call don't have the indeterminate order problem.

Connects #2698