### PR TITLE
Implement mobile responsive search for small screen sizes

### DIFF
--- a/assets/css/sass/_base.scss
+++ b/assets/css/sass/_base.scss
@@ -44,8 +44,8 @@ $table-gray                     : #DFE2E8;
 $screen-xs    : "(max-width: 767px)";
 $screen-gtxs  : "(min-width: 768px)";
 $screen-sm    : "(min-width: 768px) and (max-width: 991px)";
+$screen-gtsm  : "(min-width: 992px)";
 $screen-ltmd  : "(max-width: 991px)";
 $screen-md    : "(min-width: 992px) and (max-width: 1199px)";
 $screen-ltlg  : "(max-width: 1199px)";
 $screen-lg    : "(min-width: 1200px)";
-

--- a/assets/css/sass/_base.scss
+++ b/assets/css/sass/_base.scss
@@ -41,10 +41,11 @@ $table-gray                     : #DFE2E8;
 
 
 // Media Queries
-$screen-xs			 : "(max-width: 767px)";
-$screen-gtxs         : "(min-width: 768px)";
-$screen-sm			 : "(min-width: 768px) and (max-width: 991px)";
-$screen-md			 : "(min-width: 992px) and (max-width: 1199px)";
-$screen-ltlg         : "(max-width: 1199px)";
-$screen-lg			 : "(min-width: 1200px)";
+$screen-xs    : "(max-width: 767px)";
+$screen-gtxs  : "(min-width: 768px)";
+$screen-sm    : "(min-width: 768px) and (max-width: 991px)";
+$screen-ltmd  : "(max-width: 991px)";
+$screen-md    : "(min-width: 992px) and (max-width: 1199px)";
+$screen-ltlg  : "(max-width: 1199px)";
+$screen-lg    : "(min-width: 1200px)";
 

--- a/assets/css/sass/partials/_header.scss
+++ b/assets/css/sass/partials/_header.scss
@@ -335,7 +335,21 @@ $mobile-search-button-group-width : 166px;
             }
         }
         .search-options {
-            width: 100%;
+            width: calc(100% + 20px);
+            left: -10px;
+            position: absolute;
+            float: none;
+            margin: 0;
+            padding: 12px 15px;
+            background: #fff;
+            z-index: 10;
+            top: 0;
+
+            &.fixed {
+                position: fixed;
+                width: 100%;
+                left: 0;
+            }
             #search-advanced {
                 float: right;
                 width: 30px;
@@ -358,7 +372,7 @@ $mobile-search-button-group-width : 166px;
                 display: block;
                 position: absolute;
                 font-size: 1.6rem;
-                width: calc(50% - 18px);
+                width: calc(50% - 28px);
                 margin: 0;
                 padding: 5px 0;
                 line-height: 1.333333;
@@ -368,7 +382,7 @@ $mobile-search-button-group-width : 166px;
             }
             #perform-search {
                 top: 12px;
-                left: calc(50% - 18px);
+                left: calc(50% - 28px);
                 border-radius: 0 6px 6px 0;
             }
         }

--- a/assets/css/sass/partials/_header.scss
+++ b/assets/css/sass/partials/_header.scss
@@ -1,11 +1,18 @@
 // Partial: Header
 
+$search-button-group-width : 128px;
+$mobile-search-button-group-width : 166px;
+
 .header {
     padding: 59px 15px 15px;
     height: 153px;
     background: #fff;
     position: relative;
     z-index: 100;
+
+    @media #{$screen-xs} {
+        height: 100px;
+    }
 
     &:before {
         content: '';
@@ -42,8 +49,15 @@
     position: absolute;
     right: 15px;
     top: 60px;
-    display: inline-block;
 
+    @media #{$screen-ltmd} {
+        left: 15px;
+    }
+    @media #{$screen-xs} {
+        top: 45px;
+        left: 10px;
+        right: 10px;
+    }
     .embed & {
         top: 15px;
     }
@@ -52,36 +66,50 @@
 .search-block-wrapper {
     display: inline-block;
 
+    @media #{$screen-ltmd} {
+        width: calc(100% - #{$search-button-group-width + 16px});
+    }
     .search-block {
         padding: 12px 0;
         float: left;
         margin-left: 10px;
         width: 245px;
 
+        @media #{$screen-ltmd} {
+            width: calc(50% - 10px);
+        }
         @media #{$screen-xs} {
-            width: 185px;
+            width: 100%;
+            margin-left: 0;
         }
-
-        @media(max-width: 358px) {
-            display: none;
-        }
-
         label {
             display: block;
             margin-top: -2px;
         }
-
         .search-field-group {
             position: relative;
+
+            .twitter-typeahead {
+                display: block !important;
+            }
 
             input[type="text"] {
                 margin: 0;
                 padding-left: 32px;
                 font-size: 1.2rem;
-            }
 
-            .twitter-typeahead {
-                display: block !important;
+                &::placeholder {
+                    text-overflow: ellipsis !important;
+                }
+                &::-moz-placeholder {
+                    text-overflow: ellipsis !important;
+                }
+                &:-ms-input-placeholder {
+                    text-overflow: ellipsis !important;
+                }
+                &::-webkit-input-placeholder {
+                    text-overflow: ellipsis !important;
+                }
             }
             .typeahead-toggle {
                 padding: 9px 4px 7px;
@@ -100,8 +128,10 @@
                     color: $main-text-color;
                 }
             }
+            .search-button {
+                display: none;
+            }
         }
-
         .dropdown-menu {
             width: 257px;
             -moz-border-radius: 3px;
@@ -116,24 +146,74 @@
 }
 
 .search-options {
-    display: inline-block;
-    margin-left: 15px;
-    position: relative;
-    vertical-align: top;
-    min-width: 100px;
+    float: right;
 
     #perform-search {
         margin-top: 2px;
         padding: 5px 0;
     }
 
