### PR TITLE
cleanup on the modeling work

### DIFF
--- a/assets/css/sass/partials/pages/_modeling.scss
+++ b/assets/css/sass/partials/pages/_modeling.scss
@@ -103,7 +103,7 @@ $blue-to-red: #2791c3 10%,
     }
 
     #view-switcher {
-        padding-top: 5px;
+        padding-top: 4px;
         box-shadow: 0 6px 0 rgba(0, 0, 0, 0.15);
         position: relative;
 
@@ -164,6 +164,8 @@ $blue-to-red: #2791c3 10%,
             padding-left: 10px;
             position: relative;
             white-space: nowrap;
+            margin-top: -2px;
+            padding-bottom: 1px;
         }
 
         #scenario-buttons {
@@ -172,8 +174,6 @@ $blue-to-red: #2791c3 10%,
             > .btn-group.js-scenario {
                 display: inline-block;
                 border: 1px solid #ddd;
-                border-bottom: none;
-                border-radius: 5px 5px 0 0;
                 margin-right: 5px;
 
                 .btn {
@@ -183,6 +183,10 @@ $blue-to-red: #2791c3 10%,
                 &.active .btn {
                     color: $primary-color;
                     background-color: #fff;
+                }
+
+                .dropdown-toggle {
+                    border-left: 1px solid #ddd;
                 }
             }
         }
@@ -461,6 +465,34 @@ $blue-to-red: #2791c3 10%,
         .legend-label {
             white-space: nowrap;
         }
+    }
+
+    #tree-mortality-container {
+        .col-sm-12 {
+            padding: 10px;
+        }
+    }
+
+    #mortality-rate-table {
+        th, td {
+            vertical-align: middle;
+        }
+    }
+
+    .remove-tree-button {
+        padding: 5px;
+        border-radius: 4px;
+        border: 1px solid #e84f4f;
+        color: #e84f4f;
+        opacity: 1;
+        display: block;
+        margin: auto;
+        text-align: center;
+    }
+
+    #mortality-rate-dropdown .dropdown-menu {
+        max-height: 200px;
+        overflow: auto;
     }
 }
 

--- a/assets/css/sass/partials/pages/_modeling.scss
+++ b/assets/css/sass/partials/pages/_modeling.scss
@@ -470,6 +470,19 @@ $blue-to-red: #2791c3 10%,
     #tree-mortality-container {
         .col-sm-12 {
             padding: 10px;
+
+            label {
+                width: 50%;
+                float: left;
+                padding-top: 0;
+                font-size: 1.2rem;
+            }
+            .btn,
+            .form-group {
+                width: 46%;
+                float: left;
+                margin-left: 4%;
+            }
         }
     }
 

--- a/assets/css/sass/partials/pages/_scenarios.scss
+++ b/assets/css/sass/partials/pages/_scenarios.scss
@@ -113,7 +113,7 @@
                     }
 
                     label {
-                        font-size: 1.1rem;
+                        font-size: 1.2rem;
                         font-weight: 700;
 
                         > em {


### PR DESCRIPTION
### Overview:
- updated the label for _all trees_. Now reads _Annual mortality (%) for all trees_
- additionally updated the input-addon label to just a _%_ to mimic the table in the customize by species modal.
- added some spacing between the two Tree Mortality Rate options
- Added a _species_ table heading to the custom species modal.
- Moved the _delete button_ to the last column of the table and styled it.
- added a max-height and scroll to the _add a species dropdown_
- simplified the double row table header into a single row.
- cleaned up the scenarios menu bar a bit.

#### Testing
In order to test, pull down this branch and the branch from this PR https://github.com/OpenTreeMap/otm-addons/pull/1349