### PR TITLE
Add ipython and ipdb to dev-requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,5 @@
 django-debug-toolbar==1.5     # https://django-debug-toolbar.readthedocs.io/en/stable/changes.html
 django-extensions==1.7.4
+ipython==5.1.0
+ipdb==0.10.1
 six==1.10.0


### PR DESCRIPTION
For easy access to ipython,
* enable `django-extensions` in `local_settings.py`
* `manage.py shell_plus`

`ipython-genutils` came with the `ipdb` install. We can ignore it, but it seemed better to make it (and its version) explicit in dev-requirements.txt.

`notebook` is an `ipython` extension for serving documentation. If someone takes the time to add our markdown files to a notebook, we can serve them as html on our localhosts. Could be convenient, especially for previewing changes.

We can also use a notebook to script access to a `shell_plus` kernel, for live, interactive documentation, if we can figure out how.