-    #search-advanced.filter-active {
-        font-weight: bold;
-        color: $secondary-color;
-    }
-
     .btn-group {
         width: 100%;
+    }
+
+    @media #{$screen-gtxs} {
+        #search-advanced.filter-active {
+            font-weight: bold;
+            color: $secondary-color;
+        }
+    }
+    @media #{$screen-gtsm} {
+        margin-left: 15px;
+    }
+    @media #{$screen-xs} {
+        padding: 12px 0;
+        width: $mobile-search-button-group-width;
+        text-align: center;
+
+        .btn-group {
+            width: auto;
+        }
+
+        #search-advanced {
+            color: $primary-color;
+            border: none;
+            background: none;
+            width: auto;
+            height: 35px;
+            text-transform: uppercase;
+            font-weight: 500;
+            font-size: 1.2rem;
+            padding: 0;
+            transition: opacity 0.1s;
+            transition-delay: 0.2s;
+
+            i {
+                display: none;
+            }
+            .text {
+                display: block;
+                white-space: nowrap;
+                overflow: hidden;
+            }
+        }
+        #search-reset, #perform-search {
+            display: none;
+        }
+        .filter-active + #search-reset, .simple-filter-active + #search-reset {
+            display: block;
+            color: $primary-color;
+            border: none;
+            background: none;
+            width: auto;
+            height: 35px;
+            text-transform: uppercase;
+            font-size: 1.2rem;
+            padding: 0;
+            padding-left: 15px;
+            transition: opacity 0.1s;
+            transition-delay: 0.2s;
+        }
     }
 
     .btn-default {
@@ -144,6 +224,149 @@
             box-shadow: none;
             background: darken($button-default, 5%);
             border-color: darken($button-default, 15%);
+        }
+    }
+}
+
+@media #{$screen-xs} {
+    .header {
+        .search-block-wrapper {
+            width: calc(100% - #{$mobile-search-button-group-width});
+        }
+        &:not(.expanded) {
+            &.collapsed {
+                .search-block-wrapper {
+                    transition: width 0.2s;
+                    transition-delay: 0s;
+                }
+            }
+            .search-block {
+                .typeahead-toggle {
+                    display: none;
+                }
+                > label {
+                    display: none;
+                }
+                .search-field-group .twitter-typeahead input[type="text"] {
+                    padding-left: 8px;
+                    border-top-right-radius: 0;
+                    border-bottom-right-radius: 0;
+                    width: calc(100% - 40px);
+                }
+                .search-button {
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                    border-top-left-radius: 0;
+                    border-bottom-left-radius: 0;
+                    width: 40px;
+                    display: block;
+                }
+            }
+            .species-search-block {
+                display: none;
+            }
+            .search-block-wrapper {
+                &:after {
+                    content: '...';
+                    opacity: 0;
+                    font-size: 2rem;
+                    float: right;
+                    margin-top: 10px;
+                    margin-right: -30px;
+                    transition: opacity 0.1s;
+                    transition-delay: 0s;
+                }
+            }
+            .search-wrapper.typeahead-active {
+                .search-block-wrapper {
+                    width: calc(100% - 30px);
+                    transition-delay: 0.1s;
+
+                    &:after {
+                        opacity: 1;
+                        transition-delay: 0.2s;
+                    }
+                }
+                #search-advanced {
+                    opacity: 0;
+                    transition-delay: 0s;
+                    z-index: -1;
+                }
+                .simple-filter-active + #search-reset, .filter-active + #search-reset {
+                    opacity: 0;
+                    transition-delay: 0s;
+                    z-index: -1;
+                }
+            }
+            #search-advanced {
+                &.filter-active, &.simple-filter-active {
+                    font-weight: 700;
+
+                    &:before {
+                        content: '';
+                        display: block;
+                        position: absolute;
+                        width: 6px;
+                        height: 6px;
+                        background: $secondary-color;
+                        border-radius: 100%;
+                        left: -10px;
+                        top: 15px;
+                    }
+                }
+            }
+        }
+    }
+    .expanded {
+        .search-block-wrapper {
+            position: absolute;
+            top: 60px;
+            width: 100%;
+
+            .search-block {
+                label, .field-group-message {
+                    color: lighten($primary-color, 45%);
+                }
+            }
+        }
+        .search-options {
+            width: 100%;
+            #search-advanced {
+                float: right;
+                width: 30px;
+
+                .text {
+                    opacity: 0;
+                }
+                i {
+                    display: block;
+                    position: absolute;
+                    right: -8px;
+                    top: 1px;
+                    font-size: 2rem;
+                }
+            }
+            .btn-group {
+                width: 100%;
+            }
+            #search-reset, #perform-search {
+                display: block;
+                position: absolute;
+                font-size: 1.6rem;
+                width: calc(50% - 18px);
+                margin: 0;
+                padding: 5px 0;
+                line-height: 1.333333;
+            }
+            #search-reset {
+                border-radius: 6px 0 0 6px;
+            }
+            #perform-search {
+                top: 12px;
+                left: calc(50% - 18px);
+                border-radius: 0 6px 6px 0;
+            }
         }
     }
 }

--- a/assets/css/sass/partials/_header.scss
+++ b/assets/css/sass/partials/_header.scss
@@ -24,7 +24,9 @@ $mobile-search-button-group-width : 166px;
 
     .embed & {
         padding-top: 0;
-        height: 98px;
+        @media #{$screen-gtxs} {
+            height: 98px;
+        }
     }
 }
 
