### PR TITLE
Backend for filter by updated-by

### DIFF
--- a/opentreemap/treemap/lib/map_feature.py
+++ b/opentreemap/treemap/lib/map_feature.py
@@ -539,8 +539,7 @@ UPDATE treemap_mapfeature
 SET updated_by_id = m.updated_by
 FROM (
   SELECT DISTINCT ON (a.model_id)
-    a.id AS audit_id, a.model_id, a.user_id AS updated_by,
-    MAX(a.updated) AS updated_at
+    a.model_id, a.user_id AS updated_by, a.updated AS updated_at
   FROM treemap_audit a
   WHERE a.model IN %s
   GROUP BY a.model_id, a.id
@@ -568,7 +567,7 @@ FROM (
     JOIN (
       -- Most recent audit records of Trees
       SELECT DISTINCT ON (a.model_id)
-        a.model_id, a.user_id AS updated_by, MAX(a.updated) AS updated_at
+        a.model_id, a.user_id AS updated_by, a.updated AS updated_at
       FROM treemap_audit a
       WHERE a.model = 'Tree'
       GROUP BY a.model_id, a.id
@@ -604,7 +603,7 @@ FROM (
       -- where the model id is the same for a TreePhoto and its
       -- MapFeaturePhoto superclass
       SELECT DISTINCT ON (a.model_id)
-        a.model_id, a.user_id AS updated_by, MAX(a.updated) AS updated_at
+        a.model_id, a.user_id AS updated_by, a.updated AS updated_at
       FROM treemap_audit a
       WHERE a.model in ('TreePhoto', 'MapFeaturePhoto')
       GROUP BY a.model_id, a.id

--- a/opentreemap/treemap/management/commands/set_mapfeature_updated_by.py
+++ b/opentreemap/treemap/management/commands/set_mapfeature_updated_by.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django.core.management.base import BaseCommand
+
+from treemap.lib.map_feature import set_map_feature_updated_by
+
+
+class Command(BaseCommand):
+    """
+    Sets the value of MapFeature.updated_by based on the content of the
+    treemap_audit table.
+
+    Run this command after migration `0038_updated_by`, before the
+    subsequent migration that removes nullable.
+    """
+    def handle(self, *args, **options):
+        print('If you have a large database, the queries run by this command '
+              'may take a while to complete')
+        set_map_feature_updated_by()

--- a/opentreemap/treemap/migrations/0038_updated_by.py
+++ b/opentreemap/treemap/migrations/0038_updated_by.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+# This migration adds the `updated_by_id` column to the
+# `treemap_mapfeature` table.
+# As a new column, it is nullable.
+#
+# Before you can run the later migration to remove nullable, run
+# `manage.py set_mapfeature_updated_by` to populate the column.
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0037_fix_plot_add_delete_permission_labels'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='mapfeature',
+            name='updated_by',
+            field=models.ForeignKey(blank=True, null=True,
+                                    to=settings.AUTH_USER_MODEL),
+        ),
+    ]

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -455,6 +455,7 @@ class Species(UDFModel, PendingAuditable):
     max_height = models.IntegerField(default=DEFAULT_MAX_HEIGHT,
                                      verbose_name='Max Height')
 
+    # Included for the sake of cache busting
     updated_at = models.DateTimeField(  # TODO: remove null=True
         null=True, auto_now=True, editable=False, db_index=True)
 
@@ -573,6 +574,8 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
     # efficient.
     updated_at = models.DateTimeField(default=timezone.now,
                                       verbose_name=_("Last Updated"))
+    updated_by = models.ForeignKey(User, null=True, blank=True)
+
     objects = GeoHStoreUDFManager()
 
     # subclass responsibilities
@@ -592,11 +595,11 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
 
     @classproperty
     def always_writable(cls):
-        # `updated_at`, `hide_at_zoom`, and `geom` never need to be checked.
+        # `hide_at_zoom` and `geom` never need to be checked.
         # If we ever implement the ability to lock down a model instance,
         # `readonly` should be removed from this list.
         return PendingAuditable.always_writable | {
-            'updated_at', 'hide_at_zoom', 'geom', 'readonly'}
+            'hide_at_zoom', 'geom', 'readonly'}
 
     def __init__(self, *args, **kwargs):
         super(MapFeature, self).__init__(*args, **kwargs)
@@ -623,7 +626,7 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
     def is_plot(self):
         return getattr(self, 'feature_type', None) == 'Plot'
 
-    def update_updated_at(self):
+    def update_updated_fields(self, user):
         """Changing a child object of a map feature (tree, photo,
         etc.) demands that we update the updated_at field on the
         parent map_feature, however there is likely code throughout
@@ -631,8 +634,9 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
         calling save on the parent MapFeature. This method intended to
         by called in the save method of those child objects."""
         self.updated_at = timezone.now()
+        self.updated_by = user
         MapFeature.objects.filter(pk=self.pk).update(
-            updated_at=self.updated_at)
+            updated_at=self.updated_at, updated_by=user)
 
     def save_with_user(self, user, *args, **kwargs):
         self.full_clean_with_user(user)
