### PR TITLE
Apply model permissions

### DIFF
--- a/opentreemap/api/instance.py
+++ b/opentreemap/api/instance.py
@@ -18,7 +18,8 @@ from django.utils.translation import ugettext as _
 
 from django_tinsel.exceptions import HttpBadRequestException
 from treemap.lib.object_caches import role_field_permissions
-from treemap.models import Instance, InstanceUser
+from treemap.audit import Role
+from treemap.models import Instance, InstanceUser, Plot
 from treemap.units import (get_units_if_convertible, get_digits_if_formattable,
                            storage_to_instance_units_factor)
 from treemap.util import safe_get_model_class
@@ -152,12 +153,7 @@ def instance_info(request, instance):
     will be tailored to that user
     """
     user = request.user
-
-    role = instance.default_role
-    if user and not user.is_anonymous():
-        instance_user = user.get_instance_user(instance)
-        if instance_user:
-            role = instance_user.role
+    role = Role.objects.get_role(instance, user)
 
     collection_udfs = instance.collection_udfs
     collection_udf_dict = {"%s.%s" % (udf.model_type.lower(),
@@ -244,7 +240,7 @@ def instance_info(request, instance):
     info['meta_perms'] = {
         'can_add_tree': perms_lib.plot_is_creatable(role),
         'can_edit_tree': perms_lib.plot_is_writable(role),
-        'can_edit_tree_photo': perms_lib.treephoto_is_writable(role),
+        'can_edit_tree_photo': perms_lib.photo_is_addable(role, Plot),
     }
 
     public_config_keys = ['scss_variables']

--- a/opentreemap/stormwater/models.py
+++ b/opentreemap/stormwater/models.py
@@ -26,8 +26,12 @@ class PolygonalMapFeature(MapFeature):
 
     def __init__(self, *args, **kwargs):
         super(PolygonalMapFeature, self).__init__(*args, **kwargs)
-        self._do_not_track.add('polygonalmapfeature_ptr')
+        self._do_not_track |= self.do_not_track
         self.populate_previous_state()
+
+    @classproperty
+    def do_not_track(cls):
+        return MapFeature.do_not_track | {'polygonalmapfeature_ptr'}
 
     @property
     def is_editable(self):

--- a/opentreemap/stormwater/tests.py
+++ b/opentreemap/stormwater/tests.py
@@ -65,6 +65,16 @@ class ResourcePermsTest(PermissionsTestCase):
         rainbarrel = RainBarrel(instance=self.instance, geom=self.p)
         self.assertTrue(perms.photo_is_addable(self.role_yes, rainbarrel))
 
+    def test_rainbarrel_photo_is_not_addable(self):
+        self._add_builtin_permission(self.role_no, RainBarrel,
+                                     'add_rainbarrel')
+        self._add_builtin_permission(self.role_no, Bioswale,
+                                     'add_bioswale')
+        self._add_builtin_permission(self.role_no, MapFeaturePhoto,
+                                     'add_bioswalephoto')
+        rainbarrel = RainBarrel(instance=self.instance, geom=self.p)
+        self.assertFalse(perms.photo_is_addable(self.role_no, rainbarrel))
+
     def test_user_can_create_rainbarrel_photo(self):
         self._add_builtin_permission(self.role_yes, MapFeaturePhoto,
                                      'add_rainbarrelphoto')
@@ -75,16 +85,6 @@ class ResourcePermsTest(PermissionsTestCase):
                                 map_feature=rainbarrel)
         photo.set_image(self.load_resource('tree1.gif'))
         self.assertTrue(photo.user_can_create(user_yes))
-
-    def test_rainbarrel_photo_is_not_addable(self):
-        self._add_builtin_permission(self.role_no, RainBarrel,
-                                     'add_rainbarrel')
-        self._add_builtin_permission(self.role_no, Bioswale,
-                                     'add_bioswale')
-        self._add_builtin_permission(self.role_no, MapFeaturePhoto,
-                                     'add_bioswalephoto')
-        rainbarrel = RainBarrel(instance=self.instance, geom=self.p)
-        self.assertFalse(perms.photo_is_addable(self.role_no, rainbarrel))
 
     def test_user_cannot_create_rainbarrel_photo(self):
         self._add_builtin_permission(self.role_no, RainBarrel,

--- a/opentreemap/treemap/audit.py
+++ b/opentreemap/treemap/audit.py
@@ -15,7 +15,7 @@ from django.forms.models import model_to_dict
 from django.utils.translation import ugettext_lazy as _
 from django.utils.dateformat import format as dformat
 from django.dispatch import receiver
-from django.db.models import OneToOneField
+from django.db import models as django_models
 from django.db.models.signals import post_save, post_delete
 from django.db.models.fields import FieldDoesNotExist
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
@@ -27,7 +27,10 @@ from treemap.units import (is_convertible, is_convertible_or_formattable,
                            get_display_value, get_units, get_unit_name,
                            Convertible)
 from treemap.util import (all_models_of_class, leaf_models_of_class,
-                          to_object_name, safe_get_model_class)
+                          to_object_name, safe_get_model_class,
+                          get_pk_from_collection_audit_name,
+                          get_name_from_canonical_name,
+                          make_udf_name_from_key)
 from treemap.decorators import classproperty
 
 from treemap.lib.object_caches import (field_permissions,
@@ -56,7 +59,7 @@ def get_id_sequence_name(model_class):
     Tree => 'treemap_tree_id_seq'
     Plot => 'treemap_mapfeature_id_seq'
     """
