### PR TITLE
Separate authorization from tracking

### DIFF
--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -7,6 +7,7 @@ API_VERSION = 'v0.1'
 
 FEATURE_BACKEND_FUNCTION = None
 USER_ACTIVATION_FUNCTION = None
+INSTANCE_PERMISSIONS_FUNCTION = 'treemap.instance.get_instance_permission_spec'
 
 ECOSERVICE_NAME = 'ecoservice'
 

--- a/opentreemap/treemap/audit.py
+++ b/opentreemap/treemap/audit.py
@@ -185,12 +185,14 @@ def _add_default_permissions(models, role, instance):
     existing = FieldPermission.objects.filter(role=role, instance=instance)
     if existing.exists():
         for perm in perms:
-            perm['defaults'] = {'permission_level': role.default_permission}
+            perm['defaults'] = {
+                'permission_level': role.default_permission_level
+            }
             FieldPermission.objects.get_or_create(**perm)
     else:
         perms = [FieldPermission(**perm) for perm in perms]
         for perm in perms:
-            perm.permission_level = role.default_permission
+            perm.permission_level = role.default_permission_level
 
         FieldPermission.objects.bulk_create(perms)
         # Because we use bulk_create, we must manually trigger the save signal
@@ -683,8 +685,12 @@ class Role(models.Model):
 
     name = models.CharField(max_length=255)
     instance = models.ForeignKey('Instance', null=True, blank=True)
-    default_permission = models.IntegerField(choices=FieldPermission.choices,
-                                             default=FieldPermission.NONE)
+
+    default_permission_level = models.IntegerField(
+        db_column='default_permission',
+        choices=FieldPermission.choices,
+        default=FieldPermission.NONE)
+
     rep_thresh = models.IntegerField()
 
     def __unicode__(self):

--- a/opentreemap/treemap/audit.py
+++ b/opentreemap/treemap/audit.py
@@ -7,6 +7,7 @@ import hashlib
 from functools import partial
 from datetime import datetime
 
+from django.contrib.contenttypes.models import ContentType
 from django.contrib.gis.db import models
 from django.contrib.gis.geos import GEOSGeometry
 
@@ -20,6 +21,7 @@ from django.db.models.fields import FieldDoesNotExist
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import IntegrityError, connection, transaction
 from django.conf import settings