@@ -58,8 +60,10 @@ $mobile-search-button-group-width : 166px;
         left: 10px;
         right: 10px;
     }
-    .embed & {
-        top: 15px;
+    @media #{$screen-gtxs} {
+        .embed & {
+            top: 15px;
+        }
     }
 }
 

--- a/assets/css/sass/partials/_layout.scss
+++ b/assets/css/sass/partials/_layout.scss
@@ -2,8 +2,8 @@
 
 html,
 body {
-	height: 100%;
-	background: #f1f1f2;
+    height: 100%;
+    background: #f1f1f2;
 }
 
 .wrapper {
@@ -21,13 +21,13 @@ body {
 
 .image-background {
     //background-image: $background-image;
-	background-image: none;
-	height: 500px;
-	position: absolute;
-	z-index: 0;
-	width: 100%;
-	background-size: cover;
-	background-repeat: no-repeat;
+    background-image: none;
+    height: 500px;
+    position: absolute;
+    z-index: 0;
+    width: 100%;
+    background-size: cover;
+    background-repeat: no-repeat;
 }
 
 .content {
@@ -69,26 +69,26 @@ body {
 }
 
 .container.contained {
-	padding: 25px;
-	background: white;
-	border-radius: 6px;
-	box-shadow: 0 3px 0 gray;
-	box-shadow: 0 3px 0 rgba(0,0,0,.35);
-	margin: 90px auto;
-	position: relative;
-	width: 920px;
+    padding: 25px;
+    background: white;
+    border-radius: 6px;
+    box-shadow: 0 3px 0 gray;
+    box-shadow: 0 3px 0 rgba(0,0,0,.35);
+    margin: 90px auto;
+    position: relative;
+    width: 920px;
     z-index: 98;
 
-	@media (min-width: 1200px) {
-		width: 1100px;
-	}
-	@media (max-width: 979px) and (min-width: 768px) {
-		width: 710px;
-	}
-	@media (max-width: 767px) {
-		width: auto;
-		margin: 50px 10px 90px;
-	}
+    @media (min-width: 1200px) {
+        width: 1100px;
+    }
+    @media (max-width: 979px) and (min-width: 768px) {
+        width: 710px;
+    }
+    @media (max-width: 767px) {
+        width: auto;
+        margin: 50px 10px 90px;
+    }
 
     &.topper:before {
         content: '';
@@ -206,33 +206,33 @@ body {
 }
 
 .well {
-	border: 1px solid lighten($well-color, 10%);
-	background: $light-gray-color;
-	border-radius: 6px;
+    border: 1px solid lighten($well-color, 10%);
+    background: $light-gray-color;
+    border-radius: 6px;
 
-	> :last-child {
-		margin-bottom: 0;
-	}
+    > :last-child {
+        margin-bottom: 0;
+    }
 
-	h4 {
-		color: $secondary-color;
-		font-size: 1.6rem;
-		font-weight: 400;
-		line-height: 2.1rem;
-		margin-bottom: 8px;
-	}
-	h5 {
-		margin-bottom: 6px;
+    h4 {
         color: $secondary-color;
-		font-size: 1.4rem;
-		font-weight: 700;
-	}
-	p, li {
-		font-size: 1.4rem;
-		font-weight: 300;
-		line-height: 2.1rem;
+        font-size: 1.6rem;
+        font-weight: 400;
+        line-height: 2.1rem;
+        margin-bottom: 8px;
+    }
+    h5 {
+        margin-bottom: 6px;
+        color: $secondary-color;
+        font-size: 1.4rem;
+        font-weight: 700;
+    }
+    p, li {
+        font-size: 1.4rem;
+        font-weight: 300;
+        line-height: 2.1rem;
         word-wrap: break-word;
-	}
+    }
     p {
         clear: both;
     }
@@ -254,7 +254,7 @@ body {
 }
 
 @media (max-width: 767px) {
-	body {
-		padding: 0;
-	}
+    body {
+        padding: 0;
+    }
 }

--- a/assets/css/sass/partials/_layout.scss
+++ b/assets/css/sass/partials/_layout.scss
@@ -48,7 +48,9 @@ body {
 
         .embed & {
             bottom: 0;
-            top: 141px;
+            @media #{$screen-gtxs} {
+                top: 141px;
+            }
         }
 
         @media #{$screen-xs} {
@@ -56,11 +58,6 @@ body {
             top: 128px;
             bottom: 0;
             overflow: auto;
-
-            .embed & {
-                bottom: 0;
-                top: 98px;
-            }
 
             .map {
                 height: 300px;

--- a/assets/css/sass/partials/_layout.scss
+++ b/assets/css/sass/partials/_layout.scss
@@ -53,7 +53,8 @@ body {
 
         @media #{$screen-xs} {
             right: 0;
-            top: 154px;
+            top: 128px;
+            bottom: 0;
             overflow: auto;
 
             .embed & {
@@ -253,7 +254,7 @@ body {
     z-index: 1040 !important;
 }
 
-@media (max-width: 767px) {
+@media #{$screen-xs} {
     body {
         padding: 0;
     }

--- a/assets/css/sass/partials/_navbar.scss
+++ b/assets/css/sass/partials/_navbar.scss
@@ -103,10 +103,6 @@
                 top: 6px;
                 position: relative;
 
-                @media (max-width: 979px) {
-                    display: none;
-                }
-
                 a {
                     padding: 0;
                     height: auto;
@@ -117,7 +113,6 @@
                     max-width: 105%;
                 }
             }
-
             > a {
                 padding: 10px 0;
                 height: 44px;
@@ -206,9 +201,6 @@
         padding-left: 30px;
     }
 
-    .user-img {
-        border-radius: 9px;
-    }
     h2 {
         color: white;
         margin: 0 0 2px;

--- a/assets/css/sass/partials/_navbar.scss
+++ b/assets/css/sass/partials/_navbar.scss
@@ -17,6 +17,16 @@
             padding-right: 0;
         }
     }
+    @media #{$screen-gtxs} {
+        .embed & {
+            display: none;
+        }
+    }
+    .embed & {
+        .navbar-right {
+            display: none;
+        }
+    }
 
     .nav {
         margin: 0 -15px;

--- a/assets/css/sass/partials/_subheader.scss
+++ b/assets/css/sass/partials/_subheader.scss
@@ -7,16 +7,47 @@
     border-top: 1px solid lighten($primary-color, 15%);
     transition: all 400ms cubic-bezier(0, 0, 0.1, 1);
 
+    @media #{$screen-xs} {
+        border-top: none;
+        > .advanced-search > .dropdown {
+            position: absolute;
+            bottom: 0;
+            height: 300px;
+        }
+        > .advanced-search .dropdown {
+            width: 100%;
+
+            .dropdown-menu {
+                display: block;
+                position: static;
+                width: 100%;
+                max-height: initial;
+                min-width: 0;
+            }
+            .dropdown-toggle {
+                &:hover, &:focus, &:active, .active {
+                    background: none !important;
+                    cursor: initial;
+                }
+            }
+        }
+    }
     &.expanded {
         > .advanced-search {
             -webkit-transform: translate(0);
                     transform: translate(0);
             box-shadow: 0 6px 0 rgba(0,0,0,.15);
-            transition-delay: .1s;
 
             + .stats-bar {
                 -webkit-transform: translate(0,-101%);
                         transform: translate(0,-101%);
+            }
+            @media #{$screen-xs} {
+                padding-top: 150px;
+                padding-bottom: 300px;
+            }
+            @media #{$screen-gtxs} {
+                transition-delay: .1s;
             }
         }
     }
@@ -28,8 +59,130 @@
                 transform: translate(0,-110%);
         width: 100%;
         z-index: 11;
-        transition: .2s ease-in-out -webkit-transform;
-        transition: .2s ease-in-out transform;
+
+        @media #{$screen-xs} {
+            span.caret {
+                display: none;
+            }
+        }
+        @media #{$screen-gtxs} {
+            transition: .2s ease-in-out -webkit-transform;
+            transition: .2s ease-in-out transform;
+        }
+        .search-block-wrapper {
+            display: none;
+        }
+        .dropdown {
+            display: inline-block;
+        }
+
+        > .dropdown:first-child {
+            border-right: 1px solid $primary-color;
+        }
+        .search-right {
+            @media #{$screen-gtxs} {
+                float: right;
+            }
+        }
+
+        // Dropdown Toggles
+        .dropdown-toggle {
+            background: none;
+            border: none;
+            border-radius: 0;
+            color: lighten($primary-color, 45%);
+            padding: 18px 12px;
+
+            &:hover, &.hover,
+            &:focus, &.focus,
+            &:active, &.active {
+                background: $primary-color;
+                color: #fff;
+            }
+        }
+
+        .open > .dropdown-toggle {
+            background: $primary-color;
+            color: #fff;
+
+            &:hover, &.hover,
+            &:focus, &.focus,
+            &:active, &.active {
+                background: $primary-color;
+                color: #fff;
+            }
+        }
+
+        // Dropdown Popups
+        .dropdown-menu {
+            border-radius: 0;
+            margin: 0;
+            border: none;
+            padding: 15px;
+            background: $primary-color;
+            color: lighten($primary-color, 45%);
+            min-width: 300px;
+            max-height: 350px;
+            overflow: auto;
+        }
+
+        .field-group {
+            border-bottom: none;
+        }
+
+        // Labels
+        label {
+            color: lighten($primary-color, 45%);
+            font-size: 1.4rem;
+        }
+
+        // Search Range
+        .search-range {
+            margin-bottom: 15px;
+            clear: both;
+
+            > label {
+                display: block;
+            }
+
+            > .input-group,
+            > input {
+                float: left;
+                width: 35%;
+
+                @media #{$screen-xs} {
+                    width: 45%;
+                }
+            }
+
+            > span {
+                float: left;
+                margin: 6px 0;
+                font-size: 1.3rem;
+                width: 30%;
+                text-align: center;
+
+                @media #{$screen-xs} {
+                    width: 10%;
+                }
+            }
+        }
+
+        .field-group + .field-group {
+            padding-top: 10px;
+            border-top: 1px solid lighten($primary-color, 15%);
+        }
+
+        .form-group:last-child {
+            margin-bottom: 0;
+        }
+
+        .search-fields-title {
+            display: block;
+            font-size: 1.4rem;
+            font-weight: 600;
+            margin-bottom: 10px;
+        }
 
         .dropdown-toggle.filter-active {
             font-weight: bold;
@@ -44,7 +197,7 @@
                 background: $secondary-color;
                 border-radius: 100%;
                 left: 3px;
-                top: 50%;
+                top: 28px;
                 -webkit-transform: translate(0, -50%);
                         transform: translate(0, -50%);
             }
@@ -72,7 +225,27 @@
         }
 
         @media #{$screen-xs} {