-    if isinstance(model_class._meta.pk, OneToOneField):
+    if isinstance(model_class._meta.pk, django_models.OneToOneField):
         # Model uses multi-table inheritance (probably a MapFeature subclass)
         model_class = model_class._meta.get_parent_list()[-1]
 
@@ -146,6 +149,9 @@ def approve_or_reject_audits_and_apply(audits, user, approved):
 
 
 def add_instance_permissions(roles):
+    """
+    Add all the instance permissions to all the roles passed in.
+    """
     from treemap.plugin import get_instance_permission_spec
     for spec in get_instance_permission_spec():
         perm = Permission.objects.get(codename=spec['codename'])
@@ -155,6 +161,14 @@ def add_instance_permissions(roles):
 
 
 def add_default_permissions(instance, roles=None, models=None):
+    """
+    Add field permissions with the `role.default_permission_level`
+    for all the models to all the roles.
+
+    For roles with `default_permission_level` that permits write,
+    also add all the `add` and `delete` model permissions
+    for all the models.
+    """
     # Audit is imported into models, so models can't be imported up top
     from treemap.models import MapFeaturePhoto
     if roles is None:
@@ -186,12 +200,7 @@ def _add_default_add_and_delete_permissions(models, roles):
     existing = ThroughModel.objects.filter(role_id__in=role_ids)
     existing_pairs = [(e.role_id, e.permission_id) for e in existing]
 
