### PR TITLE
Display new custom field

### DIFF
--- a/opentreemap/treemap/lib/udf.py
+++ b/opentreemap/treemap/lib/udf.py
@@ -47,13 +47,12 @@ def udf_create(params, instance):
 
     field_name = udf.canonical_name
 
-    # Add a restrictive permission for this UDF to all roles in the
-    # instance
+    # Add the default permission for this UDF to all roles in the instance
     for role in Role.objects.filter(instance=instance):
         FieldPermission.objects.get_or_create(
             model_name=model_type,
             field_name=field_name,
-            permission_level=FieldPermission.NONE,
+            permission_level=role.default_permission_level,
             role=role,
             instance=role.instance)
 

--- a/opentreemap/treemap/lib/udf.py
+++ b/opentreemap/treemap/lib/udf.py
@@ -82,7 +82,8 @@ def _add_scalar_udf_to_field_configs(udf, instance):
     save_instance = False
 
     for prop in ('mobile_api_fields', 'web_detail_fields'):
-        for group in getattr(instance, prop):
+        attr = getattr(instance, prop)
+        for group in attr:
             if (('model' in group and
                  group['model'] == to_object_name(udf.model_type))):
                 field_keys = group.get('field_keys')
@@ -90,6 +91,13 @@ def _add_scalar_udf_to_field_configs(udf, instance):
                 if 'field_keys' in group and udf.full_name not in field_keys:
                     field_keys.append(udf.full_name)
                     save_instance = True
+                    # The first time a udf is configured,
+                    # getattr(instance, prop) returns a deepcopy of
+                    # the default for prop.
+                    # Mutating the deepcopy does not set prop on config
+                    # to refer to that deepcopy, so we must do the
+                    # setattr here.
+                    setattr(instance, prop, attr)
 
     if save_instance:
         instance.save()

--- a/opentreemap/treemap/tests/test_udfs.py
+++ b/opentreemap/treemap/tests/test_udfs.py
@@ -21,6 +21,7 @@ from treemap.tests import (make_instance, make_commander_user,
 from treemap.lib.object_caches import role_field_permissions
 from treemap.lib.udf import udf_create
 
+from treemap.instance import create_stewardship_udfs
 from treemap.udf import UserDefinedFieldDefinition
 from treemap.models import Instance, Plot, User
 from treemap.audit import (AuthorizeException, FieldPermission, Role,
@@ -1310,6 +1311,7 @@ class UdfCRUTestCase(OTMTestCase):
         User._system_user.save_base()
 
         self.instance = make_instance()
+        create_stewardship_udfs(self.instance)
         self.user = make_commander_user(self.instance)
 
         set_write_permissions(self.instance, self.user,


### PR DESCRIPTION
- Enable new custom field by default
- Use role default field permissions instead of NONE for all the roles
- Fix a test to create stewardship udfs, to be consistent with instance config

Connects to #2871 
Depends on OpenTreeMap/otm-addons#1342