### PR TITLE
Do not mutate the static SPECIES list

### DIFF
--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -92,6 +92,7 @@ def add_species_to_instance(instance):
     instance_species_list = []
     for species_dict in SPECIES:
         if species_dict['otm_code'] in species_code_set:
+            species_dict = deepcopy(species_dict)
             species_dict['instance'] = instance
             instance_species_list.append(Species(**species_dict))
     Species.objects.bulk_create(instance_species_list)


### PR DESCRIPTION
The `SPECIES` list defined in `opentreemap/treemap/__init__.py` is intended to be a constant. The `add_species_to_instance` function was mutating it, adding full `Instance` objects to each species object. This came to our attention when some other code was trying to call `json.dumps` on the species dict and the `Instance` objects are not JSON serializable.