-    perm_names = [Role.permission_codename(Model, action)
-                  for Model in models for action in ['add', 'delete']] + \
-                 [Role.permission_codename(Model, action, photo=True)
-                  for Model in models for action in ['add', 'delete']
-                  if Model.__name__ != 'Plot']
-    perms = Permission.objects.filter(codename__in=perm_names)
+    perms = Role.model_permissions(models)
 
     role_perms = [ThroughModel(role_id=role_id, permission_id=perm.id)
                   for role_id in role_ids for perm in perms
@@ -211,46 +220,25 @@ def _add_default_field_permissions(models, role, instance):
         mobj = Model(instance=instance)
 
         model_name = mobj._model_name
-        udfs = [udf.canonical_name for udf in udf_defs(instance, model_name)]
+        udfs = {udf.canonical_name for udf in udf_defs(instance, model_name)}
 
-        model_fields = set(mobj.tracked_fields + udfs)
-
-        for field_name in model_fields:
-            perms.append({
-                'model_name': model_name,
-                'field_name': field_name,
-                'role': role,
-                'instance': role.instance
-            })
-
-    #TODO: Remove while implementing issue
-    # https://github.com/OpenTreeMap/otm-core/issues/2176
-    # Making photos read only used to be done in the management page,
-    # but hopefully #2176 can be done without touching management,
-    # so move it here for now.
-    #
-    # Ugliness is due to perm sometimes being a dict,
-    # sometimes a FieldPermission.
-    def default_permission_level(perm):
-        if role.default_permission_level < FieldPermission.READ_ONLY:
-            model_name = getattr(perm, 'model_name', '')
-            if model_name == '' and getattr(perm, 'get'):
-                model_name = perm.get('model_name', '')
-            if model_name.lower().endswith('photo'):
-                return FieldPermission.READ_ONLY
-        return role.default_permission_level
+        perms += [{'model_name': model_name,
+                   'field_name': field_name,
+                   'role': role,
+                   'instance': role.instance}
+                  for field_name in Model.requires_authorization | udfs]
 
     existing = FieldPermission.objects.filter(role=role, instance=instance)
     if existing.exists():
         for perm in perms:
             perm['defaults'] = {
-                'permission_level': default_permission_level(perm)
+                'permission_level': role.default_permission_level
             }
             FieldPermission.objects.get_or_create(**perm)
     else:
         perms = [FieldPermission(**perm) for perm in perms]
         for perm in perms:
-            perm.permission_level = default_permission_level(perm)
+            perm.permission_level = role.default_permission_level
 
         FieldPermission.objects.bulk_create(perms)
         # Because we use bulk_create, we must manually trigger the save signal
@@ -468,38 +456,42 @@ def _verify_user_can_apply_audit(audit, user):
     If the model is a udf collection, verify the user has
     write directly permission on the UDF
     """
-    # This comingling here isn't really great...
-    # However it allows us to have a pretty external interface in that
-    # UDF collections can have a single permission based on the original
-    # model, instead of having to assign a bunch of new ones.
-    from udf import UserDefinedFieldDefinition
 
+    model, field = _get_model_and_field(audit)
+    Model = safe_get_model_class(model)
+
+    if field in Model.bypasses_authorization:
+        return
+
+    perms = [perm for perm in field_permissions(user, audit.instance, model)
+             if perm.field_name == field]
+    if len(perms) == 1:
+        if perms[0].permission_level != FieldPermission.WRITE_DIRECTLY:
+                raise AuthorizeException(
+                    "User %s can't edit field %s on model %s" %
+                    (user, field, model))
+    elif len(perms) == 0:
+        raise AuthorizeException(
+            "User %s can't edit field %s on model %s"
+            " (No permissions found)" %
+            (user, field, model))
+
+
+def _get_model_and_field(audit):
     if audit.model.startswith('udf:'):
-        # TODO: should use caching (udf_defs)
-        udf = UserDefinedFieldDefinition.objects.get(pk=audit.model[4:])
-        field = 'udf:%s' % udf.name
+        # This comingling here isn't really great...
+        # However it allows us to have a pretty external interface in that
+        # UDF collections can have a single permission based on the original
+        # model, instead of having to assign a bunch of new ones.
+        key = get_pk_from_collection_audit_name(audit.model)
+        udf = [defn for defn in udf_defs(audit.instance)
+               if defn.pk == key][0]
+        field = make_udf_name_from_key(udf.name)
         model = udf.model_type
     else:
         field = audit.field
         model = audit.model
-
-    perms = field_permissions(user, audit.instance, model)
-
-    foundperm = False
-    for perm in perms:
-        if perm.field_name == field:
-            if perm.permission_level == FieldPermission.WRITE_DIRECTLY:
-                foundperm = True
-                break
-            else:
-                raise AuthorizeException(
-                    "User %s can't edit field %s on model %s" %
-                    (user, field, model))
-
-    if not foundperm:
-        raise AuthorizeException(
-            "User %s can't edit field %s on model %s (No permissions found)" %
-            (user, field, model))
+    return model, field
 
 
 @transaction.atomic
@@ -543,7 +535,7 @@ class UserTrackable(Dictable):
         # updated_at is "metadata" and it does not make sense to
         # redundantly track when it changes, assign reputation for
         # editing it, etc.
-        self._do_not_track = set(['instance', 'updated_at'])
+        self._do_not_track = self.do_not_track
         super(UserTrackable, self).__init__(*args, **kwargs)
         self.populate_previous_state()
 
@@ -553,12 +545,9 @@ class UserTrackable(Dictable):
         # is none, set it to the default value of the field.
         setattr(self, key, orig_value)
 
-    def _fields_required_for_create(self):
-        return [field for field in self._meta.fields
-                if (not field.null and
-                    not field.blank and
-                    not field.primary_key and
-                    not field.name in self._do_not_track)]
+    @classproperty
+    def do_not_track(cls):
+        return {'instance', 'updated_at'}
 
     @property
     def tracked_fields(self):
@@ -703,7 +692,7 @@ class FieldPermission(models.Model):
     @property
     def display_field_name(self):
         if self.field_name.startswith('udf:'):
-            base_name = self.field_name[4:]
+            base_name = get_name_from_canonical_name(self.field_name)
         else:
             Model = safe_get_model_class(self.model_name)
             field = Model._meta.get_field(self.field_name)
@@ -745,10 +734,19 @@ post_save.connect(invalidate_adjuncts, sender=FieldPermission)
 post_delete.connect(invalidate_adjuncts, sender=FieldPermission)
 
 
+class RoleManager(models.Manager):
+    def get_role(self, instance, user=None):
+        if user is None or user.is_anonymous():
+            return instance.default_role
+        return user.get_role(instance)
+
+
 class Role(models.Model):
     # special role names, used in the app
     DEFAULT_ROLE_NAMES = ('administrator', 'editor', 'public')
     ADMINISTRATOR, EDITOR, PUBLIC = DEFAULT_ROLE_NAMES
+
+    objects = RoleManager()
 
     name = models.CharField(max_length=255)
     instance = models.ForeignKey('Instance', null=True, blank=True)
@@ -781,6 +779,20 @@ class Role(models.Model):
         photo = 'photo' if photo else ''
         return '{}_{}{}'.format(action, Model.__name__.lower(), photo)
 
+    @classmethod
+    def model_permissions(clz, models, actions=None,
+                          include_photos=True):
+        if actions is None:
+            actions = ['add', 'delete']
+        perm_names = [Role.permission_codename(Model, action)
+                      for Model in models for action in actions]
+        if include_photos:
+            perm_names += [
+                Role.permission_codename(Model, action, photo=True)
+                for Model in models for action in ['add', 'delete']
+                if Model.__name__ != 'Plot']
+        return Permission.objects.filter(codename__in=perm_names)
+
     def has_permission(self, codename, Model=None):
         """
         Return true if role has permission 'codename' for 'Model';
@@ -798,7 +810,7 @@ class Role(models.Model):
 
 class AuthorizeException(Exception):
     def __init__(self, name):
-        super(Exception, self).__init__(name)
+        super(AuthorizeException, self).__init__(name)
 
 
 class Authorizable(UserTrackable):
@@ -844,24 +856,8 @@ class Authorizable(UserTrackable):
         return perm_set.union(self.always_writable)
 
     def user_can_delete(self, user):
-        """
-        A user is able to delete an object if they have all
-        field permissions on a model.
-        If the model sets 'users_can_delete_own_creations',
-        then the user that created it can delete it without
-        necessarily having all the field permissions.
-        """
-
-        if not user or not user.is_authenticated():
-            return False
-        if self.is_user_administrator(user):
-            return True
-        writable_perms = set()
-        try:
-            writable_perms = self._get_writable_perms_set(user)
-        except AuthorizeException:
-            pass
-        can_delete = writable_perms >= set(self.tracked_fields)
+        can_delete = user.get_role(self.get_instance()).can_delete(
+            self.__class__)
         if not can_delete:
             if getattr(self, 'users_can_delete_own_creations', False):
                 can_delete = self.was_created_by(user)
@@ -876,25 +872,8 @@ class Authorizable(UserTrackable):
         )
         return fields_created_by_user.exists()
 
