### PR TITLE
Support new roles management.

### DIFF
--- a/assets/css/sass/partials/pages/_admin.scss
+++ b/assets/css/sass/partials/pages/_admin.scss
@@ -360,6 +360,16 @@
             min-width: 200px;
             max-width: 200px;
         }
+        .codename-radio {
+            font-weight: normal;
+            text-transform: none;
+        }
+        .boolean-radio {
+            margin: 0;
+            input[type="radio"] {
+                margin: 0;
+            }
+        }
     }
 
     .admin-table {

--- a/opentreemap/api/instance.py
+++ b/opentreemap/api/instance.py
@@ -17,7 +17,7 @@ from django.contrib.gis.measure import D
 from django.utils.translation import ugettext as _
 
 from django_tinsel.exceptions import HttpBadRequestException
-from treemap.lib.object_caches import role_permissions
+from treemap.lib.object_caches import role_field_permissions
 from treemap.models import Instance, InstanceUser
 from treemap.units import (get_units_if_convertible, get_digits_if_formattable,
                            storage_to_instance_units_factor)
@@ -168,7 +168,7 @@ def instance_info(request, instance):
     # dictionary. If a field isn't at least readable, it doesn't
     # get sent over at all.
     perms = {}
-    for fp in role_permissions(role, instance):
+    for fp in role_field_permissions(role, instance):
         model = fp.model_name.lower()
         field_key = '%s.%s' % (model, fp.field_name)
         if fp.allows_reads:

--- a/opentreemap/stormwater/models.py
+++ b/opentreemap/stormwater/models.py
@@ -20,6 +20,10 @@ class PolygonalMapFeature(MapFeature):
 
     objects = GeoHStoreUDFManager()
 
+    @classproperty
+    def always_writable(cls):
+        return MapFeature.always_writable | {'polygon'}
+
     def __init__(self, *args, **kwargs):
         super(PolygonalMapFeature, self).__init__(*args, **kwargs)
         self._do_not_track.add('polygonalmapfeature_ptr')

--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -106,8 +106,10 @@ def get_instance_permission_spec():
     return [
         {
             'codename': PERMISSION_VIEW_EXTERNAL_LINK,
-            'label': _('Can view "External Link" of a tree or map feature'),
-            'default_role_names': [Role.ADMINISTRATOR, Role.EDITOR]
+            'description': _('Can view "External Link" '
+                             'of a tree or map feature'),
+            'default_role_names': [Role.ADMINISTRATOR, Role.EDITOR],
+            'label': _('Can View External Link')
         }
     ]
 

--- a/opentreemap/treemap/js/src/lib/editableForm.js
+++ b/opentreemap/treemap/js/src/lib/editableForm.js
@@ -89,7 +89,7 @@ exports.init = function(options) {
             $(editFields).each(function(index, el){
                 var field = $(el).attr('data-field'),
                     $input, value, display, digits, units,
-                    displayValue;
+                    displayValue, displayMap;
 
                 // if the edit field has a data-field property,
                 // look for a corresponding display value and if
@@ -108,6 +108,9 @@ exports.init = function(options) {
                             value = FH.getTimestampFromDatepicker($input);
                         } else if ($input.is('select[multiple]')) {
                             value = JSON.stringify($input.val());
+                        } else if ($input.is('[type="radio"]')) {
+                            $input = $input.filter(':checked');
+                            value = $input.attr('data-value');
                         } else {
                             value = $input.val();
                         }
@@ -125,6 +128,13 @@ exports.init = function(options) {
                             displayValue = getBooleanFieldText(display, value);
                         } else if (value && $input.is('[data-date-format]')) {
                             displayValue = $input.val();
+                        } else if ($input.is('[type="radio"]')) {
+                            if ($(display).is('[data-display-map]')) {
+                                displayMap = JSON.parse($(display).attr('data-display-map'));
+                                if (displayMap[displayValue]) {
+                                    displayValue = displayMap[displayValue];
+                                }
+                            }
                         } else if (value) {
                             digits = $(display).data('digits');
                             if (digits) {

--- a/opentreemap/treemap/lib/object_caches.py
+++ b/opentreemap/treemap/lib/object_caches.py
@@ -31,11 +31,12 @@ def field_permissions(user, instance, model_name=None):
 permissions = field_permissions
 
 
-def role_permissions(role, instance=None, model_name=None):
+def role_field_permissions(role, instance=None, model_name=None):
     if settings.USE_OBJECT_CACHES:
         if not instance:
             instance = role.instance
-        return _get_adjuncts(instance).role_permissions(role.id, model_name)
+        return _get_adjuncts(instance).role_field_permissions(
+            role.id, model_name)
     else:
         return _role_permissions_from_db(role, model_name)
 
@@ -128,9 +129,9 @@ class _InstanceAdjuncts:
             role_id = self._user_role_ids[user.id]
         else:
             role_id = self._user_role_ids[None]
-        return self.role_permissions(role_id, model_name)
+        return self.role_field_permissions(role_id, model_name)
 
-    def role_permissions(self, role_id, model_name):
+    def role_field_permissions(self, role_id, model_name):
         if not self._permissions:
             self._load_permissions()
         return self._permissions.get((role_id, model_name), [])

--- a/opentreemap/treemap/lib/perms.py
+++ b/opentreemap/treemap/lib/perms.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-from treemap.lib.object_caches import role_permissions
+from treemap.lib.object_caches import role_field_permissions
 
 from django.contrib.gis.db.models import Field
 from treemap.models import InstanceUser, Role, Plot
@@ -71,7 +71,7 @@ def _allows_perm(role_related_obj, model_name,
         return False
 
     perms = {perm for perm in
-             role_permissions(role, role.instance, model_name)}
+             role_field_permissions(role, role.instance, model_name)}
 
     # process args
     if field and fields:

--- a/opentreemap/treemap/migrations/0035_merge.py
+++ b/opentreemap/treemap/migrations/0035_merge.py
@@ -8,6 +8,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('treemap', '0032_add_udfs_to_web_detail_fields'),
+        ('treemap', '0032_rename_to_role_default_permission_level'),
         ('treemap', '0034_add_permission_view_external_link'),
     ]
 

--- a/opentreemap/treemap/migrations/0036_assign_role_add_delete_permissions.py
+++ b/opentreemap/treemap/migrations/0036_assign_role_add_delete_permissions.py
@@ -1,0 +1,294 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from django.db.models import Q
+
+
+_WRITE_DIRECTLY = 3
+
+
+def add_permission(apps, schema_editor):
+    models = _get_main_models(apps)
+    Role, __, __, ContentType = models
+
+    authorizable_models = _get_authorizable_models(apps)
+    model_untracked = {Model: _model_do_not_track(apps, Model)
+                       for Model in authorizable_models}
+
+    photo_add_permissions = {
+        _get_model_hash(Model): _make_photo_permission('add', Model, models)
+        for Model in authorizable_models}
+
+    photo_delete_permissions = {
+        _get_model_hash(Model): _make_photo_permission('delete', Model, models)
+        for Model in authorizable_models}
+
+    for role in Role.objects.filter(instance__isnull=False):
+        _add_permissions_to_role(role, ContentType, authorizable_models,
+                                 model_untracked,
+                                 photo_add_permissions,
+                                 photo_delete_permissions)
+
+
+def _add_permissions_to_role(role, ContentType, authorizable_models,
+                             model_untracked,
+                             photo_add_permissions, photo_delete_permissions):
+    role_permissions = set()
+
+    for Model in authorizable_models:
+
+        can_create, can_delete = _can_create_or_delete(
+            model_untracked[Model], role, Model)
+
+        add_permission, delete_permission = tuple(
+            _get_model_perms(Model, ContentType))
+
+        if can_create:
+            role_permissions.add(add_permission)
+            photo_permission = photo_add_permissions[_get_model_hash(Model)]
+            if photo_permission:
+                role_permissions.add(photo_permission)
+        if can_delete:
+            role_permissions.add(delete_permission)
+            photo_permission = photo_delete_permissions[_get_model_hash(Model)]
+            if photo_permission:
+                role_permissions.add(photo_permission)
+
+    role.instance_permissions.add(*role_permissions)
+
+
+def remove_permission(apps, schema_editor):
+    models = _get_main_models(apps)
+    Role, Permission, MapFeaturePhoto, ContentType = models
+    RolePermissionModel = Role.instance_permissions.through
+
+    authorizable_models = _get_authorizable_models(apps)
+
+    app_labels = {M._meta.app_label: [] for M in authorizable_models}
+    for M in authorizable_models:
+        app_labels[M._meta.app_label].append(M.__name__.lower())
+
+    ct_query = reduce(lambda q1, q2: q1 | q2, [
+        Q(app_label=label, model__in=app_models)
+        for label, app_models in app_labels.iteritems()])
+
+    photo_query = Q(app_label='treemap', model='mapfeaturephoto')
+
+    all_permissions = Permission.objects.filter(
+        content_type__in=ContentType.objects.filter(ct_query | photo_query))
+    rpms = RolePermissionModel.objects.filter(permission__in=all_permissions)
+
+    non_photo_permissions = all_permissions.filter(
+        content_type__in=ContentType.objects.filter(ct_query))
+
+    # role_{add,delete}_models contain (role, model) pairs for models
+    # on which the old field permissions must be restored to the roles.
+    # They include Tree and TreePhoto because there always was
+    # a field permission setup for them,
+    # but exclude MapFeaturePhoto because that previously was not managed
+    # per subclass of MapFeature.
+    role_delete_models = _get_role_model_action_perms(
+        apps, rpms, non_photo_permissions, 'delete')
+    # if it's deletable, it's creatable
+    role_add_models = _get_role_model_action_perms(
+        apps, rpms, non_photo_permissions, 'add') - role_delete_models
+
+    artificial_permissions = Permission.objects.filter(
+        content_type__in=ContentType.objects.filter(photo_query)).exclude(
+        codename__endswith='mapfeaturephoto')
+
+    artificial_permissions_roles = {ar.role for ar in rpms.filter(
+                                    permission__in=artificial_permissions)}
+
+    FieldPermission = apps.get_model('treemap', 'FieldPermission')
+
+    # Remove *all* permissions from roles
+    rpms.delete()
+
+    model_untracked = {Model: _model_do_not_track(apps, Model)
+                       for Model in authorizable_models | {MapFeaturePhoto}}
+    _restore_add_delete_field_permissions(
+        FieldPermission, model_untracked,
+        role_add_models, role_delete_models)
+
+    _restore_photo_permissions(
+        FieldPermission, MapFeaturePhoto, model_untracked,
+        artificial_permissions, artificial_permissions_roles)
+
+    # Remove artificial permissions themselves
+    artificial_permissions.delete()
+
+
+def _restore_photo_permissions(FieldPermission, MapFeaturePhoto,
+                               model_untracked, artificial_permissions,
+                               roles):
+    _restore_add_delete_field_permissions(FieldPermission, model_untracked,
+                                          set(),
+                                          {(r, MapFeaturePhoto)
+                                           for r in roles})
+
+
+def _restore_add_delete_field_permissions(FieldPermission, model_untracked,
+                                          role_add_models, role_delete_models):
+    perms_to_recreate = []
+    perms_to_update = []
+
+    def record_perms(fieldnames_func):
+        not_tracked = model_untracked[Model]
+        fieldnames = fieldnames_func(not_tracked, Model)
+        for name in fieldnames:
+            fp = FieldPermission.objects.filter(
+                model_name=Model.__name__,
+                field_name=name,
+                role=role,
+                instance=role.instance).first()
+            if fp is None:
+                perms_to_recreate.append(FieldPermission(
+                    model_name=Model.__name__,
+                    field_name=name,
+                    role=role,
+                    instance=role.instance,
+                    permission_level=_WRITE_DIRECTLY))
+            elif fp.permission_level < _WRITE_DIRECTLY:
+                perms_to_update.append(fp.id)
+
+    for role, Model in role_add_models:
+        record_perms(_fieldnames_required_for_create)
+
+    for role, Model in role_delete_models:
+        record_perms(_tracked_fields)
+
+    FieldPermission.objects.bulk_create(perms_to_recreate)
+    FieldPermission.objects.filter(id__in=perms_to_update).update(
+        permission_level=_WRITE_DIRECTLY)
+
+
+def _get_role_model_action_perms(apps, role_model_permissions, permissions,
+                                 action):
+    action_permissions = permissions.filter(codename__startswith=action)
+    role_model_action_perms = role_model_permissions.filter(
+        permission__in=action_permissions)
+
+    get_model = lambda rmap: apps.get_model(
+        rmap.permission.content_type.app_label,
+        rmap.permission.content_type.model)
+    return {(rmap.role, get_model(rmap))
+            for rmap in role_model_action_perms}
+
+
+def _get_model_perms(Model, ContentType):
+    return ContentType.objects.get_for_model(Model)\
+        .permission_set\
+        .exclude(codename__startswith='change_')\
+        .order_by('codename')
+
+
+def _get_model_hash(Model):
+    return '{}.{}'.format(Model._meta.app_label, Model.__name__)
+
+
+def _can_create_or_delete(not_tracked, role, Model):
+    field_permissions = role.fieldpermission_set.filter(
+        model_name=Model.__name__,
+        permission_level=_WRITE_DIRECTLY)
+
+    required_for_create = _fieldnames_required_for_create(not_tracked, Model)
+    can_create_permissions = field_permissions.filter(
+        field_name__in=required_for_create)
+
+    can_create = len(required_for_create) == can_create_permissions.count()
+
+    tracked_fields = _tracked_fields(not_tracked, Model)
+    can_delete_permissions = field_permissions.filter(
+        field_name__in=tracked_fields)
+    can_delete = len(tracked_fields) == can_delete_permissions.count()
+
+    return (can_create, can_delete)
+
+
+def _model_do_not_track(apps, Model):
+    MapFeature = apps.get_model('treemap', 'MapFeature')
+    MapFeaturePhoto = apps.get_model('treemap', 'MapFeaturePhoto')
+    PolygonalMapFeature = apps.get_model('stormwater', 'PolygonalMapFeature')
+    UserDefinedFieldDefinition = apps.get_model(
+        'treemap', 'UserDefinedFieldDefinition')
+    collection_udfs = UserDefinedFieldDefinition.objects.filter(
+        model_type=Model.__name__, iscollection=True)
+    no_track = {'instance', 'updated_at'}
+    if issubclass(Model, MapFeature):
+        no_track |= {'feature_type', 'mapfeature_ptr', 'hide_at_zoom'}
+    if issubclass(Model, MapFeaturePhoto):
+        no_track |= {'created_at', 'mapfeaturephoto_ptr'}
+    if issubclass(Model, PolygonalMapFeature):
+        no_track |= {'polygonalmapfeature_ptr'}
+    # django doesn't find class UDFModel in treemap.
+    if 'udfs' in [f.name for f in Model._meta.fields]:
+        no_track |= {'udfs'} | {'udf:{}'.format(udfd.name)
+                                for udfd in collection_udfs}
+    return no_track
+
+
+def _fieldnames_required_for_create(not_tracked, Model):
+    return {field.name for field in Model._meta.fields
+            if (not field.null and
+                not field.blank and
+                not field.primary_key and
+                not field.name in not_tracked)}
+
+
+def _tracked_fields(not_tracked, Model):
+    return {field.name for field in Model._meta.fields
+            if field.name not in not_tracked}
+
+
+def _to_photo_codename(Model, action):
+    return '{}_{}{}'.format(action, Model.__name__.lower(), 'photo')
+
+
+def _make_photo_permission(action, Model, models):
+    if Model.__name__ in {'Tree', 'Plot', 'TreePhoto'}:
+        return None
+
+    __, Permission, MapFeaturePhoto, ContentType = models
+
+    # MapFeaturePhoto is not subclassed for each MapFeature leaf class,
+    # so per-MapFeature-leaf permissions must be constructed.
+    photo_content_type = ContentType.objects.get_for_model(MapFeaturePhoto)
+    return Permission.objects.create(
+        codename=_to_photo_codename(Model, action),
+        name='Can {} {} photo'.format(action, Model._meta.verbose_name),
+        content_type=photo_content_type)
+
+
+def _get_main_models(apps):
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+    Role = apps.get_model('treemap', 'Role')
+    Permission = apps.get_model('auth', 'Permission')
+    MapFeaturePhoto = apps.get_model('treemap', 'MapFeaturePhoto')
+    return Role, Permission, MapFeaturePhoto, ContentType
+
+
+def _all_subclasses(cls):
+    subclasses = set(cls.__subclasses__())
+    return subclasses | {clz for s in subclasses for clz in _all_subclasses(s)}
+
+
+def _get_authorizable_models(apps):
+    Tree = apps.get_model('treemap', 'Tree')
+    TreePhoto = apps.get_model('treemap', 'TreePhoto')
+    MapFeature = apps.get_model('treemap', 'MapFeature')
+    all_models = set(apps.get_models()) & _all_subclasses(MapFeature)
+    leaves = {s for s in all_models if not s.__subclasses__()}
+    return leaves | {Tree, TreePhoto}
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0035_merge'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_permission, remove_permission),
+    ]

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -583,6 +583,14 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
 
     users_can_delete_own_creations = True
 
+    @classproperty
+    def always_writable(cls):
+        # `updated_at`, `hide_at_zoom`, and `geom` never need to be checked.
+        # If we ever implement the ability to lock down a model instance,
+        # `readonly` should be removed from this list.
+        return PendingAuditable.always_writable | {
+            'updated_at', 'hide_at_zoom', 'geom', 'readonly'}
+
     def __init__(self, *args, **kwargs):
         super(MapFeature, self).__init__(*args, **kwargs)
         if self.feature_type == '':
@@ -590,12 +598,6 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
         self._do_not_track.add('feature_type')
         self._do_not_track.add('mapfeature_ptr')
         self._do_not_track.add('hide_at_zoom')
-
-        # `updated_at`, `hide_at_zoom`, and `geom` never need to be checked.
-        # If we ever implement the ability to lock down a model instance,
-        # `readonly` should be removed from this list.
-        self._always_writable.update({'updated_at', 'hide_at_zoom', 'geom',
-                                     'readonly'})
 
         self.populate_previous_state()
 
@@ -1036,6 +1038,14 @@ class Tree(Convertible, UDFModel, PendingAuditable, ValidationMixin):
         }
     }
 
+    @classproperty
+    def always_writable(cls):
+        # `plot` never needs to be checked.
+        # If we ever implement the ability to lock down a model instance,
+        # `readonly` should be removed from this list.
+        return PendingAuditable.always_writable | {
+            'plot', 'readonly'}
+
     _terminology = {'singular': _('Tree'), 'plural': _('Trees')}
 
     def __unicode__(self):
@@ -1049,10 +1059,6 @@ class Tree(Convertible, UDFModel, PendingAuditable, ValidationMixin):
 
     def __init__(self, *args, **kwargs):
         super(Tree, self).__init__(*args, **kwargs)
-        # `plot` never needs to be checked.
-        # If we ever implement the ability to lock down a model instance,
-        # `readonly` should be removed from this list.
-        self._always_writable.update({'plot', 'readonly'})
 
     def dict(self):
         props = self.as_dict()

--- a/opentreemap/treemap/tests/__init__.py
+++ b/opentreemap/treemap/tests/__init__.py
@@ -20,7 +20,8 @@ from django.http import HttpResponse
 from django.conf.urls import patterns
 
 from django.contrib.gis.geos import Point, Polygon, MultiPolygon
-from django.contrib.auth.models import AnonymousUser
+from django.contrib.auth.models import AnonymousUser, Permission
+from django.contrib.contenttypes.models import ContentType
 
 from treemap.models import (User, InstanceUser, Boundary, FieldPermission,
                             Role)
@@ -338,6 +339,14 @@ def make_request(params={}, user=None, instance=None,
         setattr(req, 'instance', instance)
 
     return req
+
+
+def make_permission(codename, Model, name=None):
+    perm, __ = Permission.objects.get_or_create(
+        codename=codename,
+        name=name or codename,
+        content_type=ContentType.objects.get_for_model(Model))
+    return perm
 
 
 def media_dir(f):

--- a/opentreemap/treemap/tests/test_audit.py
+++ b/opentreemap/treemap/tests/test_audit.py
@@ -967,20 +967,15 @@ class UserRoleFieldPermissionTest(OTMTestCase):
 
         plot = Plot.objects.get(pk=self.plot.pk)
         plot.mask_unauthorized_fields(self.observer)
-        self.assertEqual(None, plot.width)
+        self.assertEqual(plot.width, None)
+        # geom is always readable
+        self.assertEqual(plot.geom, self.plot.geom)
 
         plot = Plot.objects.get(pk=self.plot.pk)
         plot.mask_unauthorized_fields(self.outlaw)
-        self.assertEqual(None, plot.width)
-
-    def test_masking_whole_queryset(self):
-        "Masking also works on entire querysets"
-        self.plot.width = 5
-        self.plot.save_base()
-
-        plots = Plot.objects.filter(pk=self.plot.pk)
-        plot = Plot.mask_queryset(plots, self.observer)[0]
-        self.assertEqual(None, plot.width)
+        self.assertEqual(plot.width, None)
+        # geom is always readable
+        self.assertEqual(plot.geom, self.plot.geom)
 
     def test_write_fails_if_any_fields_cant_be_written(self):
         """ If a user tries to modify several fields simultaneously,

--- a/opentreemap/treemap/tests/test_object_caches.py
+++ b/opentreemap/treemap/tests/test_object_caches.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 
 from treemap.audit import FieldPermission
-from treemap.lib.object_caches import (clear_caches, role_permissions,
+from treemap.lib.object_caches import (clear_caches, role_field_permissions,
                                        field_permissions, udf_defs)
 from treemap.models import InstanceUser
 from treemap.tests import (make_instance, make_commander_user,
@@ -37,7 +37,7 @@ class PermissionsCacheTest(TestCase):
 
     def get_role_permission(self, role, expectedCount, model_name='Plot',
                             field_name='geom'):
-        perms = role_permissions(role, self.instance, model_name)
+        perms = role_field_permissions(role, self.instance, model_name)
         return self.get_permission(perms, field_name, expectedCount)
 
     def get_user_permission(self, user, expectedCount, model_name='Plot',

--- a/opentreemap/treemap/tests/test_udfs.py
+++ b/opentreemap/treemap/tests/test_udfs.py
@@ -18,7 +18,7 @@ from treemap.tests import (make_instance, make_commander_user,
                            make_officer_user,
                            set_write_permissions)
 
-from treemap.lib.object_caches import role_permissions
+from treemap.lib.object_caches import role_field_permissions
 from treemap.lib.udf import udf_create
 
 from treemap.udf import UserDefinedFieldDefinition
@@ -1349,7 +1349,7 @@ class UdfCreateTest(UdfCRUTestCase):
 
         for role in roles_in_instance:
             perms = [perm.field_name
-                     for perm in role_permissions(role, self.instance)]
+                     for perm in role_field_permissions(role, self.instance)]
 
             self.assertIn('udf:cool udf', perms)
 


### PR DESCRIPTION
* Data migration for instance and model level permissions
* Change permission spec to suit roles management.
* Styling for the updated roles management page
* Changes in audit.py to better support the new permission universe,
  and corresponding test updates.
* Temporarily move photo READ_ONLY FieldPermission minimum into
  default method until #2176 is done.
  FieldPermission for photos can be entirely removed during #2176.
* Handle radio inputs in editable form JavaScript.
* Add test utility functions for use in addons.

--

Connects to OpenTreeMap/otm-addons#1287
Depends on OpenTreeMap/otm-addons#1312