### PR TITLE
Explicitly set celery version limits in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,10 @@ boto==2.42.0                             # http://docs.pythonboto.org/en/latest/
 # https://docs.djangoproject.com/en/1.10/releases/#id2
 Django==1.8.14  # rq.filter: >=1.8,<1.9
 django-apptemplates==1.2
+# django-celery requires celery, but is incompatible with celery
+# 4.0. django-celery has added this restriction on the master branch,
+# but it has not yet been released.
+celery>=3.1.15,<4.0
 django-celery-with-redis==3.0
 django-contrib-comments==1.7.3
 django-hstore==1.4.2


### PR DESCRIPTION
Version 3.1.17 of `django-celery`, which we are installing via `django-celery-with-redis` only has a minimum `celery` version set in its requirements

https://github.com/celery/django-celery/blob/v3.1.17/requirements/default.txt

```
celery>=3.1.15
```

`django-celery` fixed their requirements file on the master branch 19 days ago, but `celery` released version 4.0 before an updated version of `django-celery` was released.

I have copied the celery version restriction into our `requirements.txt` as a temporary fix until either:

- `django-celery` releases an update, and we switch to that new release.
- We remove `django-celery-with-redis` and replace it with explicit individual package references.

---

##### Testing

Using the `develop` branch, destroy your vagrant app VM and recreate it. Provisioning will fail with an `ImportError: No module named timeutils` exception. Check out this branch, destroy your vagrant app VM again, and recreate it. Provisioning should be successful

---

Connects to https://github.com/OpenTreeMap/otm-cloud/issues/313