@@ -642,6 +646,7 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
                 'Never save a MapFeature -- only save a MapFeature subclass')
 
         self.updated_at = timezone.now()
+        self.updated_by = user
         super(MapFeature, self).save_with_user(user, *args, **kwargs)
 
     def clean(self):
@@ -1119,7 +1124,7 @@ class Tree(Convertible, UDFModel, PendingAuditable, ValidationMixin):
         self.validate_height()
         self.validate_canopy_height()
 
-        self.plot.update_updated_at()
+        self.plot.update_updated_fields(user)
         super(Tree, self).save_with_user(user, *args, **kwargs)
 
     @property
@@ -1154,7 +1159,7 @@ class Tree(Convertible, UDFModel, PendingAuditable, ValidationMixin):
         photos = self.photos()
         for photo in photos:
             photo.delete_with_user(user)
-        self.plot.update_updated_at()
+        self.plot.update_updated_fields(user)
         self.instance.update_universal_rev()
         super(Tree, self).delete_with_user(user, *args, **kwargs)
 
@@ -1231,7 +1236,7 @@ class MapFeaturePhoto(models.Model, PendingAuditable, Convertible):
             image_data, self.image_prefix, thumb_size=(256, 256),
             degrees_to_rotate=degrees_to_rotate)
 
-    def save_with_user(self, *args, **kwargs):
+    def save_with_user(self, user, *args, **kwargs):
         if not self.thumbnail.name:
             raise Exception('You need to call set_image instead')
         if (hasattr(self, 'map_feature') and
@@ -1243,15 +1248,15 @@ class MapFeaturePhoto(models.Model, PendingAuditable, Convertible):
         if self.pk is None:
             self.created_at = timezone.now()
 
-        self.map_feature.update_updated_at()
-        super(MapFeaturePhoto, self).save_with_user(*args, **kwargs)
+        self.map_feature.update_updated_fields(user)
+        super(MapFeaturePhoto, self).save_with_user(user, *args, **kwargs)
 
-    def delete_with_user(self, *args, **kwargs):
+    def delete_with_user(self, user, *args, **kwargs):
         thumb = self.thumbnail
         image = self.image
 
-        self.map_feature.update_updated_at()
-        super(MapFeaturePhoto, self).delete_with_user(*args, **kwargs)
+        self.map_feature.update_updated_fields(user)
+        super(MapFeaturePhoto, self).delete_with_user(user, *args, **kwargs)
 
         thumb.delete(False)
         image.delete(False)
@@ -1353,6 +1358,7 @@ class Boundary(models.Model):
     category = models.CharField(max_length=255)
     sort_order = models.IntegerField()
 
+    # Included for the sake of cache busting
     updated_at = models.DateTimeField(auto_now=True, editable=False,
                                       db_index=True)
 

--- a/opentreemap/treemap/tests/test_cached_audit_info.py
+++ b/opentreemap/treemap/tests/test_cached_audit_info.py
@@ -8,19 +8,19 @@ import pytz
 from datetime import datetime, timedelta
 
 from django.contrib.gis.geos import Point
-from django.db.models import Q
 from django.utils import timezone
 
 from treemap.lib import execute_sql
-from treemap.lib.map_feature import set_map_feature_updated_at
+from treemap.lib.map_feature import (set_map_feature_updated_at,
+                                     set_map_feature_updated_by)
 from treemap.models import Tree, Plot, Audit
 from treemap.tests import (LocalMediaTestCase, make_instance,
-                           make_commander_user)
+                           make_commander_user, make_user_with_default_role)
 
 
-class UpdatedAtTestCase(LocalMediaTestCase):
+class UpdateTestCase(LocalMediaTestCase):
     def setUp(self):