-            min-width: 350px;
+            min-width: auto;
+
+            .udfc-label, .udfc-label select {
+                width: 100% !important;
+                text-align: center;
+                margin: 0 !important;
+            }
+            .udfc-selector {
+                width: calc(75% - 14px) !important;
+                text-align: center;
+                margin: 0 !important;
+                margin-left: 10px !important;
+            }
+            span:not(:first-child) {
+                padding-top: 15px;
+            }
+            .udfc-date-label {
+                width: 25%;
+                text-align: right;
+                padding-bottom: 10px;
+            }
         }
 
         > span,
@@ -181,9 +354,18 @@
         color: darken($primary-color, 25%);
         width: 100%;
         box-shadow: 0 6px 0 rgba(0,0,0,.15);
-        transition: .2s ease-in-out -webkit-transform;
-        transition: .2s ease-in-out transform;
 
+        @media #{$screen-xs} {
+            background: #FFF;
+            border-left:none;
+            padding: 0px 10px 0 13px;
+            height: auto;
+            font-size: 1.2rem;
+        }
+        @media #{$screen-gtxs} {
+            transition: .2s ease-in-out -webkit-transform;
+            transition: .2s ease-in-out transform;
+        }
         span {
             font-weight: bold;
         }
@@ -207,6 +389,10 @@
                 overflow: hidden;
                 white-space: nowrap;
                 text-overflow: ellipsis;