-    def user_can_create(self, user, direct_only=False):
-        """
-        A user is able to create an object if they have permission on
-        all required fields of its model.
-
-        If direct_only is False this method will return true
-        if the user has either permission to create directly or
-        create with audits
-        """
-        can_create = True
-
-        perm_set = self._get_writable_perms_set(user, direct_only)
-
-        for field in self._fields_required_for_create():
-            if field.name not in perm_set:
-                can_create = False
-                break
-
-        return can_create
+    def user_can_create(self, user):
+        return user.get_role(self.get_instance()).can_create(self.__class__)
 
     def _assert_not_masked(self):
         """
@@ -967,6 +946,9 @@ class Authorizable(UserTrackable):
                     raise AuthorizeException("Can't edit field %s on %s" %
                                             (field, self._model_name))
 
+        # If `WRITE_WITH_AUDIT` (i.e. pending write) is resurrected,
+        # this test will prevent `_PendingAuditable` from getting called
+        # and making the audit objects required for approval or rejection.
         elif not self.user_can_create(user):
             raise AuthorizeException("%s does not have permission to "
                                      "create new %s objects." %
@@ -991,6 +973,19 @@ class Authorizable(UserTrackable):
             raise AuthorizeException("%s does not have permission to "
                                      "delete %s %s." %
                                      (user, self._model_name, self.id))
+
+    @classproperty
+    def bypasses_authorization(cls):
+        return cls.do_not_track | cls.always_writable
+
+    @classproperty
+    def requires_authorization(cls):
+        """
+        Return the set of fieldnames that require FieldPermission
+        in order to read or write.
+        """
+        return {f.name for f in cls._meta.fields
+                if f.name not in cls.bypasses_authorization}
 
 
 class AuditException(Exception):
@@ -1155,17 +1150,16 @@ class _PendingAuditable(Auditable):
                         "'full_clean_with_user'")
 
     def full_clean_with_user(self, user):
-        if (self.user_can_create(user, direct_only=True)):
+        if self.user_can_create(user):
             exclude_fields = []
         else:
             # If we aren't making a real object then we shouldn't
             # check foreign key contraints. These will be checked
             # when the object is actually made. They are also enforced
-            # a the database level
-            exclude_fields = []
-            for field in self._fields_required_for_create():
-                if isinstance(field, models.ForeignKey):
-                    exclude_fields.append(field.name)
+            # at the database level
+            exclude_fields = [
+                field for field in self._meta.fields
+                if isinstance(field, models.ForeignKey)]
 
         super(_PendingAuditable, self).full_clean(exclude=exclude_fields)
 
@@ -1175,9 +1169,7 @@ class _PendingAuditable(Auditable):
                    .filter(ref__isnull=True)\
                    .order_by('-created')
 
-    def save_with_system_user_bypass_auth(self,
-                                          *args,
-                                          **kwargs):
+    def save_with_system_user_bypass_auth(self, *args, **kwargs):
         from treemap.models import User
         return self.save_with_user(User.system_user(),
                                    auth_bypass=True, *args, **kwargs)
@@ -1203,7 +1195,7 @@ class _PendingAuditable(Auditable):
 
         is_insert = self.pk is None
 
-        if ((self.user_can_create(user, direct_only=True)
+        if ((self.user_can_create(user)
              or not is_insert or auth_bypass)):
             # Auditable will make the audits for us (including pending audits)
             return super(_PendingAuditable, self).save_with_user(
@@ -1368,11 +1360,11 @@ class Audit(models.Model):
         # get the model/field class for each audit record and convert
         # the value to a python object
         if self.field.startswith('udf:'):
-            field_name = self.field[4:]
+            field_name = get_name_from_canonical_name(self.field)
             udfds = udf_defs(self.instance)
 
             if self.model.startswith('udf:'):
-                udfd_pk = int(self.model[4:])
+                udfd_pk = get_pk_from_collection_audit_name(self.model)
                 udf_def = next((udfd for udfd in udfds if udfd.pk == udfd_pk),
                                None)
                 if udf_def is not None:
@@ -1468,7 +1460,7 @@ class Audit(models.Model):
             return ''
         name = self.field
         if name.startswith('udf:'):
-            return name[4:]
+            return get_name_from_canonical_name(name)
         else:
             return name.replace('_', ' ')
 

--- a/opentreemap/treemap/lib/object_caches.py
+++ b/opentreemap/treemap/lib/object_caches.py
@@ -80,10 +80,8 @@ def increment_adjuncts_timestamp(instance):
 
 
 def _permissions_from_db(user, instance, model_name):
-    if user is None or user.is_anonymous():
-        role = instance.default_role
-    else:
-        role = user.get_role(instance)
+    from treemap.audit import Role
+    role = Role.objects.get_role(instance, user)
     return _role_permissions_from_db(role, model_name)
 
 

--- a/opentreemap/treemap/lib/perms.py
+++ b/opentreemap/treemap/lib/perms.py
@@ -217,6 +217,8 @@ def any_resource_is_creatable(role_related_obj):
 
 
 def _get_associated_model_class(associated_model):
+    if callable(getattr(associated_model, 'cast_to_subtype', None)):
+        associated_model = associated_model.cast_to_subtype()
     clz = associated_model.__class__ if \
         isinstance(associated_model, Authorizable) else associated_model
     return Tree if clz == Plot else clz

--- a/opentreemap/treemap/lib/perms.py
+++ b/opentreemap/treemap/lib/perms.py
@@ -5,7 +5,9 @@ from __future__ import division
 from treemap.lib.object_caches import role_field_permissions
 
 from django.contrib.gis.db.models import Field
-from treemap.models import InstanceUser, Role, Plot
+from treemap.audit import Authorizable
+from treemap.models import (InstanceUser, Role, Plot, Tree, TreePhoto,
+                            MapFeaturePhoto)
 
 """
 Tools to assist in resolving permissions, specifically when the type of