+from django.contrib.auth.models import Permission
 
 from treemap.units import (is_convertible, is_convertible_or_formattable,
                            get_display_value, get_units, get_unit_name,
@@ -142,6 +144,15 @@ def approve_or_reject_audits_and_apply(audits, user, approved):
         approve_or_reject_audit_and_apply(audit, user, approved)
 
 
+def add_instance_permissions(roles):
+    from treemap.plugin import get_instance_permission_spec
+    for spec in get_instance_permission_spec():
+        perm = Permission.objects.get(codename=spec['codename'])
+        for role in roles:
+            if role.name in spec['default_role_names']:
+                role.instance_permissions.add(perm)
+
+
 def add_default_permissions(instance, roles=None, models=None):
     # Audit is imported into models, so models can't be imported up top
     from treemap.models import MapFeaturePhoto
@@ -156,10 +167,36 @@ def add_default_permissions(instance, roles=None, models=None):
         models = leaf_models_of_class(Authorizable) | {MapFeaturePhoto}
 
     for role in roles:
-        _add_default_permissions(models, role, instance)
+        _add_default_field_permissions(models, role, instance)
+
+    _add_default_add_and_delete_permissions(models, roles)
 
 
-def _add_default_permissions(models, role, instance):
+def _add_default_add_and_delete_permissions(models, roles):
+    # Each of the 'models' has built-in "add" and "delete" permissions
+    # (from django.contrib.auth, e.g. Plot has "add_plot" and "delete_plot").
+    # Bulk create those permissions for all 'roles' whose default permission
+    # level allows write.
+    role_ids = [
+        role.id for role in roles
+        if role.default_permission_level > FieldPermission.READ_ONLY]
+
+    ThroughModel = Role.instance_permissions.through
+    existing = ThroughModel.objects.filter(role_id__in=role_ids)
+    existing_pairs = [(e.role_id, e.permission_id) for e in existing]
+
+    perm_names = [Role.permission_codename(Model, action)
+                  for Model in models for action in ['add', 'delete']]
+    perms = Permission.objects.filter(codename__in=perm_names)
+
+    role_perms = [ThroughModel(role_id=role_id, permission_id=perm.id)
+                  for role_id in role_ids for perm in perms
+                  if (role_id, perm.id) not in existing_pairs]
+
+    ThroughModel.objects.bulk_create(role_perms)
+
+
+def _add_default_field_permissions(models, role, instance):
     """
     Create FieldPermission entries for role using its default permission level.
     Make an entry for every tracked field of given models, as well as UDFs of
@@ -691,7 +728,38 @@ class Role(models.Model):
         choices=FieldPermission.choices,
         default=FieldPermission.NONE)
 
+    instance_permissions = models.ManyToManyField(Permission)
+
     rep_thresh = models.IntegerField()
+
+    def can_create(self, Model):
+        return self._can_do_action(Model, 'add')
+
+    def can_delete(self, Model):
+        return self._can_do_action(Model, 'delete')
+
+    def _can_do_action(self, Model, action):
+        codename = self.permission_codename(Model, action)
+        return self.has_permission(codename, Model)
+
+    @classmethod
+    def permission_codename(clz, Model, action):
+        """
+        Return name of built-in permission (django.contrib.auth) for
+        performing 'action' on 'Model'.
+        """
+        return '%s_%s' % (action, Model.__name__.lower())
+
+    def has_permission(self, codename, Model=None):
+        """
+        Return true if role has permission 'codename' for 'Model';
+        otherwise return false. 'Model' may be None.
+        """
+        qs = self.instance_permissions.filter(codename=codename)
+        if Model is not None:
+            content_type = ContentType.objects.get_for_model(Model)
+            qs = qs.filter(content_type=content_type)
+        return qs.exists()
 
     def __unicode__(self):
         return '%s (%s)' % (self.name, self.pk)

--- a/opentreemap/treemap/decorators.py
+++ b/opentreemap/treemap/decorators.py
@@ -134,6 +134,11 @@ def requires_permission(codename):
     def wrapper_function(view_fn):
         @wraps(view_fn)
         def wrapped(request, instance, *args, **kwargs):
+            if not hasattr(request, 'instance_user'):
+                raise Exception(
+                    'request.instance_user not defined -- requires_permission '
+                    'should only be used inside of instance_request, which '
+                    'sets request.instance_user')
             if request.instance_user.role.has_permission(codename):
                 return view_fn(request, instance, *args, **kwargs)
             else:

--- a/opentreemap/treemap/decorators.py
+++ b/opentreemap/treemap/decorators.py
@@ -130,6 +130,20 @@ def requires_feature(ft):
     return wrapper_function
 
 
+def requires_permission(codename):
+    def wrapper_function(view_fn):
+        @wraps(view_fn)
+        def wrapped(request, instance, *args, **kwargs):
+            if request.instance_user.role.has_permission(codename):
+                return view_fn(request, instance, *args, **kwargs)
+            else:
+                raise PermissionDenied
+
+        return wrapped
+
+    return wrapper_function
+
+
 def json_api_edit(req_function):
     """
     Wraps view function for an AJAX call which modifies data.

--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -97,6 +97,21 @@ def add_species_to_instance(instance):
     Species.objects.bulk_create(instance_species_list)
 
 
+PERMISSION_VIEW_EXTERNAL_LINK = 'view_external_link_on_detail_page'
+
+
+# Don't call this function directly, call plugin.get_instance_permission_spec()
+def get_instance_permission_spec():
+    from treemap.audit import Role
+    return [
+        {
+            'codename': PERMISSION_VIEW_EXTERNAL_LINK,
+            'label': _('Can view "External Link" on detail pages'),
+            'default_role_names': [Role.ADMINISTRATOR, Role.EDITOR]
+        }
+    ]
+
+
 class InstanceBounds(models.Model):
     """ Center of the map when loading the instance """
     geom = models.MultiPolygonField(srid=3857)

--- a/opentreemap/treemap/management/commands/create_instance.py
+++ b/opentreemap/treemap/management/commands/create_instance.py
@@ -101,7 +101,7 @@ class Command(BaseCommand):
 
         role = Role.objects.create(
             name='user', instance=instance, rep_thresh=0,
-            default_permission=FieldPermission.WRITE_DIRECTLY)
+            default_permission_level=FieldPermission.WRITE_DIRECTLY)
 
         create_stewardship_udfs(instance)
 

--- a/opentreemap/treemap/management/commands/create_instance.py
+++ b/opentreemap/treemap/management/commands/create_instance.py
@@ -16,7 +16,8 @@ from treemap.instance import (Instance, InstanceBounds,
                               add_species_to_instance)
 from treemap.models import (Boundary, InstanceUser, User,
                             BenefitCurrencyConversion)
-from treemap.audit import (Role, FieldPermission, add_default_permissions)
+from treemap.audit import (Role, FieldPermission, add_default_permissions,
+                           add_instance_permissions)
 
 logger = logging.getLogger('')
 