+
+                @media #{$screen-xs} {
+                    max-width: 100%;
+                }
             }
         }
         .addBtn {
@@ -249,117 +435,7 @@
     color: #799397;
     font-size: 1.2rem;
     font-weight: 400;
-}
-
-.advanced-search {
-
-    .dropdown {
-        display: inline-block;
-    }
-
-    > .dropdown:first-child {
-        border-right: 1px solid $primary-color;
-    }
-
-
-    // Dropdown Toggles
-    .dropdown-toggle {
-        background: none;
-        border: none;
-        border-radius: 0;
-        color: lighten($primary-color, 45%);
-        padding: 18px 12px;
-
-        &:hover, &.hover,
-        &:focus, &.focus,
-        &:active, &.active {
-            background: $primary-color;
-            color: #fff;
-        }
-    }
-
-    .open > .dropdown-toggle {
-        background: $primary-color;
-        color: #fff;
-
-        &:hover, &.hover,
-        &:focus, &.focus,
-        &:active, &.active {
-            background: $primary-color;
-            color: #fff;
-        }
-    }
-
-    // Dropdown Popups
-    .dropdown-menu {
-        border-radius: 0;
-        margin: 0;
-        border: none;
-        padding: 15px;
-        background: $primary-color;
-        color: lighten($primary-color, 45%);
-        min-width: 300px;
-        max-height: 350px;
-        overflow: auto;
-    }
-
-    .field-group {
-        border-bottom: none;
-    }
-
-    // Labels
-    label {
-        color: lighten($primary-color, 45%);
-        font-size: 1.4rem;
-    }
-
-    // Search Range
-    .search-range {
-        margin-bottom: 15px;
-        clear: both;
-
-        > label {
-            display: block;
-        }
-
-        > .input-group,
-        > input {
-            float: left;
-            width: 35%;
-
-            @media #{$screen-xs} {
-                width: 45%;
-            }
-        }
-
-        > span {
-            float: left;
-            margin: 6px 0;
-            font-size: 1.3rem;
-            width: 30%;
-            text-align: center;
-
-            @media #{$screen-xs} {
-                width: 10%;
-            }
-        }
-    }
-
-    .field-group + .field-group {
-        padding-top: 10px;
-        border-top: 1px solid lighten($primary-color, 15%);
-    }
-
-    .form-group:last-child {
-        margin-bottom: 0;
-    }
-
-    .search-fields-title {
-        display: block;
-        font-size: 1.4rem;
-        font-weight: 600;
-        margin-bottom: 10px;
-    }
+    margin-bottom: -17px;
 }
 
 #missing-data,
@@ -370,5 +446,7 @@
 }
 
 #search-fields-Tree {
-    min-width: 340px;
+    @media #{$screen-gtxs} {
+        min-width: 340px;
+    }
 }

