### PR TITLE
Fix comment handling in migrator

### DIFF
--- a/opentreemap/otm1_migrator/migration_rules/standard_otm1.py
+++ b/opentreemap/otm1_migrator/migration_rules/standard_otm1.py
@@ -185,7 +185,7 @@ MIGRATION_RULES = {
                          'contenttype': 'content_type'},
         'common_fields': {'comment', 'is_public',
                           'ip_address'},
-        'renamed_fields': {'submit_date': 'date_submitted'},
+        'renamed_fields': {'date_submitted': 'submit_date'},
         'removed_fields': {'is_removed', 'user_name', 'user_email',
                            'user_url', 'site', 'object_pk'},
     },
@@ -195,8 +195,8 @@ MIGRATION_RULES = {
         'dependencies': {'user': 'user',
                          'contenttype': 'content_type'},
         'common_fields': {'comment', 'is_public', 'is_approved',
-                          'ip_address', 'date_submitted',
-                          'date_modified', 'date_approved'},
+                          'ip_address', 'date_modified', 'date_approved'},
+        'renamed_fields': {'date_submitted': 'submit_date'},
         'removed_fields': {'markup',  # this is no longer in the schema
                            # object_id and parent are not actually removed
                            # but they have to be processed manually so they

--- a/opentreemap/otm1_migrator/model_processors.py
+++ b/opentreemap/otm1_migrator/model_processors.py
@@ -256,10 +256,18 @@ def _base_process_comment(migration_rules, migration_event,
     comment_obj.site_id = 1
 
     if comment_obj.content_type_id == models.UNBOUND_MODEL_ID:
-        print("Can't import comment %s because "
-              "it is assigned to a ContentType (model) "
-              "that does not exist in OTM2 .. SKIPPING"
-              % comment_obj.comment.encode('utf-8'))
+        try:
+            print("Can't import comment %s because "
+                  "it is assigned to a ContentType (model) "
+                  "that does not exist in OTM2 .. SKIPPING"
+                  % comment_obj.comment.encode('utf-8'))
+        except:
+            # There was a problem handling the comment string when
+            # printing the warning message. Ignore it and move on
+            # rather than crash the import.
+            print("Can't import comment because "
+                  "it is assigned to a ContentType (model) "
+                  "that does not exist in OTM2 .. SKIPPING")
         return None
     content_type = ContentType.objects.get(pk=comment_obj.content_type_id)
 


### PR DESCRIPTION
Threaded comments were being migrated incorrectly. The `submit_date` was being set to the date of the migration, not the original comment submit date. The solution is to ensure that the renaming of `date_submitted` (which is the name used in the OTM1 fixtures) to `submit_date` is configured in the standard migration rules for both comments and threadedcomments, and that the mapping old name to new name is correctly defined.

I have opted to swallow a character encoding exception raised when
attempting to print a skipped migration warning message:

- The comment text does not provide extra information

- We do not anticipate using the OTM1 migrator in the future. Properly
  debugging the character encoding failure is not a good use of
  development time.

---

##### Testing

I tested this by:

- Creating abbreviated `config.json`

```json
{
    "user_fixture": "local/fixtures/users.json",
    "plot_fixture": "local/fixtures/plots.json",
    "threadedcomment_fixture": "local/fixtures/threadedcomments.json"
}
```

- Running through a migration, ensuring that the content type fixture is migrated before running the migrator with the abbreviated `config.json`

- Validating that the comments have the correct `submit_date` by running this query

```sql

SELECT object_pk AS feature_id, user_id, user_name, left(comment,20) AS comment, submit_date
FROM django_comments
WHERE id IN (
  SELECT otm2_model_id
  FROM otm1_migrator_otm1commentrelic
  WHERE migration_event_id = (SELECT MAX(id) FROM otm1_migrator_migrationevent)
  AND otm2_model_name = 'threadedcomment'
)
ORDER BY submit_date;

feature_id | user_id | user_name |       comment        |      submit_date
------------+---------+-----------+----------------------+------------------------
 2913077    |    5644 |           | Tree died due to an  | 2012-11-27 16:37:07+00
 2913075    |    5644 |           | Tree came down night | 2012-11-28 17:19:58+00
 2913769    |    5647 |           | I don't know the spe | 2012-11-28 17:22:51+00
 2913076    |    5644 |           | Tree came down night | 2012-11-28 17:26:22+00
 2913075    |    5644 |           | the above comment is | 2012-11-28 17:27:50+00
...
```

---

Connects to #2841 