@@ -108,6 +109,7 @@ class Command(BaseCommand):
         add_species_to_instance(instance)
 
         add_default_permissions(instance, roles=[role])
+        add_instance_permissions([role])
 
         eco_benefits_conversion = \
             BenefitCurrencyConversion.get_default_for_instance(instance)

--- a/opentreemap/treemap/management/util.py
+++ b/opentreemap/treemap/management/util.py
@@ -59,7 +59,7 @@ class InstanceDataCommand(BaseCommand):
             r = Role.objects.get_or_create(name=Role.ADMINISTRATOR,
                                            rep_thresh=0,
                                            instance=instance,
-                                           default_permission=3)
+                                           default_permission_level=3)
             instance_user = InstanceUser(instance=instance,
                                          user=user,
                                          role=r[0])

--- a/opentreemap/treemap/migrations/0032_rename_to_role_default_permission_level.py
+++ b/opentreemap/treemap/migrations/0032_rename_to_role_default_permission_level.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0031_add_custom_id_to_default_search_fields'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='role',
+            name='default_permission',
+            field=models.IntegerField(default=0, db_column='default_permission', choices=[(0, 'Invisible'), (1, 'Read Only'), (2, 'Pending Write Access'), (3, 'Full Write Access')]),
+        ),
+        migrations.RenameField(
+            model_name='role',
+            old_name='default_permission',
+            new_name='default_permission_level',
+        ),
+    ]

--- a/opentreemap/treemap/migrations/0033_instance_permissions.py
+++ b/opentreemap/treemap/migrations/0033_instance_permissions.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auth', '0006_require_contenttypes_0002'),
+        ('treemap', '0032_rename_to_role_default_permission_level'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='role',
+            name='instance_permissions',
+            field=models.ManyToManyField(to='auth.Permission'),
+        ),
+    ]

--- a/opentreemap/treemap/migrations/0034_add_permission_view_external_link.py
+++ b/opentreemap/treemap/migrations/0034_add_permission_view_external_link.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+# Note: to reuse this data migration when adding a new permission
+# in the future, copy the code and update these two lines:
+
+_new_permission_codename = 'view_external_link_on_detail_page'
+_default_role_names = ['administrator', 'editor']
+
+
+def add_permission(apps, schema_editor):
+    Permission, Instance, instance_content_type = _get_models(apps)
+    Role = apps.get_model('treemap', 'Role')
+
+    # Create new permission
+    perm = Permission.objects.create(
+        codename=_new_permission_codename,
+        name=_new_permission_codename,
+        content_type=instance_content_type
+    )
+
+    # Add new permission to specified roles in all instances
+    for instance in Instance.objects.all():
+        for role in Role.objects.filter(instance=instance):
+            if role.name in _default_role_names:
+                role.instance_permissions.add(perm)
+
+
+def remove_permission(apps, schema_editor):
+    Permission, Instance, instance_content_type = _get_models(apps)
+
+    perm = Permission.objects.get(codename=_new_permission_codename,
+                                  content_type=instance_content_type)
+
+    # Remove permission from all roles
+    Role = apps.get_model('treemap', 'Role')
+    ThroughModel = Role.instance_permissions.through
+    ThroughModel.objects.filter(permission_id=perm.id).delete()
+
+    # Remove permission itself
+    Permission.objects.filter(id=perm.id).delete()
+
+
+def _get_models(apps):
+    Instance = apps.get_model('treemap', 'Instance')
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+    instance_content_type = ContentType.objects.get_for_model(Instance)
+    Permission = apps.get_model('auth', 'Permission')
+    return Permission, Instance, instance_content_type
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0033_instance_permissions'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_permission, remove_permission),
+    ]