-        super(UpdatedAtTestCase, self).setUp()
+        super(UpdateTestCase, self).setUp()
         self.image = self.load_resource('tree1.gif')
         self.test_start = timezone.now()
         self.point = Point(-8515941.0, 4953519.0)
@@ -29,16 +29,10 @@ class UpdatedAtTestCase(LocalMediaTestCase):
         self.plot = Plot(geom=self.point, instance=self.instance)
         self.plot.save_with_user(self.user)
 
-    def reload_members(self):
-        self.plot = Plot.objects.get(pk=self.plot.pk)
-
     def max_audit_for_model_type(self, models):
         if isinstance(models, basestring):
             models = [models]
-        model_q = Q()
-        for model in models:
-            model_q |= Q(model=model)
-        audits = Audit.objects.filter(model_q)\
+        audits = Audit.objects.filter(model__in=models)\
                               .order_by('-created')
 
         if audits:
@@ -52,11 +46,14 @@ class UpdatedAtTestCase(LocalMediaTestCase):
     def clear_and_set_and_reload(self):
         self.clear_updated_at()
         set_map_feature_updated_at()
-        self.reload_members()
+        self.plot.refresh_from_db()
+
+
+class UpdatedAtTest(UpdateTestCase):
 
     def test_helpers(self):
         self.clear_updated_at()
-        self.reload_members()
+        self.plot.refresh_from_db()
         self.assertEqual(self.plot.updated_at,
                          datetime(1970, 1, 1, tzinfo=pytz.UTC))
 
@@ -94,3 +91,57 @@ class UpdatedAtTestCase(LocalMediaTestCase):
 
         self.clear_and_set_and_reload()
         self.assertEqual(self.plot.updated_at, treephoto_audit.created)
+
+
+class UpdatedByTest(UpdateTestCase):
+
+    def setUp(self):
+        super(UpdatedByTest, self).setUp()
+        self.other = make_commander_user(instance=self.instance,
+                                         username='other')
+        self.default_user = make_user_with_default_role(
+            instance=self.instance, username='default')
+
+        self.other.save()
+        self.default_user.save()
+        self.other.refresh_from_db()
+        self.default_user.refresh_from_db()
+
+    def clear_updated_by(self):
+        execute_sql(
+            "UPDATE treemap_mapfeature SET updated_by_id = {};".format(
+                self.default_user.pk))
+
+    def clear_and_set_and_reload(self):
+        self.clear_updated_by()
+        set_map_feature_updated_by()
+        self.plot.refresh_from_db()
+
+    def test_helpers(self):
+        self.clear_updated_by()
+        self.plot.refresh_from_db()
+        self.assertEqual(self.plot.updated_by, self.default_user)
+
+    def test_map_feature_is_updated_by(self):
+        self.clear_and_set_and_reload()
+        self.assertEqual(self.plot.updated_by_id, self.user.pk)
+
+        self.plot.width = 24.0
+        self.plot.save_with_user(self.other)
+        self.clear_and_set_and_reload()
+        self.assertEqual(self.plot.updated_by_id, self.other.pk)
+
+    def test_tree_overrides_plot(self):
+        tree = Tree(diameter=10, plot=self.plot, instance=self.instance)
+        tree.save_with_user(self.other)
+
+        self.clear_and_set_and_reload()
+        self.assertEqual(self.plot.updated_by_id, self.other.pk)
+
+    def test_treephoto_overrides_tree_and_plot(self):
+        tree = Tree(diameter=10, plot=self.plot, instance=self.instance)
+        tree.save_with_user(self.user)
+        tree.add_photo(self.image, self.other)
+
+        self.clear_and_set_and_reload()
+        self.assertEqual(self.plot.updated_by_id, self.other.pk)

--- a/opentreemap/treemap/tests/test_management.py
+++ b/opentreemap/treemap/tests/test_management.py
@@ -22,10 +22,11 @@ class CreateInstanceManagementTest(OTMTestCase):
         name = 'my_instance'
         url_name = 'my-instance'
 
