### PR TITLE
Prevent urlState crash

### DIFF
--- a/opentreemap/importer/templates/importer/partials/clientside_templates.html
+++ b/opentreemap/importer/templates/importer/partials/clientside_templates.html
@@ -81,16 +81,16 @@
 <script type="text/template" id="pager-template">
   <div class="pages pagination pagination-small">
     <ul>
-      <li><a href="#">&lt;</a></li>
-      <li><a href="#">&lt;&lt;</a></li>
+      <li><a href="javascript:;">&lt;</a></li>
+      <li><a href="javascript:;">&lt;&lt;</a></li>
       <% _.each(_.range(start_page, end_page), function(i) { %>
         <li
           <% if (i == page) { %> class="active" <% } %>
-          ><a href="#"><%= i + 1 %></a>
+          ><a href="javascript:;"><%= i + 1 %></a>
         </li>
       <% }); %>
-      <li><a href="#">&gt;&gt;</a></li>
-      <li><a href="#">&gt;</a></li>
+      <li><a href="javascript:;">&gt;&gt;</a></li>
+      <li><a href="javascript:;">&gt;</a></li>
     </ul>
   </div>
 </script>

--- a/opentreemap/otm_comments/templates/otm_comments/partials/moderation_row.html
+++ b/opentreemap/otm_comments/templates/otm_comments/partials/moderation_row.html
@@ -12,7 +12,7 @@
     <td><span class="label label-danger">{{ comment.visible_flag_count }}</span></td>
     <td>
       <a class="user-link" href="{{ comment.user|detail_link }}">{{ comment.user.username }} </a>
-      <div class="comment less">{{ comment.comment }}</div> <a data-less-more href="#">more</a>
+      <div class="comment less">{{ comment.comment }}</div> <a data-less-more href="javascript:;">more</a>
       {% with visible_flags=comment.visible_flags %}
       {% if visible_flags %}
         <p><label>Flagged By: {% spaceless %}

--- a/opentreemap/treemap/js/src/lib/urlState.js
+++ b/opentreemap/treemap/js/src/lib/urlState.js
@@ -1,5 +1,14 @@
 "use strict";
 
+// Manage the URL query string.
+// Callers may:
+// * Fetch data from the URL using get()
+// * Store data in the URL using set() or custom functions like setSearch()
+// * Handle events in the stateChangeStream to respond to URL changes
+//
+// We store a data object in window.history.state, and use it when the
+// history changes to send only changed values to the stateChangeStream.
+
 var _ = require('lodash'),
     Bacon = require('baconjs'),
     url = require('url'),
@@ -168,7 +177,7 @@ module.exports = {
         setStateAndPushToApp(getStateFromCurrentUrl());
 
         _history.onStateChange(function() {
-            setStateAndPushToApp(_history.getState().data || getStateFromCurrentUrl());
+            setStateAndPushToApp(getStateFromCurrentUrl());
         });
     },
 

--- a/opentreemap/treemap/js/src/lib/urlState.js
+++ b/opentreemap/treemap/js/src/lib/urlState.js
@@ -6,13 +6,12 @@
 // * Store data in the URL using set() or custom functions like setSearch()
 // * Handle events in the stateChangeStream to respond to URL changes
 //
-// We store a data object in window.history.state, and use it when the
-// history changes to send only changed values to the stateChangeStream.
+// We track in _state the current values of URL query string parameters, and use
+// it when the history changes to send only changed values to the stateChangeStream.
 
 var _ = require('lodash'),
     Bacon = require('baconjs'),
     url = require('url'),
