### PR TITLE
Allow using non-ASCII characters when hashing for an etag

### DIFF
--- a/opentreemap/treemap/audit.py
+++ b/opentreemap/treemap/audit.py
@@ -534,8 +534,8 @@ class Dictable(object):
     @property
     def hash(self):
         values = ['%s:%s' % (k, v) for (k, v) in self.as_dict().iteritems()]
-
-        return hashlib.md5('|'.join(values)).hexdigest()
+        string = '|'.join(values).encode('utf-8')
+        return hashlib.md5(string).hexdigest()
 
 
 class UserTrackable(Dictable):


### PR DESCRIPTION
Connects OpenTreeMap/otm-addons#1160