--- a/opentreemap/treemap/plugin.py
+++ b/opentreemap/treemap/plugin.py
@@ -96,3 +96,7 @@ get_viewable_instances_filter = get_plugin_function(
 
 get_tree_limit = get_plugin_function('TREE_LIMIT_FUNCTION',
                                      lambda instance: None)
+
+
+get_instance_permission_spec = get_plugin_function(
+    'INSTANCE_PERMISSIONS_FUNCTION', lambda instance: [])

--- a/opentreemap/treemap/templates/instance_base.html
+++ b/opentreemap/treemap/templates/instance_base.html
@@ -60,11 +60,13 @@ ga('set', 'page', pathname);
 
 {% if settings.MODELING_VIEW_NAME %}
   {% if request.instance|feature_enabled:'modeling' %}
-    <li class="{% block activemodeling %}{% endblock %} hidden-xs">
-      <a href="{% url settings.MODELING_VIEW_NAME instance_url_name=request.instance.url_name %}">
-        <span>{% trans "Plan" %}</span>
-      </a>
-    </li>
+    {% if last_effective_instance_user|has_permission:'modeling' %}
+      <li class="{% block activemodeling %}{% endblock %} hidden-xs">
+        <a href="{% url settings.MODELING_VIEW_NAME instance_url_name=request.instance.url_name %}">
+          <span>{% trans "Plan" %}</span>
+        </a>
+      </li>
+    {% endif %}
   {% endif %}
 {% endif %}
 

--- a/opentreemap/treemap/templatetags/instance_config.py
+++ b/opentreemap/treemap/templatetags/instance_config.py
@@ -35,6 +35,11 @@ def feature_enabled(instance, feature):
 
 
 @register.filter
+def has_permission(instance_user, codename):
+    return instance_user.role.has_permission(codename)
+
+
+@register.filter
 def plot_field_is_writable(thing, field):
     return perms.plot_is_writable(thing, field=field)
 

--- a/opentreemap/treemap/tests/__init__.py
+++ b/opentreemap/treemap/tests/__init__.py
@@ -84,10 +84,11 @@ def _set_permissions(instance, role, permissions):
         fp.save()
 
 
-def _make_loaded_role(instance, name, default_permission, permissions=(),
+def _make_loaded_role(instance, name, default_permission_level, permissions=(),
                       rep_thresh=2):
     role, created = Role.objects.get_or_create(
-        name=name, instance=instance, default_permission=default_permission,
+        name=name, instance=instance,
+        default_permission_level=default_permission_level,
         rep_thresh=rep_thresh)
     role.save()
 
@@ -278,7 +279,7 @@ def make_instance(name=None, is_public=False, url_name=None, point=None,
 
     new_role = Role.objects.create(
         name='role-%s' % name, instance=instance,
-        rep_thresh=0, default_permission=FieldPermission.READ_ONLY)
+        rep_thresh=0, default_permission_level=FieldPermission.READ_ONLY)
 
     instance.default_role = new_role
     instance.save()

--- a/opentreemap/treemap/tests/test_perms.py
+++ b/opentreemap/treemap/tests/test_perms.py
@@ -3,8 +3,13 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-from treemap.models import Role
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+
+from treemap.instance import Instance
+from treemap.models import Role, Plot
 from treemap.lib import perms
+from treemap.tests import make_instance
 
 from treemap.tests.base import OTMTestCase
 
@@ -15,3 +20,42 @@ class PermTestCase(OTMTestCase):
                          perms._allows_perm(Role(),
                                             'NonExistentModel',
                                             any, 'allows_reads'))
+
+
+class InstancePermissionsTestCase(OTMTestCase):
+    def setUp(self):
+        self.instance = make_instance()
+        self.role_yes = self._make_empty_role('yes')
+        self.role_no = self._make_empty_role('no')
+
+    def _make_empty_role(self, name):
+        return Role.objects.create(
+            name=name, instance=self.instance, rep_thresh=0,
+            default_permission_level=0)
+
+    def _add_new_permission(self, role, Model, name):
+        content_type = ContentType.objects.get_for_model(Model)
+        perm = Permission.objects.create(codename=name, name=name,
+                                         content_type=content_type)
+        role.instance_permissions.add(perm)
+
+    def _add_builtin_permission(self, role, Model, codename):
+        content_type = ContentType.objects.get_for_model(Model)
+        perm = Permission.objects.get(content_type=content_type,
+                                      codename=codename)
+        role.instance_permissions.add(perm)
+
+    def test_builtin_permission(self):
+        self._add_builtin_permission(self.role_yes, Plot, 'add_plot')
+        self.assertTrue(self.role_yes.has_permission('add_plot', Plot))
+        self.assertFalse(self.role_no.has_permission('add_plot', Plot))
+
+    def test_new_permission(self):
+        self._add_new_permission(self.role_yes, Instance, 'can_fly')
+        self.assertTrue(self.role_yes.has_permission('can_fly', Instance))
+        self.assertFalse(self.role_no.has_permission('can_fly', Instance))
+
+    def test_lookup_without_model(self):
+        self._add_new_permission(self.role_yes, Instance, 'can_fly')
+        self.assertTrue(self.role_yes.has_permission('can_fly'))
+        self.assertFalse(self.role_no.has_permission('can_fly'))


### PR DESCRIPTION
Rename `joint_writable` to start with `_`, and comment more fully. Always initialize it to include
`id` in `Authorizable`. Update it with MapFeature and Tree fields, both the fields that already were
in it and fields that we no longer want to expose to role administration.

Also minor refactoring.

--

Depends on #2821 
Depends on OpenTreeMap/otm-cloud#305
Depends on OpenTreeMap/otm-addons#1290