-    L = require('leaflet'),
 
     modeNamesForUrl = [
         require('treemap/lib/addTreeMode.js').name,
@@ -33,26 +32,22 @@ function HistoryApi() {
         stateChangeCallback = callback;
         window.onpopstate = callback;
     }
-    function getState() {
-        return history.state;
-    }
-    function pushState(state, title, url) {
-        history.pushState(state, title, url);
+    function pushUrl(url) {
+        history.pushState(null, document.title, url);
         if (stateChangeCallback) {
             stateChangeCallback();
         }
     }
-    function replaceState(state, title, url) {
-        history.replaceState(state, title, url);
+    function replaceUrl(url) {
+        history.replaceState(null, document.title, url);
         if (stateChangeCallback) {
             stateChangeCallback();
         }
     }
     return {
         onStateChange: onStateChange,
-        getState: getState,
-        pushState: pushState,
-        replaceState: replaceState
+        pushUrl: pushUrl,
+        replaceUrl: replaceUrl
     };
 }
 
@@ -136,7 +131,7 @@ var deserializers = {
 function set(key, value, options) {
     options = _.defaults({}, options, {
         silent: false,
-        replaceState: false
+        replace: false
     });
 
     var currentValue = _state && _state[key];
@@ -155,10 +150,10 @@ function set(key, value, options) {
             _state = newState;
         }
 
-        if (options.replaceState) {
-            _history.replaceState(newState, '', getUrlFromState(newState));
+        if (options.replace) {
+            _history.replaceUrl(getUrlFromState(newState));
         } else {
-            _history.pushState(newState, '', getUrlFromState(newState));
+            _history.pushUrl(getUrlFromState(newState));
         }
     }
 }
@@ -185,7 +180,7 @@ module.exports = {
         if (!_.isEmpty(zoomLatLng)) {
             set('zoomLatLng', zoomLatLng, {
                 silent: true,
-                replaceState: true
+                replace: true
             });
         }
     },
@@ -193,7 +188,7 @@ module.exports = {
     setSearch: function (otmSearch) {
         set('search', otmSearch, {
             silent: true,
-            replaceState: false
+            replace: false
         });
     },
 
@@ -201,14 +196,14 @@ module.exports = {
         modeName = _.contains(modeNamesForUrl, modeName) ? modeName : '';
         set('modeName', modeName, {
             silent: true,
-            replaceState: true
+            replace: true
         });
     },
 
     setModeType: function (modeType) {
         set('modeType', modeType, {
             silent: true,
-            replaceState: true
+            replace: true
         });
     },
 

--- a/opentreemap/treemap/js/test/urlState.js
+++ b/opentreemap/treemap/js/test/urlState.js
@@ -6,37 +6,28 @@ var assert = require('chai').assert,
 
 
 function HistoryApiMock() {
-    var _state = null,
-        _url = '',
+    var _url = '',
         _callbacks = [];
 
     function onStateChange(callback) {
         _callbacks.push(callback);
     }
 
-    function getState() {
-        return {
-            data: _state
-        };
-    }
-
     // Exists on mock only.
-    function getStateUrl() {
+    function getUrl() {
         return _url;
     }
 
-    function pushState(state, title, url) {
-        _state = state;
+    function pushUrl(url) {
         _url = url;
         _.invoke(_callbacks, 'apply');
     }
 
     return {
         onStateChange: onStateChange,
-        getState: getState,
-        getStateUrl: getStateUrl,
-        pushState: pushState,
-        replaceState: pushState
+        getUrl: getUrl,
+        pushUrl: pushUrl,
+        replaceUrl: pushUrl
     };
 }
 
@@ -60,7 +51,7 @@ function createContext() {
         history = new HistoryApiMock();
 
     history.onStateChange(function() {
-        win.setLocationHref(history.getStateUrl());
+        win.setLocationHref(history.getUrl());
     });
 
     return {
@@ -71,17 +62,16 @@ function createContext() {
 
 
 var historyApiMockTests = {
-    'pushState': function(done) {
+    'pushUrl': function(done) {
         var history = new HistoryApiMock();
-        assert.equal(history.getState().data, null);
+        assert.equal(history.getUrl(), '');
 
         history.onStateChange(function() {
-            assert.deepEqual(history.getState().data, {foo: 1});
-            assert.equal(history.getStateUrl(), '?foo=1');
+            assert.equal(history.getUrl(), '?foo=1');
             done();
         });
 
-        history.pushState({foo: 1}, '', '?foo=1');
+        history.pushUrl('?foo=1');
     }
 };
 

--- a/opentreemap/treemap/templates/treemap/partials/export.html
+++ b/opentreemap/treemap/templates/treemap/partials/export.html
@@ -12,8 +12,8 @@
         <span style="display: none;" class="error-msg">{% trans "There was an error while generating your export. Please try again later." %}</span>
       </div>
       <div class="modal-footer">
-        <a href="#" class="btn dismiss-cancel" data-dismiss="modal">{% trans "Cancel" %}</a>
-        <a style="display: none;" href="#" class="btn dismiss-ok" data-dismiss="modal">{% trans "OK" %}</a>
+        <a href="javascript:;" class="btn dismiss-cancel" data-dismiss="modal">{% trans "Cancel" %}</a>
+        <a style="display: none;" href="javascript:;" class="btn dismiss-ok" data-dismiss="modal">{% trans "OK" %}</a>
       </div>
     </div>
   </div>

--- a/opentreemap/treemap/templates/treemap/partials/photo_social_media_sharing.html
+++ b/opentreemap/treemap/templates/treemap/partials/photo_social_media_sharing.html
@@ -25,7 +25,7 @@
       </div>
       <div class="modal-footer">
         <label class="pull-left"><input data-class="social-media-sharing-dont-show-again" type="checkbox"/>{% trans "Don't show me again" %}</label>
-        <a href="#" class="btn" data-dismiss="modal">{% trans "No Thanks" %}</a>
+        <a href="javascript:;" class="btn" data-dismiss="modal">{% trans "No Thanks" %}</a>
       </div>
     </div>
   </div>

--- a/opentreemap/treemap/templates/treemap/partials/step_controls.html
+++ b/opentreemap/treemap/templates/treemap/partials/step_controls.html
@@ -12,11 +12,11 @@
     <ul class="pager">
         {% if not first %}
         <li class="previous">
-            <a href="#">&laquo; Back</a>
+            <a href="javascript:;">&laquo; Back</a>
         </li>
         {% endif %}
         <li class="next">
-            <a href="#"{% if feature_name and last %} data-event-category="add-{{ feature_name }}" data-event-action="confirm-done"{% endif %}>
+            <a href="javascript:;"{% if feature_name and last %} data-event-category="add-{{ feature_name }}" data-event-action="confirm-done"{% endif %}>
                 {% if last %} Done {% else %} Next &raquo; {% endif %}
             </a>
         </li>

--- a/opentreemap/treemap/templates/treemap/partials/upload_image.html
+++ b/opentreemap/treemap/templates/treemap/partials/upload_image.html
@@ -19,7 +19,7 @@
         </div>
       </div>
       <div class="modal-footer">
-        <a href="#" class="btn" data-dismiss="modal">Cancel</a>
+        <a href="javascript:;" class="btn" data-dismiss="modal">Cancel</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
`urlState.js` keeps an object in `window.history.state` and, on history changes, uses it to detect which part of a URL has changed. Things work fine when history changes are initiated by the `urlState` module itself. But clicking a link with `href="#"` without calling `preventDefault()` also causes a history change, and we weren't handling that correctly.

So:
1. Replace occurrences of `href="*"` with `href="javascript:;"`. It's just safer. Adding `#` to the URL is not always innocuous, and we don't want to rely on `preventDefault` being called.
2. Don't assume our history state object exists. On history changes, construct our state object from the URL.

Either of these changes would suffice by itself. Do both -- belt and suspenders.

And it turns out that we don't actually need to store an object in `window.history.state`, so `urlstate.js` can be simplified accordingly.

Also added module overview documentation for `urlState.js`.

Connects #2784

To make sure nothing is broken, verify that app changes are reflected in the URL, and properly re-established when refreshing the page:
- Change zoom/lat/long
- Change mode of map page (add tree / add resource / quick edit)
- Change search
