### PR TITLE
Restore RainBarrel.is_editable

### DIFF
--- a/opentreemap/stormwater/models.py
+++ b/opentreemap/stormwater/models.py
@@ -198,6 +198,11 @@ class RainBarrel(MapFeature):
         'plural': _('Rain Barrels'),
     }
 
+    @property
+    def is_editable(self):
+        # this is a holdover until we can support editing for all resources
+        return True
+
     @classproperty
     def benefits(cls):
         return CountOnlyBenefitCalculator(cls)


### PR DESCRIPTION
The code was mistakenly removed on August 5 2016, in c805dc8385dfe595be21379b5a8858c24bca8eb3

Connects #2877 