@@ -75,8 +77,7 @@ def _allows_perm(role_related_obj, model_name,
 
     # process args
     if field and fields:
-        raise ValueError("Cannot provide non-None values "
-                         "to both 'field' and 'fields'. Pick One.")
+        fields = set(fields) | {field}
     elif field and not fields:
         fields = {field}
     elif not fields:
@@ -143,6 +144,10 @@ def is_read_or_write(perm_string):
 
 
 def is_deletable(instanceuser, obj):
+    # Have to ask if a specific user can delete a specific object
+    # because even if the specific user's role cannot delete instances
+    # of the object's class, the original creator of the object can,
+    # if the Model sets `users_can_delete_own_creations` to `True`
     if _invalid_instanceuser(instanceuser):
         return False
     else:
@@ -178,21 +183,6 @@ def udf_write_level(instanceuser, udf):
     return level
 
 
-def plot_is_creatable(role_related_obj):
-    return _allows_perm(role_related_obj, 'Plot',
-                        perm_attr=ALLOWS_WRITES,
-                        fields=Plot()._fields_required_for_create(),
-                        feature_name='add_plot',
-                        predicate=all)
-
-
-def map_feature_is_creatable(role_related_obj, Model):
-    return _allows_perm(role_related_obj, Model.__name__,
-                        perm_attr=ALLOWS_WRITES,
-                        fields=Model()._fields_required_for_create(),
-                        predicate=all)
-
-
 def map_feature_is_writable(role_related_obj, model_obj, field=None):
     return _allows_perm(role_related_obj,
                         model_obj.__class__.__name__,
@@ -206,6 +196,17 @@ def plot_is_writable(role_related_obj, field=None):
                         predicate=any, field=field)
 
 
+def plot_is_creatable(role_related_obj):
+    return map_feature_is_creatable(role_related_obj, Plot)
+
+
+def map_feature_is_creatable(role_related_obj, Model):
+    role = _get_role_from_related_object(role_related_obj)
+    if role is None:
+        return False
+    return role.can_create(Model)
+
+
 def any_resource_is_creatable(role_related_obj):
     role = _get_role_from_related_object(role_related_obj)
     if role is None:
@@ -215,23 +216,15 @@ def any_resource_is_creatable(role_related_obj):
                for Model in role.instance.resource_classes)
 
 
