### PR TITLE
Add safety code in requires_permission decorator

### DIFF
--- a/opentreemap/treemap/decorators.py
+++ b/opentreemap/treemap/decorators.py
@@ -139,7 +139,8 @@ def requires_permission(codename):
     def wrapper_function(view_fn):
         @wraps(view_fn)
         def wrapped(request, instance, *args, **kwargs):
-            if request.instance_user.role.has_permission(codename):
+            iuser = request.instance_user
+            if iuser and iuser.role.has_permission(codename):
                 return view_fn(request, instance, *args, **kwargs)
             else:
                 raise PermissionDenied


### PR DESCRIPTION
Prevents a crash when trying to load an instance you aren't authorized to access.