### PR TITLE
External link

### DIFF
--- a/opentreemap/treemap/lib/external_link.py
+++ b/opentreemap/treemap/lib/external_link.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+import re
+
+from django.utils.translation import ugettext_lazy as _
+
+
+# Utilities for external links
+_valid_url_tokens = ['tree.id', 'planting_site.id', 'planting_site.custom_id']
+
+
+def get_external_link_choice_pattern():
+    return '|'.join([choice.replace('.', r'\.')
+                     for choice in _valid_url_tokens])
+
+_validation_pattern = r'''\#(?:   # starts with a hash
+    (?P<valid>{{(?:{})}}) |       # valid group is braced, filled by format
+    (?P<invalid>{{.*?}})          # anything else braced is invalid
+    )
+    '''.format(get_external_link_choice_pattern())
+
+_validator_re = re.compile(_validation_pattern, re.VERBOSE | re.IGNORECASE)
+
+
+def _re_group_count(compiled, text):
+    '''
+    Return a dict with the counts of valid and invalid strings in text
+    '''
+    totals = {'valid': 0, 'invalid': 0}
+
+    return reduce(
+        lambda ac, groupdict: {
+            k: v if groupdict[k] is None else v + 1
+            for k, v in ac.iteritems()},
+        [m.groupdict() for m in compiled.finditer(text)],
+        totals)
+
+
+def validate_token_template(token_template):
+    check = _re_group_count(_validator_re, token_template)
+    return 0 == check['invalid']
+
+
+def get_url_tokens_for_display(in_bold=False):
+    show = lambda t: ('<b>#{%s}</b>' if in_bold else '#{%s}') % t
+
+    return (', '.join(show(token) for token in _valid_url_tokens[:-1]) +
+            unicode(_(' or ')) + show(_valid_url_tokens[-1]))

--- a/opentreemap/treemap/lib/map_feature.py
+++ b/opentreemap/treemap/lib/map_feature.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from __future__ import division
 
 import datetime
+from string import Template
 
 from django.conf import settings
 from django.core.urlresolvers import reverse
@@ -14,15 +15,16 @@ from django.utils.formats import number_format
 from django.utils.translation import ugettext as _
 from django.db.models import Q
 
-from treemap.audit import Audit
+from treemap.audit import Audit, Role
 from treemap.ecobackend import ECOBENEFIT_FAILURE_CODES_AND_PATTERNS
+from treemap.json_field import get_attr_from_json_field
 from treemap.lib import execute_sql
 from treemap.models import Tree, MapFeature, User, Favorite
 
 from treemap.lib import format_benefits
 from treemap.lib.photo import context_dict_for_photo
 from treemap.units import get_display_value, get_units, get_unit_abbreviation
-from treemap.util import leaf_models_of_class, to_object_name
+from treemap.util import (leaf_models_of_class, to_object_name)
 
 from stormwater.models import PolygonalMapFeature
 
@@ -204,6 +206,45 @@ def context_dict_for_plot(request, plot, tree_id=None, **kwargs):
     else:
         photos = []
 
+    def get_external_link_url(user, feature, tree=None):
+        if not user or not feature or not feature.is_plot:
+            return None
+        instance = feature.instance
+        external_link_config =  \
+            get_attr_from_json_field(instance, 'config.externalLink') or None
+        if not external_link_config or \
+                not external_link_config.get('url', None) or \
+                not external_link_config.get('text', None):
+            return None
+        role = Role.objects.get_role(instance, user)
+        if not role.has_permission('view_external_link'):
+            return None
+        external_url = external_link_config['url']
+        if not tree and -1 < external_url.find(r'#{tree.id}'):
+            return None
+
+        plot = feature.cast_to_subtype()
+        substitutes = {
+            'planting_site.id': str(plot.pk),
+            'planting_site.custom_id': plot.owner_orig_id or '',
+            'tree.id': tree and str(tree.pk) or ''
+        }
+
+        class UrlTemplate(Template):
+            delimiter = '#'
+            pattern = '''
+            \#(?:
+                (?P<escaped>\#) |          # escape with repeated delimiter
+                (?P<named>[_.a-z]+) |      # "#foo" substitutes foo keyword
+                {(?P<braced>[_.a-z]+)} |   # "#{foo}" substitutes foo keyword
+                (?P<invalid>)              # not sure what would be invalid
+            )
+            '''
+
+        return UrlTemplate(external_url).safe_substitute(substitutes)
+
+    context['external_link'] = get_external_link_url(user, plot, tree)
+
     has_tree_diameter = tree is not None and tree.diameter is not None
     has_tree_species_with_code = tree is not None \
         and tree.species is not None and tree.species.otm_code is not None