-def geom_is_writable(instanceuser, model_name):
-    return _allows_perm(instanceuser, model_name,
-                        perm_attr=ALLOWS_WRITES,
-                        predicate=any, field='geom')
+def _get_associated_model_class(associated_model):
+    clz = associated_model.__class__ if \
+        isinstance(associated_model, Authorizable) else associated_model
+    return Tree if clz == Plot else clz
 
 
-def treephoto_is_writable(role_related_obj):
-    return _allows_perm(role_related_obj, 'TreePhoto',
-                        fields=PHOTO_PERM_FIELDS | {'tree'},
-                        feature_name='tree_image_upload',
-                        perm_attr=ALLOWS_WRITES,
-                        predicate=all)
-
-
-def mapfeaturephoto_is_writable(role_related_obj):
-    return _allows_perm(role_related_obj, 'MapFeaturePhoto',
-                        fields=PHOTO_PERM_FIELDS,
-                        feature_name='tree_image_upload',
-                        perm_attr=ALLOWS_WRITES,
-                        predicate=all)
+def photo_is_addable(role_related_obj, associated_model):
+    AssociatedClass = _get_associated_model_class(associated_model)
+    PhotoClass = TreePhoto if AssociatedClass == Tree else MapFeaturePhoto
+    codename = Role.permission_codename(AssociatedClass, 'add', photo=True)
+    role = _get_role_from_related_object(role_related_obj)
+    return role and role.has_permission(codename, PhotoClass) or False

--- a/opentreemap/treemap/migrations/0037_fix_plot_add_delete_permission_labels.py
+++ b/opentreemap/treemap/migrations/0037_fix_plot_add_delete_permission_labels.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def change_labels(apps, term):
+    Permission = apps.get_model('auth', 'Permission')
+    add_plot = Permission.objects.filter(codename='add_plot')
+    delete_plot = Permission.objects.filter(codename='delete_plot')
+    add_plot.update(name='Can add {}'.format(term))
+    delete_plot.update(name='Can delete {}'.format(term))
+
+
+def fix_labels(apps, schema_editor):
+    change_labels(apps, 'planting site')
+
+
+def revert_labels(apps, schema_editor):
+    change_labels(apps, 'plot')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0036_assign_role_add_delete_permissions'),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_labels, revert_labels),
+    ]

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -1253,16 +1253,21 @@ class MapFeaturePhoto(models.Model, PendingAuditable, Convertible):
         thumb.delete(False)
         image.delete(False)
 
+    def user_can_create(self, user):
+        return self._user_can_do(user, 'add')
+
     def user_can_delete(self, user):
         """
         A user can delete a photo if their role has the right permission
         or if they created the photo.
         """
+        return self._user_can_do(user, 'delete') or self.was_created_by(user)
+
+    def _user_can_do(self, user, action):
         role = user.get_role(self.get_instance())
         codename = Role.permission_codename(self.map_feature.__class__,
-                                            'delete', photo=True)
-        return role.has_permission(codename, Model=self.__class__) or \
-            self.was_created_by(user)
+                                            action, photo=True)
+        return role.has_permission(codename, Model=self.__class__)
 
 
 class TreePhoto(MapFeaturePhoto):

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -1268,9 +1268,11 @@ class MapFeaturePhoto(models.Model, PendingAuditable, Convertible):
 
     def _user_can_do(self, user, action):
         role = user.get_role(self.get_instance())
-        codename = Role.permission_codename(self.map_feature.__class__,
-                                            action, photo=True)
-        return role.has_permission(codename, Model=self.__class__)
+        Clz = self.map_feature.__class__
+        if callable(getattr(self.map_feature, 'cast_to_subtype', None)):
+            Clz = self.map_feature.cast_to_subtype().__class__
+        codename = Role.permission_codename(Clz, action, photo=True)
+        return role.has_permission(codename, Model=MapFeaturePhoto)
 
 
 class TreePhoto(MapFeaturePhoto):

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -1277,6 +1277,11 @@ class TreePhoto(MapFeaturePhoto):
     def always_writable(cls):
         return MapFeaturePhoto.always_writable | {'tree'}
 
+    def user_can_create(self, user):
+        # MapFeaturePhoto as a leaf obeys different rules,
+        # so defer to our grand-super.
+        return super(MapFeaturePhoto, self).user_can_create(user)
+
     def user_can_delete(self, user):
         # MapFeaturePhoto as a leaf obeys different rules,
         # so defer to our grand-super.

