### PR TITLE
Add tree owner to Treezilla migration

### DIFF
--- a/opentreemap/otm1_migrator/migration_rules/treezilla.py
+++ b/opentreemap/otm1_migrator/migration_rules/treezilla.py
@@ -7,6 +7,9 @@ TREEZILLA_ITREE_REGION_CODE = 'NoEastXXX'
 METERS_TO_INCHES = 39.3701
 METERS_TO_FEET = 3.28084
 
+MIGRATION_RULES['tree']['removed_fields'].remove('tree_owner')
+MIGRATION_RULES['tree']['common_fields'].add('tree_owner')
+
 BOUNDARY_TYPES = {
     'DIS': {'name': 'District', 'sort_order': 10},
     'LBO': {'name': 'London Borough', 'sort_order': 10},
@@ -100,6 +103,7 @@ UDFS = {
     },
     'tree': {
         'sponsor': {'udf.name': 'Sponsor'},
+        'tree_owner': {'udf.name': 'Owner'},
         'pests': {
             'udf.name': 'Pests',
             'udf.choices': [


### PR DESCRIPTION
The `Tree.tree_owner` field is "removed" in the default migration rules, but over half of the trees in the Treezilla data set have a `tree_owner` value that we should preserve.

--- 

##### Testing

I ran a migration into a new instance on my developer VM using this branch.

OTM1
```sql
tz=# select tree_owner, count(*) from treemap_tree group by tree_owner order by tree_owner;
           tree_owner           | count
--------------------------------+-------
 0                              |     1
 David and Judith Jenkins       |     1
 Open University                |   862
 RBG Edinburgh                  |     1
 Robert and Angela Hull         |     1
 Royal Botanic Garden Edinburgh |  2588
 Stowupland Parish Council      |   114
 Stowupland Parish Council      |     8
 Stowupland Parish Councl       |     1
 Walsall Council                | 24236
                                | 23040
```

OTM2
```sql
otm=# select udfs->'Owner', count(*) from treemap_tree where instance_id = 720 group by udfs->'Owner' order by udfs->'Owner';
            ?column?            | count
--------------------------------+-------
 0                              |     1
 David and Judith Jenkins       |     1
 Open University                |   862
 RBG Edinburgh                  |     1
 Robert and Angela Hull         |     1
 Royal Botanic Garden Edinburgh |  2588
 Stowupland Parish Council      |   114
 Stowupland Parish Council      |     8
 Stowupland Parish Councl       |     1
 Walsall Council                | 24236
                                | 22942
```

All counts match except for the null values, which can be attributed to the fact that the fixtures I imported are several weeks old.

---

Connects to https://github.com/OpenTreeMap/otm-clients/issues/260