-        self.assertEqual(Instance.objects.count(), 0)
+        # Allow test --keepdb to work
+        count = Instance.objects.count()
         call_command('create_instance', name, center=center, user=user,
                      url_name=url_name)
-        self.assertEqual(Instance.objects.count(), 1)
+        self.assertEqual(Instance.objects.count(), count + 1)
 
 
 class RandomTreesManagementTest(OTMTestCase):

--- a/opentreemap/treemap/tests/test_util.py
+++ b/opentreemap/treemap/tests/test_util.py
@@ -34,6 +34,10 @@ class VisitedInstancesTests(ViewTestCase):
         middleware.process_request(self.request)
         self.request.session.save()
 
+    def _format(self, number):
+        # Allow tests to work with --keepdb
+        return '{:,d}'.format(number)
+
     def test_session(self):
         #
         # Create a view that renders a simple template
@@ -51,25 +55,25 @@ class VisitedInstancesTests(ViewTestCase):
         # Going to an instance sets the context variable
         self.client.get('/%s/map/' % self.instance1.url_name)
         self.assertEqual(self.client.get('/test').content,
-                         str(self.instance1.pk))
+                         self._format(self.instance1.pk))
 
         # Going to a non-public instance doesn't update it
         self.client.get('/%s/map/' % self.instance3.url_name)
         self.assertEqual(self.client.get('/test').content,
-                         str(self.instance1.pk))
+                         self._format(self.instance1.pk))
 
         # Going to a private instance while not logged in
         # also doesn't update
         self.client.get('/%s/map/' % self.instance4.url_name)
         self.assertEqual(self.client.get('/test').content,
-                         str(self.instance1.pk))
+                         self._format(self.instance1.pk))
 
         self.client.login(username='joe', password='joe')
 
         # But should change after logging in
         self.client.get('/%s/map/' % self.instance4.url_name)
         self.assertEqual(self.client.get('/test').content,
-                         str(self.instance4.pk))
+                         self._format(self.instance4.pk))
 
     def test_get_last_instance(self):
         add_visited_instance(self.request, self.instance1)

--- a/opentreemap/treemap/tests/test_views.py
+++ b/opentreemap/treemap/tests/test_views.py
@@ -199,22 +199,26 @@ class TreePhotoTestCase(LocalMediaTestCase):
 class TreePhotoAffectsPlotUpdatedAtTestCase(TreePhotoTestCase):
     def setUp(self):
         super(TreePhotoAffectsPlotUpdatedAtTestCase, self).setUp()
+        self.fellow = make_commander_user(self.instance, 'other-commander')
         self.initial_updated = self.plot.updated_at
 
     def test_add_photo_sets_updated(self):
-        self.tree.add_photo(self.image, self.user)
+        self.tree.add_photo(self.image, self.fellow)
+        self.plot.refresh_from_db()
         self.assertGreater(self.plot.updated_at, self.initial_updated)
+        self.assertEqual(self.plot.updated_by, self.fellow)
 
     def test_delete_photo_sets_updated(self):
         self.tree.add_photo(self.image, self.user)
-        self.plot = Plot.objects.get(pk=self.plot.pk)
+        self.plot.refresh_from_db()
         self.initial_updated = self.plot.updated_at
 
         photo = self.plot.current_tree().photos()[0]
-        photo.delete_with_user(self.user)
+        photo.delete_with_user(self.fellow)
 
-        self.plot = Plot.objects.get(pk=self.plot.pk)
+        self.plot.refresh_from_db()
         self.assertGreater(self.plot.updated_at, self.initial_updated)
+        self.assertEqual(self.plot.updated_by, self.fellow)
 
 
 class DeleteOwnPhotoTest(TreePhotoTestCase):


### PR DESCRIPTION
Changes:
* Add `updated_by` field, and make it not trackable
* Migration to add the column to the db
* Command in lieu of a migration to populate the column
* `treemap.model` updates `updated_by` along with `updated_at`
* Tests for the population command
* Tests for updating `updated_by`
* Minor refactor from references to `always_writable`
  to `bypasses_authorization`
* Minor test changes to facilitate `test --keepdb`

--

Connects to #2863