@@ -273,6 +314,8 @@ def context_dict_for_resource(request, resource, **kwargs):
     # Give them 2 for adding the resource and answering its questions
     total_progress_items = 3
     completed_progress_items = 2
+
+    context['external_link'] = None
 
     photos = resource.photos()
     context['photos'] = [context_dict_for_photo(request, photo)

--- a/opentreemap/treemap/lib/map_feature.py
+++ b/opentreemap/treemap/lib/map_feature.py
@@ -22,10 +22,10 @@ from treemap.lib import execute_sql
 from treemap.models import Tree, MapFeature, User, Favorite
 
 from treemap.lib import format_benefits
+from treemap.lib.external_link import get_external_link_choice_pattern
 from treemap.lib.photo import context_dict_for_photo
 from treemap.units import get_display_value, get_units, get_unit_abbreviation
-from treemap.util import (leaf_models_of_class, to_object_name,
-                          get_external_link_choice_pattern)
+from treemap.util import leaf_models_of_class, to_object_name
 
 from stormwater.models import PolygonalMapFeature
 

--- a/opentreemap/treemap/lib/map_feature.py
+++ b/opentreemap/treemap/lib/map_feature.py
@@ -24,7 +24,8 @@ from treemap.models import Tree, MapFeature, User, Favorite
 from treemap.lib import format_benefits
 from treemap.lib.photo import context_dict_for_photo
 from treemap.units import get_display_value, get_units, get_unit_abbreviation
-from treemap.util import (leaf_models_of_class, to_object_name)
+from treemap.util import (leaf_models_of_class, to_object_name,
+                          get_external_link_choice_pattern)
 
 from stormwater.models import PolygonalMapFeature
 
@@ -234,12 +235,12 @@ def context_dict_for_plot(request, plot, tree_id=None, **kwargs):
             delimiter = '#'
             pattern = '''
             \#(?:
-                (?P<escaped>\#) |          # escape with repeated delimiter
-                (?P<named>[_.a-z]+) |      # "#foo" substitutes foo keyword
-                {(?P<braced>[_.a-z]+)} |   # "#{foo}" substitutes foo keyword
-                (?P<invalid>)              # not sure what would be invalid
+                (?P<escaped>\#)         |  # escape with repeated delimiter
+                (?P<named>(?:{0}))      |  # "#foo" substitutes foo keyword
+                {{(?P<braced>(?:{0}))}} |  # "#{{foo}}" substitutes foo keyword
+                (?P<invalid>{{}})          # requires a name
             )
-            '''
+            '''.format(get_external_link_choice_pattern())
 
         return UrlTemplate(external_url).safe_substitute(substitutes)
 

--- a/opentreemap/treemap/templates/treemap/partials/detail_external_link.html
+++ b/opentreemap/treemap/templates/treemap/partials/detail_external_link.html
@@ -1,0 +1,9 @@
+{% load instance_config %}
+
+{% if external_link %}
+    <a href="{{ external_link }}"
+       title="{{ last_instance|instance_config:'externalLink.text' }}">
+        {{ last_instance|instance_config:'externalLink.text' }}
+    </a>
+    <hr>
+{% endif %}

--- a/opentreemap/treemap/templates/treemap/partials/map_feature_detail_base.html
+++ b/opentreemap/treemap/templates/treemap/partials/map_feature_detail_base.html
@@ -87,6 +87,7 @@
         <button id="delete-cancel" class="btn btm-small">{% trans "Cancel" %}</button>
     </div>
     <hr>
+    {% include 'treemap/partials/detail_external_link.html' %}
 
     <!-- Map Feature Details -->
     <form id="map-feature-form">

--- a/opentreemap/treemap/templatetags/util.py
+++ b/opentreemap/treemap/templatetags/util.py
@@ -3,6 +3,7 @@ from django.core.urlresolvers import reverse
 from django.core.exceptions import ObjectDoesNotExist
 
 import json
+import re
 
 from opentreemap.util import dotted_split
 
@@ -11,6 +12,9 @@ from treemap.udf import UserDefinedCollectionValue
 from treemap.util import (get_filterable_audit_models, to_model_name,
                           safe_get_model_class)
 from treemap.units import Convertible
+
+
+_external_tree_id_url_re = re.compile(r'#{tree.id}')
 
 
 register = template.Library()

--- a/opentreemap/treemap/tests/__init__.py
+++ b/opentreemap/treemap/tests/__init__.py
@@ -112,15 +112,6 @@ def _make_permissions(field_permission):
     return permissions
 
 
-def make_administrator_role(instance):
-    """
-    The administrator role has permission to modify all model fields
-    directly for all models under test, and has the name Role.ADMINISTRATOR.
-    """
-    return _make_loaded_role(instance, Role.ADMINISTRATOR,
-                             FieldPermission.WRITE_DIRECTLY)
-
-
 def make_commander_role(instance):
     """
     The commander role has permission to modify all model fields
@@ -274,10 +265,6 @@ def make_user(instance=None, username='username', make_role=None,
 
 def make_commander_user(instance=None, username='commander'):
     return make_user(instance, username, make_commander_role)
-
-
-def make_administrator_user(instance, username='administrator', admin=True):
-    return make_user(instance, username, make_administrator_role, admin)
 
 
 def make_admin_user(instance, username='admin'):

--- a/opentreemap/treemap/tests/test_audit.py
+++ b/opentreemap/treemap/tests/test_audit.py
@@ -32,7 +32,6 @@ from treemap.tests import (make_instance, make_user_with_default_role,
                            make_officer_user, make_observer_user,
                            make_apprentice_user, set_write_permissions,
                            make_admin_user, make_tweaker_user,
-                           make_administrator_user,
                            make_conjurer_user, make_commander_role)
 from treemap.tests.base import OTMTestCase
 
@@ -1039,7 +1038,6 @@ class UserCanDeleteTestCase(OTMTestCase):
 
         self.creator_user = make_officer_user(instance)
         self.admin_user = make_admin_user(instance)
-        self.administrator_user = make_administrator_user(instance)
         self.other_user = make_observer_user(instance, username='other')
         self.tweaker_user = make_tweaker_user(instance)
         self.conjurer_user = make_conjurer_user(instance)
@@ -1089,16 +1087,6 @@ class UserCanDeleteTestCase(OTMTestCase):
         self.assertEqual(role.instance_permissions.count(), 0)
 
         self.assert_can_delete(self.admin_user, self.tree, False)
-
-    def test_administrator_cannot_delete_by_role_name(self):
-        instance = self.tree.get_instance()
-        role = self.administrator_user.get_role(instance)
-        role.instance_permissions.clear()
-
-        self.assertEqual(role.name, Role.ADMINISTRATOR)
-        self.assertEqual(role.instance_permissions.count(), 0)
-
-        self.assert_can_delete(self.administrator_user, self.tree, False)
 
 
 class FieldPermMgmtTest(OTMTestCase):

--- a/opentreemap/treemap/tests/test_views.py
+++ b/opentreemap/treemap/tests/test_views.py
@@ -30,6 +30,9 @@ from treemap.models import (Instance, Species, User, Plot, Tree, TreePhoto,
                             InstanceUser, StaticPage, ITreeRegion)
 from treemap.routes import (root_settings_js, instance_settings_js,
                             instance_user_page)
+
+from treemap.lib.external_link import validate_token_template
+from treemap.instance import PERMISSION_VIEW_EXTERNAL_LINK
 from treemap.lib.tree import add_tree_photo_helper
 from treemap.lib.user import get_user_instances
 from treemap.views.misc import (public_instances_geojson, species_list,
@@ -1000,10 +1003,6 @@ class PlotViewPhotoProgressTest(TreePhotoTestCase):
                         self.initial_progress)
         self.assertTrue(len(context['progress_messages']) <
                         self.initial_message_count)
-
-
-from treemap.util import validate_token_template
-from treemap.instance import PERMISSION_VIEW_EXTERNAL_LINK
 
 
 class PlotExternalLinkTest(OTMTestCase):

--- a/opentreemap/treemap/util.py
+++ b/opentreemap/treemap/util.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from __future__ import division
 
 import datetime
+import re
 from collections import OrderedDict
 
 from urlparse import urlparse
@@ -225,3 +226,24 @@ def get_name_from_canonical_name(canonical_name):
 
 def make_udf_name_from_key(key):
     return 'udf:{}'.format(key)
+
+
+# Utilities for external links
+_external_url_re = re.compile(r'#{([_.a-z]+)}', re.IGNORECASE)
+_valid_url_tokens = ['tree.id', 'planting_site.id', 'planting_site.custom_id']
+
+
+def get_tokens_from_template(token_template):
+    return _external_url_re.findall(token_template)
+
+
+def validate_token_template(token_template):
+    tokens = get_tokens_from_template(token_template)
+    return not tokens or any(token in _valid_url_tokens for token in tokens)
+
+
+def get_url_tokens_for_display(in_bold=False):
+    show = lambda t: ('<b>#{%s}</b>' if in_bold else '#{%s}') % t
+
+    return (', '.join(show(token) for token in _valid_url_tokens[:-1]) +
+            unicode(_(' or ')) + show(_valid_url_tokens[-1]))

--- a/opentreemap/treemap/util.py
+++ b/opentreemap/treemap/util.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 from __future__ import division
 
 import datetime
-import re
 from collections import OrderedDict
 
 from urlparse import urlparse
@@ -226,53 +225,3 @@ def get_name_from_canonical_name(canonical_name):
 
 def make_udf_name_from_key(key):
     return 'udf:{}'.format(key)
-
-
-# Utilities for external links
-def _build_choice_pattern(choices):
-    '''
-    Return a string describing a regex oring choices together
-    '''
-    return '|'.join([choice.replace('.', r'\.') for choice in choices])
-
-
-_valid_url_tokens = ['tree.id', 'planting_site.id', 'planting_site.custom_id']
-
-
-def get_external_link_choice_pattern():
-    return '|'.join([choice.replace('.', r'\.')
-                     for choice in _valid_url_tokens])
-
-_validation_pattern = r'''\#(?:   # starts with a hash
-    (?P<valid>{{(?:{})}}) |       # valid group is braced, filled by format
-    (?P<invalid>{{.*?}})          # anything else braced is invalid
-    )
-    '''.format(get_external_link_choice_pattern())
-
-_validator_re = re.compile(_validation_pattern, re.VERBOSE | re.IGNORECASE)
-
-
-def _re_group_count(compiled, text):
-    '''
-    Return a dict with the counts of valid and invalid strings in text
-    '''
-    totals = {'valid': 0, 'invalid': 0}
-
-    return reduce(
-        lambda ac, groupdict: {
-            k: v if groupdict[k] is None else v + 1
-            for k, v in ac.iteritems()},
-        [m.groupdict() for m in compiled.finditer(text)],
-        totals)
-
-
-def validate_token_template(token_template):
-    check = _re_group_count(_validator_re, token_template)
-    return 0 == check['invalid']
-
-
-def get_url_tokens_for_display(in_bold=False):
-    show = lambda t: ('<b>#{%s}</b>' if in_bold else '#{%s}') % t
-
-    return (', '.join(show(token) for token in _valid_url_tokens[:-1]) +
-            unicode(_(' or ')) + show(_valid_url_tokens[-1]))

--- a/opentreemap/treemap/util.py
+++ b/opentreemap/treemap/util.py
@@ -252,10 +252,6 @@ _validation_pattern = r'''\#(?:   # starts with a hash
 _validator_re = re.compile(_validation_pattern, re.VERBOSE | re.IGNORECASE)
 
 
-def get_valid_url_tokens():
-    return tuple(_valid_url_tokens)
-
-
 def _re_group_count(compiled, text):
     '''
     Return a dict with the counts of valid and invalid strings in text


### PR DESCRIPTION
Ignore all the commits but the last one, subject line __External link__.

This PR is based off another PR, #2847, before the other one is merged,
causing all the commits from the latter PR to appear in this one.

Changes:
* Create a new partial template for external link
  and include it in the detail template
* Make template filters for use in the template
* Move stuff into treemap.util to share with addons

--

Connects to #2785
Depends on OpenTreeMap/otm-addons#1332