--- a/opentreemap/treemap/templates/treemap/map_feature_detail.html
+++ b/opentreemap/treemap/templates/treemap/map_feature_detail.html
@@ -71,13 +71,12 @@
                             data-toggle="modal"
                             data-target="#add-photo-modal"
                             data-href="{{ request.get_full_path }}"
+                            data-always-enable="{{ last_effective_instance_user|photo_is_addable:feature }}"
                             disabled="disabled"
                             {% if feature.is_plot %}
                             data-disabled-title="{% trans "Adding tree photos is not available to all users" %}"
-                            data-always-enable="{{ last_effective_instance_user|treephoto_is_writable }}"
                             {% else %}
                             data-disabled-title="{% trans "Adding resource photos is not available to all users" %}"
-                            data-always-enable="{{ last_effective_instance_user|mapfeaturephoto_is_writable }}"
                             {% endif %}
                             class="btn btn-xs add-photos">{% trans "Add Photo" %}</button>
                 </div>
@@ -99,9 +98,6 @@
                         </div>
                         {% if feature.is_editable %}
                             <button
-                                    disabled="disabled"
-                                    data-always-enable="{{ last_effective_instance_user|geom_is_writable:feature.feature_type }}"
-                                    data-disabled-title="{% trans "Editing location is not available to all users" %}"
                                     data-href="{{ request.get_full_path }}"
                                     style="display:none"
                                     id="edit-location"

--- a/opentreemap/treemap/templates/treemap/partials/photo_carousel.html
+++ b/opentreemap/treemap/templates/treemap/partials/photo_carousel.html
@@ -23,7 +23,7 @@
     </a>
     {% endif %}
   </div>
-{% empty %}
+  {% empty %}
   {% if feature.is_plot %}
   <div class="item active">
     <img id="tree-photo-placeholder" src="{{ STATIC_URL }}img/tree.png" alt="{% trans 'There are no photos' %}">

--- a/opentreemap/treemap/templatetags/instance_config.py
+++ b/opentreemap/treemap/templatetags/instance_config.py
@@ -67,13 +67,10 @@ def as_json(d):
     return json.dumps(d)
 
 udf_write_level = register.filter(perms.udf_write_level)
-geom_is_writable = register.filter(perms.geom_is_writable)
 map_feature_is_writable = register.filter(perms.map_feature_is_writable)
 plot_is_writable = register.filter(perms.plot_is_writable)
 is_deletable = register.filter(perms.is_deletable)
 is_read_or_write = register.filter(perms.is_read_or_write)
-treephoto_is_writable = register.filter(perms.treephoto_is_writable)
-mapfeaturephoto_is_writable = register.filter(
-    perms.mapfeaturephoto_is_writable)
+photo_is_addable = register.filter(perms.photo_is_addable)
 any_resource_is_creatable = register.filter(perms.any_resource_is_creatable)
 plot_is_creatable = register.filter(perms.plot_is_creatable)

--- a/opentreemap/treemap/tests/test_object_caches.py
+++ b/opentreemap/treemap/tests/test_object_caches.py
@@ -26,7 +26,7 @@ class PermissionsCacheTest(TestCase):
 
         self.simple_user = make_user()
         default_role = self.instance.default_role
-        FieldPermission(model_name='Plot', field_name='geom',
+        FieldPermission(model_name='Plot', field_name='owner_orig_id',
                         role=default_role, instance=self.instance,
                         permission_level=READ).save()
 
@@ -36,27 +36,27 @@ class PermissionsCacheTest(TestCase):
         return perms[0] if expectedCount == 1 else None
 
     def get_role_permission(self, role, expectedCount, model_name='Plot',
-                            field_name='geom'):
+                            field_name='owner_orig_id'):
         perms = role_field_permissions(role, self.instance, model_name)
         return self.get_permission(perms, field_name, expectedCount)
 
     def get_user_permission(self, user, expectedCount, model_name='Plot',
-                            field_name='geom'):
+                            field_name='owner_orig_id'):
         perms = field_permissions(user, self.instance, model_name)
         return self.get_permission(perms, field_name, expectedCount)
 
     def assert_role_permission(self, role, level, model_name='Plot',
-                               field_name='geom'):
+                               field_name='owner_orig_id'):
         perm = self.get_role_permission(role, 1, model_name, field_name)
         self.assertEqual(level, perm.permission_level)
 
     def assert_user_permission(self, user, level, model_name='Plot',
-                               field_name='geom'):
+                               field_name='owner_orig_id'):
         perm = self.get_user_permission(user, 1, model_name, field_name)
         self.assertEqual(level, perm.permission_level)
 
     def set_permission(self, role, level, model_name='Plot',
-                       field_name='geom'):
+                       field_name='owner_orig_id'):
         fp, created = FieldPermission.objects.get_or_create(
             model_name=model_name,
             field_name=field_name,
@@ -65,7 +65,8 @@ class PermissionsCacheTest(TestCase):
         fp.permission_level = level
         fp.save()
 
-    def get_single_perm_qs(self, role, model_name='Plot', field_name='geom'):
+    def get_single_perm_qs(self, role, model_name='Plot',
+                           field_name='owner_orig_id'):
         return FieldPermission.objects.filter(
             model_name=model_name,
             field_name=field_name,
@@ -74,12 +75,13 @@ class PermissionsCacheTest(TestCase):
         )
 
     def set_permission_silently(self, role, level, model_name='Plot',
-                                field_name='geom'):
+                                field_name='owner_orig_id'):
         # update() sends no signals, so cache won't be invalidated
         qs = self.get_single_perm_qs(role, model_name, field_name)
         qs.update(permission_level=level)
 