--- a/opentreemap/treemap/js/src/lib/otmTypeahead.js
+++ b/opentreemap/treemap/js/src/lib/otmTypeahead.js
@@ -185,10 +185,19 @@ var create = exports.create = function(options) {
         editStream = selectStream.merge(backspaceOrDeleteStream.map(undefined)),
 
         idStream = selectStream.map(".id")
-                               .merge(backspaceOrDeleteStream.map(""));
+                               .merge(backspaceOrDeleteStream.map("")),
+
+        openCloseStream = Bacon.mergeAll(
+                $input.asEventStream('focus typeahead:active typeahead:open').map(true),
+                $input.asEventStream('typeahead:idle typeahead:close').map(false)
+            );
 
     editStream.filter(BU.isDefined).onValue($input, "data", "datum");
     editStream.filter(BU.isUndefined).onValue($input, "removeData", "datum");
+
+    openCloseStream.onValue(function(active) {
+            $input.closest('.search-wrapper').toggleClass('typeahead-active', active);
+        });
 
     if (options.forceMatch) {
         $input.on('blur', function() {

--- a/opentreemap/treemap/js/src/lib/searchBar.js
+++ b/opentreemap/treemap/js/src/lib/searchBar.js
@@ -25,6 +25,7 @@ var $ = require('jquery'),
     mapManager = new MapManager();
 
 var dom = {
+    header: '.header',
     subheader: '.subhead',
     advanced: '.advanced-search',
     advancedToggle: '#search-advanced',
@@ -43,7 +44,8 @@ var dom = {
     searchFieldContainer: '.search-field-wrapper',
     speciesSearchTypeahead: '#species-typeahead',
     speciesSearchToggle: '#species-toggle',
-    speciesSearchContainer: '#species-search-wrapper'
+    speciesSearchContainer: '#species-search-wrapper',
+    locationSearchTypeahead: '#boundary-typeahead',
 };
 
 // Placed onto the jquery object
@@ -83,6 +85,7 @@ function redirectToSearchPage(filters, wmCoords) {
 
 function initSearchUi(searchStream) {
     var $advancedToggle = $(dom.advancedToggle),
+        $header = $(dom.header),
         $subheader = $(dom.subheader);
     otmTypeahead.create({
         name: "species",
@@ -143,21 +146,29 @@ function initSearchUi(searchStream) {
         // Close open categories (in case search was triggered by hitting "enter")
         $(dom.categoryOpenToggle).dropdown('toggle');
 
-        if ($advancedToggle.hasClass('active')) {
-            $advancedToggle.removeClass('active').blur();
-        }
-        if ($subheader.hasClass('expanded')) {
-            $subheader.removeClass('expanded');
-        }
+        toggleAdvanced(false);
         updateUi(Search.buildSearch());
     });
 
     $advancedToggle.on("click", function() {
-        $advancedToggle.toggleClass('active').blur();
-        $subheader.toggleClass('expanded');
+        toggleAdvanced();
     });
     $subheader.find("input[data-date-format]").datepicker();
+
+    function toggleAdvanced(active) {
+        $advancedToggle.toggleClass('active', active).blur();
+        $subheader.toggleClass('expanded', active);
+        $header.toggleClass('expanded', active);
+        // Waiting until we've given the browser a chance to repaint the DOM
+        // to add 'collapsed' helps us prevent unwanted CSS animations
+        setTimeout(function() {
+            active = $header.hasClass('expanded');
+            $subheader.toggleClass('collapsed', !active);
+            $header.toggleClass('collapsed', !active);
+        }, 20);
+    }
 }
+
 
 function updateUi(search) {
     updateActiveSearchIndicators(search);
@@ -167,10 +178,12 @@ function updateUi(search) {
 
 function updateActiveSearchIndicators(search) {
     var activeCategories = _(search.filter)
-        .map(getFilterCategory)
-        .unique()
-        .filter() // remove "false" (category with a filter that isn't displayed)
-        .value();
+            .map(getFilterCategory)
+            .unique()
+            .filter() // remove "false" (category with a filter that isn't displayed)
+            .value(),
+
+        simpleSearchKeys = ['species.id', 'mapFeature.geom'];
 
     function getFilterCategory(filter, key) {
         var moreSearchFeatureBlacklist;
@@ -180,7 +193,6 @@ function updateActiveSearchIndicators(search) {
         } else {
             var featureName = key.split('.')[0],
                 featureCategories = ['tree', 'plot', 'mapFeature'],
-                simpleSearchKeys = ['species.id', 'mapFeature.geom'],
                 displayedFeatures = _.map(search.display, function (s) {
                     return s.toLowerCase();
                 });
@@ -215,7 +227,10 @@ function updateActiveSearchIndicators(search) {
         activeCategories.push('display');
     }
 
+    var simpleSearchActive = _.any(simpleSearchKeys, _.partial(_.has, search.filter)) || $(dom.locationSearchTypeahead).val() !== "";
+
     $(dom.advancedToggle).toggleClass('filter-active', activeCategories.length > 0);
+    $(dom.advancedToggle).toggleClass('simple-filter-active', simpleSearchActive);
 
     $(dom.categoryToggle).removeClass('filter-active');
 
@@ -323,7 +338,7 @@ module.exports = exports = {
     init: function () {
         var searchStream = BU.enterOrClickEventStream({
                 inputs: 'input[data-class="search"]',
-                button: '#perform-search'
+                button: '#perform-search,#location-perform-search'
             }),
             resetStream = $("#search-reset").asEventStream("click"),
             searchFiltersProp = searchStream.map(Search.buildSearch).toProperty(),

--- a/opentreemap/treemap/js/src/lib/searchBar.js
+++ b/opentreemap/treemap/js/src/lib/searchBar.js
@@ -22,6 +22,7 @@ var $ = require('jquery'),
     MapManager = require('treemap/lib/MapManager.js'),
     reverse = require('reverse'),
     config = require('treemap/lib/config.js'),
+    stickyTitles = require('treemap/lib/stickyTitles.js'),
     mapManager = new MapManager();
 
 var dom = {
@@ -167,6 +168,10 @@ function initSearchUi(searchStream) {
             $header.toggleClass('collapsed', !active);
         }, 20);
     }
+
+    // Update CSS on search options bar to keep it fixed to top of the screen
+    // when scrolling on mobile
+    stickyTitles($(window), '.search-options', $header);
 }
 
 

--- a/opentreemap/treemap/js/src/lib/stickyTitles.js
+++ b/opentreemap/treemap/js/src/lib/stickyTitles.js
@@ -1,0 +1,85 @@
+"use strict";
+
+/*
+ Sticky Headers
+
+ In a scrolling list of sections, ensure that header of first visible section
+ is always visible. Works with add/remove section and collapse/expand section.
+
+ Adds either "fixed" or "absolute" class to a header when its section is
+ the first visible.
+
+ CSS class "fixed" should use position:fixed so the header won't scroll.
+
+ Class "absolute" is used when the header is at the bottom of its section.
+ CSS should use position:absolute so the header will scroll off the top.
+
+ The header must be wrapped by a <div>, used to preserve its height when
+ its positioning changes.
+ */
+
+
+var $ = require('jquery');
+
+module.exports = function ($scrollContainer, stickiesSelector, $positionContainer) {
+
+    var self = {};
+
+    $scrollContainer.off("scroll").on("scroll", function() {
+        self.update();
+    });
+
+    self.update = function() {
+
+        var $stickies = $(stickiesSelector);
+
+        for (var i = $stickies.length - 1; i >= 0; --i) {
+
+            var $sticky = $stickies.eq(i);
+
+            if (getTop($sticky) < 0) {
+                // Found sticky of first visible section
+                if (i === $stickies.length - 1) {
+                    // Final section always uses "fixed"
+                    updateActiveSticky($sticky, 'fixed');
+                } else {
+                    var bottom = getTop($stickies.eq(i + 1)),
+                        height = $sticky.outerHeight();
+                    if (height < bottom) {
+                        updateActiveSticky($sticky, 'fixed');
+                    } else {
+                        updateActiveSticky($sticky, 'absolute');
+                        $sticky.css("top", $scrollContainer.scrollTop() + bottom - height);
+                    }
+                }
+                return;
+            }
+        }
+        clearOverrides($stickies);
+
+        function updateActiveSticky($sticky, cssClass) {
+            if (!$sticky.hasClass(cssClass)) {
+                $sticky.parent().height($sticky.outerHeight());  // parent preserves vertical space
+                clearOverrides($stickies);
+                $sticky.addClass(cssClass);
+            }
+        }
+    };
+
+    function getTop($sticky) {
+        var containerOffset = $scrollContainer.offset(),
+            containerTop = containerOffset ? containerOffset.top
+                : $scrollContainer.scrollTop() + $positionContainer.offset().top,
+            top = $sticky.parent().offset().top - containerTop;
+        return top;
+    }
+
+    function clearOverrides($stickies) {
+        $stickies
+            .removeClass('fixed')
+            .removeClass('absolute')
+            .css('top', '');
+    }
+
+    return self;
+};

--- a/opentreemap/treemap/templates/base.html
+++ b/opentreemap/treemap/templates/base.html
@@ -135,10 +135,10 @@
 
       {% block header %}
       <!-- Logo and Search -->
-      <div class="header">
+      <div class="header collapsed">
 
         {% block logo %}
-        <div class="logo hidden-xs">
+        <div class="logo hidden-xs hidden-sm">
           <a href="{% if last_instance %}{% url 'map' instance_url_name=last_instance.url_name %}{% else %}/{% endif %}"
             ><img id="site-logo" src="{{ logo_url }}" alt="OpenTreeMap">
           </a>
@@ -175,7 +175,7 @@
     </div>
 
     {% if not embed %}
-      <footer>{% block footer %}{% endblock footer %}</footer>
+      <footer class="hidden-xs">{% block footer %}{% endblock footer %}</footer>
     {% endif %}
 
     {% block config_scripts %}

--- a/opentreemap/treemap/templates/base.html
+++ b/opentreemap/treemap/templates/base.html
@@ -84,7 +84,7 @@
                 </a>
               </li>
               <li class="hidden-xs"><a href="{% url 'auth_logout' %}">{% trans "Logout" %}</a></li>
-              <li class="user-img">
+              <li class="user-img hidden-xs">
                 <a href="{% url 'profile' %}">
                 {% if request.user.thumbnail %}
                   <img src="{{ request.user.thumbnail.url }}">

--- a/opentreemap/treemap/templates/base.html
+++ b/opentreemap/treemap/templates/base.html
@@ -50,7 +50,6 @@
   </head>
   <body>
     <div {% block outermost_atts %}{% endblock outermost_atts %} class="wrapper{% if embed %} embed{% endif %}">
-      {% if not embed %}
       {% block topnav %}
       <!-- Top Nav -->
       <div class="navbar navbar-inverse navbar-fixed-top">
@@ -131,7 +130,6 @@
         </div>
       </div>
       {% endblock topnav %}
-      {% endif %}
 
       {% block header %}
       <!-- Logo and Search -->

--- a/opentreemap/treemap/templates/instance_base.html
+++ b/opentreemap/treemap/templates/instance_base.html
@@ -108,7 +108,7 @@ ga('set', 'page', pathname);
         {% endif %}
       {% endwith %}
     {% endwith %}
-    <div class="pull-right">
+    <div class="search-right">
       {% with fields=request.instance|get_advanced_search_fields:request.user %}
         {% include "treemap/partials/advanced_search/dropdown.html" with fields=fields.general category='mapFeature' title=_("General") %}
         {% include "treemap/partials/advanced_search/display.html" with fields=fields.display category='display' %}
@@ -121,14 +121,14 @@ ga('set', 'page', pathname);
   </div>
   {% endif %}
 
-  <div class="stats-bar hidden-xs">
+  <div class="stats-bar">
     <div class="stats-list">
       <div id="tree-and-planting-site-counts">
       </div>
       {% if not embed %}
         {% block subhead_exports %}
           {% if request.instance|export_enabled_for:request.user %}
-          <a href="javascript:;" class="btn btn-primary btn-xs exportBtn"
+          <a href="javascript:;" class="btn btn-primary btn-xs exportBtn hidden-xs"
              data-export-start-url="{% url 'begin_export' instance_url_name=request.instance.url_name model='tree' %}">
             <i class="icon-export"></i> {% trans "Export Search Results" %}
           </a>
@@ -136,7 +136,7 @@ ga('set', 'page', pathname);
         {% endblock subhead_exports %}
       {% endif %}
     </div>
-    <div class="addBtn">
+    <div class="addBtn hidden-xs">
       {% if request.instance|feature_enabled:'add_plot' and last_effective_instance_user %}
         {% if request.instance.has_resources %}
           <div class="btn-group">
@@ -173,7 +173,13 @@ ga('set', 'page', pathname);
 <div class="search-options">
   <div class="btn-group">
     <button id="search-advanced" class="btn btn-default btn-sm"
-        data-event-category="search" data-event-action="toggle-advanced">{% trans "Advanced" %}</button>
+        data-event-category="search" data-event-action="toggle-advanced">
+        <span class="hidden-xs">{% trans "Advanced" %}</span>
+        <span class="visible-xs-inline">
+            <span class="text">{% trans "Advanced" %}</span>
+            <i class="icon-cancel"></i>
+        </span>
+    </button>
     <button id="search-reset" class="btn btn-default btn-sm"
         data-event-category="search" data-event-action="reset">{% trans "Reset" %}</button>
   </div>

--- a/opentreemap/treemap/templates/instance_base.html
+++ b/opentreemap/treemap/templates/instance_base.html
@@ -40,18 +40,22 @@ ga('set', 'page', pathname);
     </li>
   {% else %}
     <li data-feature="add_plot">
-      <a data-action='addtree'
-         data-always-enable='{{ last_effective_instance_user|plot_is_creatable }}'
+      <a data-always-enable='{{ last_effective_instance_user|plot_is_creatable }}'
          data-disabled-title='{% trans "Adding trees is not available to all users" %}'
          data-href="{% url 'map' instance_url_name=request.instance.url_name %}?m=addTree"
+         {% if embed %}
+         target="_blank"
+         {% else %}
          data-event-category="add-tree" data-event-action="start-add-tree"
+         data-action='addtree'
+         {% endif %}
          disabled='disabled'>{% trans "Add a Tree" %}</a>
     </li>
   {% endif %}
 {% endif %}
 
 <li class="explore-map {% block activeexplore %}active{% endblock %}">
-  <a href="{% url 'map' instance_url_name=request.instance.url_name %}">
+    <a href="{% url 'map' instance_url_name=request.instance.url_name %}" {% if embed %}target="_blank"{% endif %}>
     <span class="hidden-xs">{% trans "Explore Map" %}</span>
     <!-- We hide the logo on mobile, so we show the instance name instead of "Explore Map" to give context about which map you are on -->
     <span class="visible-xs-inline">{{ request.instance.name }}</span>

--- a/opentreemap/treemap/templates/treemap/partials/advanced_search/tree_care.html
+++ b/opentreemap/treemap/templates/treemap/partials/advanced_search/tree_care.html
@@ -61,12 +61,12 @@
     </select>
   </label>
 
-  <span>{% trans "between" %}</span>
+  <span class="udfc-date-label">{% trans "between" %}</span>
   <input id="udfc-search-date-from" data-search-type="MIN"
          class="udfc-selector"
          {% include "treemap/partials/date_picker_init.html" %}
          />
-  <span>{% trans "and" %}</span>
+  <span class="udfc-date-label">{% trans "and" %}</span>
   <input id="udfc-search-date-to" data-search-type="MAX"
          class="udfc-selector"
          {% include "treemap/partials/date_picker_init.html" %}

--- a/opentreemap/treemap/templates/treemap/partials/search_location.html
+++ b/opentreemap/treemap/templates/treemap/partials/search_location.html
@@ -2,15 +2,16 @@
 
 <!-- Location Search -->
 <div class="search-block">
-  <label>{% trans "Search by Location" %}</label>
+  <label class="boundary-search-label">{% trans "Search by Location" %}</label>
   <div class="search-field-group">
     <a class="typeahead-toggle" id="boundary-toggle"><i class="icon-menu"></i></a>
     <input type="text"
            data-class="search"
            id="boundary-typeahead"
            class="form-control"
-           placeholder="Address, City, State"
+           placeholder="{% trans "Address, City, State" %}"
            data-thumbprint="{{ request.instance.boundary_thumbprint }}"/>
+    <a class="btn btn-default search-button" id="location-perform-search"><i class="icon-search"></i></a>
     <input name="mapFeature.geom" data-search-type="IN_BOUNDARY" type="hidden" id="boundary" />
   </div>
 </div>

--- a/opentreemap/treemap/templates/treemap/partials/search_species.html
+++ b/opentreemap/treemap/templates/treemap/partials/search_species.html
@@ -2,8 +2,8 @@
 {% load species_thumbprint %}
 
 <!--Species Search-->
-<div class="search-block visible-md visible-lg">
-    <div id="species-search-wrapper" class="search-field-wrapper">
+<div class="search-block species-search-block">
+    <div class="search-field-wrapper">
         <label>{% trans "Search by Species" %}</label>
         <div class="search-field-group">
             <button class="typeahead-toggle" id="species-toggle"><i class="icon-menu"></i></button>


### PR DESCRIPTION
With these changes, all advanced search functionality is now available on small screen sizes.

Map page on page load:
![screen shot 2016-10-10 at 14 15 46](https://cloud.githubusercontent.com/assets/4432106/19246521/bf07b702-8ef4-11e6-9270-6a54307616fc.png)

When tapping on the location search box:
![screen shot 2016-10-10 at 14 18 43](https://cloud.githubusercontent.com/assets/4432106/19246524/bf0c21fc-8ef4-11e6-955c-42ee6303200e.png)

After tapping on the "Advanced search" toggle in the header:
![screen shot 2016-10-10 at 14 19 59](https://cloud.githubusercontent.com/assets/4432106/19246520/bf07550a-8ef4-11e6-8d74-84edd8c6f65e.png)

Search buttons are sticky when scrolling:
![screen shot 2016-10-10 at 14 20 05](https://cloud.githubusercontent.com/assets/4432106/19246522/bf087458-8ef4-11e6-9777-e1f9c2ccf54c.png)

For medium-sized screens we now always show both the species and location search boxes (by hiding the map logo):
![screen shot 2016-10-10 at 14 20 24](https://cloud.githubusercontent.com/assets/4432106/19246523/bf0c131a-8ef4-11e6-82fe-820ea5e95ca4.png)

Connects to https://github.com/OpenTreeMap/otm-core/issues/1127