-    def delete_permission(self, role, model_name='Plot', field_name='geom'):
+    def delete_permission(self, role, model_name='Plot',
+                          field_name='owner_orig_id'):
         qs = self.get_single_perm_qs(role, model_name, field_name)
         qs.delete()
 

--- a/opentreemap/treemap/tests/test_templatetags.py
+++ b/opentreemap/treemap/tests/test_templatetags.py
@@ -7,7 +7,6 @@ import tempfile
 import json
 import os
 from shutil import rmtree
-from unittest.case import skip
 
 from django.template import Template, Context, TemplateSyntaxError
 from django.test.utils import override_settings
@@ -19,7 +18,8 @@ from treemap.templatetags.partial import PartialNode
 from treemap.udf import UserDefinedFieldDefinition
 from treemap.models import Plot, Tree, InstanceUser
 from treemap.tests import (make_instance, make_observer_user,
-                           make_commander_user, make_user, make_request)
+                           make_commander_user, make_user, make_request,
+                           make_conjurer_user, make_tweaker_user)
 from treemap.tests.base import OTMTestCase
 from treemap.templatetags.util import display_name
 
@@ -178,15 +178,13 @@ class UserCanCreateTagTest(OTMTestCase):
             self._render_basic_template_with_vars(AnonymousUser, self.plot),
             '')
 
-    @skip("User can create tests are broken until next iteration"
-          " in the instance permissions cutover")
     def test_works_with_user_with_no_create_perms(self):
-        user = make_observer_user(self.instance)
+        user = make_tweaker_user(self.instance)
         self.assertEqual(
             self._render_basic_template_with_vars(user, self.plot), '')
 
     def test_works_with_user_with_create_perms(self):
-        user = make_commander_user(self.instance)
+        user = make_conjurer_user(self.instance)
         self.assertEqual(
             self._render_basic_template_with_vars(user, self.plot), 'true')
 

--- a/opentreemap/treemap/udf.py
+++ b/opentreemap/treemap/udf.py
@@ -1112,6 +1112,8 @@ class UDFModel(UserTrackable, models.Model):
         # Collection UDF audits are handled by the UDFCollectionValue class
         self._collection_field_names = {udfd.canonical_name
                                         for udfd in self.collection_udfs}
+        # This is the whole reason for keeping _do_not_track
+        # in addition to the do_not_track class property.
         self._do_not_track |= self.do_not_track | self._collection_field_names
         self.populate_previous_state()
 

--- a/opentreemap/treemap/util.py
+++ b/opentreemap/treemap/util.py
@@ -33,7 +33,7 @@ def safe_get_model_class(model_string):
     """
     from treemap.models import MapFeature
 
-    # All of our models live in 'treemap.models', so
+    # All of our base models live in 'treemap.models', so
     # we can start with that namespace
     models_module = __import__('treemap.models')
 
@@ -209,3 +209,19 @@ def can_read_as_super_admin(request):
         return False
     else:
         return request.user.is_super_admin() and request.method == 'GET'
+
+
+# Utilities for ways in which a UserDefinedFieldDefinition is identified.
+# Please also see name related properties on that class.
+# Note that audits refer to collection udfds as 'udf:{udfd.pk}',
+# but to scalar udfds as 'udf:{udfd.name}', same as FieldPermissions
+def get_pk_from_collection_audit_name(name):
+    return int(name[4:])
+
+
+def get_name_from_canonical_name(canonical_name):
+    return canonical_name[4:]
+
+
+def make_udf_name_from_key(key):
+    return 'udf:{}'.format(key)


### PR DESCRIPTION
* Create new tests, adapt old tests, add to the cast of users
* Remove tests around provisional creation
* Modify `audit` and `perms` to use model permissions
* Modify `instance_config` and templates that use it
* Minor clean-up along the way

--

Connects to #2176
Connects to #2411 
Connects to #2177 
Depends on OpenTreeMap/otm-addons#1324