### PR TITLE
Support for boundary autocomplete

### DIFF
--- a/assets/css/sass/partials/_header.scss
+++ b/assets/css/sass/partials/_header.scss
@@ -90,52 +90,6 @@ $mobile-search-button-group-width : 166px;
             display: block;
             margin-top: -2px;
         }
-        .search-field-group {
-            position: relative;
-
-            .twitter-typeahead {
-                display: block !important;
-            }
-
-            input[type="text"] {
-                margin: 0;
-                padding-left: 32px;
-                font-size: 1.2rem;
-
-                &::placeholder {
-                    text-overflow: ellipsis !important;
-                }
-                &::-moz-placeholder {
-                    text-overflow: ellipsis !important;
-                }
-                &:-ms-input-placeholder {
-                    text-overflow: ellipsis !important;
-                }
-                &::-webkit-input-placeholder {
-                    text-overflow: ellipsis !important;
-                }
-            }
-            .typeahead-toggle {
-                padding: 9px 4px 7px;
-                position: absolute;
-                top: 0px;
-                z-index: 9;
-                background: none;
-                border: none;
-                cursor: pointer;
-                color: $well-color;
-                font-size: 1.8rem;
-                line-height: 1.6rem;
-
-                &.active,
-                &:hover {
-                    color: $main-text-color;
-                }
-            }
-            .search-button {
-                display: none;
-            }
-        }
         .dropdown-menu {
             width: 257px;
             -moz-border-radius: 3px;
@@ -251,7 +205,7 @@ $mobile-search-button-group-width : 166px;
                 > label {
                     display: none;
                 }
-                .search-field-group .twitter-typeahead input[type="text"] {
+                .autocomplete-group .twitter-typeahead input[type="text"] {
                     padding-left: 8px;
                     border-top-right-radius: 0;
                     border-bottom-right-radius: 0;

--- a/assets/css/sass/partials/_layout.scss
+++ b/assets/css/sass/partials/_layout.scss
@@ -251,6 +251,53 @@ body {
     z-index: 1040 !important;
 }
 
+.autocomplete-group {
+    position: relative;
+
+    .twitter-typeahead {
+        display: block !important;
+    }
+
+    input[type="text"] {
+        margin: 0;
+        padding-left: 32px;
+        font-size: 1.2rem;
+
+        &::placeholder {
+            text-overflow: ellipsis !important;
+        }
+        &::-moz-placeholder {
+            text-overflow: ellipsis !important;
+        }
+        &:-ms-input-placeholder {
+            text-overflow: ellipsis !important;
+        }
+        &::-webkit-input-placeholder {
+            text-overflow: ellipsis !important;
+        }
+    }
+    .typeahead-toggle {
+        padding: 9px 4px 7px;
+        position: absolute;
+        top: 0px;
+        z-index: 9;
+        background: none;
+        border: none;
+        cursor: pointer;
+        color: $well-color;
+        font-size: 1.8rem;
+        line-height: 1.6rem;
+
+        &.active,
+        &:hover {
+            color: $main-text-color;
+        }
+    }
+    .search-button {
+        display: none;
+    }
+}
+
 @media #{$screen-xs} {
     body {
         padding: 0;

--- a/assets/css/sass/partials/pages/_modeling.scss
+++ b/assets/css/sass/partials/pages/_modeling.scss
@@ -768,19 +768,12 @@ $blue-to-red: #2791c3 10%,
             font-weight: 400;
             font-size: 1.4rem;
         }
-
-        .remove-mask {
-            position: absolute;
-            cursor: pointer;
-            font-size: 1.2rem;
-            right: 18px;
-            top: 14px;
-            opacity: .5;
-        }
     }
 
-    .search-block {
-        padding: 12px 14px 16px;
+    #boundary-masks {
+        .mask-chooser {
+            padding: 18px 14px 16px;
+        }
 
         label {
             display: block;
@@ -796,6 +789,25 @@ $blue-to-red: #2791c3 10%,
 
             > li > a {
                 padding: 3px 12px;
+            }
+        }
+
+        #chosen-masks {
+            .mask-name {
+                font-size: 1.3rem;
+                font-weight: 600;
+                color: $main-text-color;
+            }
+            .mask-category {
+                font-size: 1.1rem;
+            }
+            .remove-mask {
+                position: absolute;
+                cursor: pointer;
+                font-size: 2rem;
+                right: 18px;
+                top: 14px;
+                opacity: .5;
             }
         }
     }

--- a/assets/css/sass/partials/pages/_modeling.scss
+++ b/assets/css/sass/partials/pages/_modeling.scss
@@ -788,37 +788,6 @@ $blue-to-red: #2791c3 10%,
             font-size: 1.2rem;
         }
 
-        .search-field-group {
-            position: relative;
-
-            input[type="text"] {
-                margin: 0;
-                padding-left: 32px;
-                font-size: 1.2rem;
-            }
-
-            .twitter-typeahead {
-                display: block !important;
-            }
-            .typeahead-toggle {
-                padding: 9px 4px 7px;
-                position: absolute;
-                top: 0px;
-                z-index: 9;
-                background: none;
-                border: none;
-                cursor: pointer;
-                color: $well-color;
-                font-size: 1.8rem;
-                line-height: 1.6rem;
-
-                &.active, 
-                &:hover {
-                    color: $main-text-color;
-                }
-            }
-        }
-
         .dropdown-menu {
             width: 257px;
             -moz-border-radius: 3px;

--- a/opentreemap/treemap/js/src/lib/baconUtils.js
+++ b/opentreemap/treemap/js/src/lib/baconUtils.js
@@ -112,22 +112,26 @@ exports.getJsonFromUrl = function(url) {
 // a button to provide a consistent form submission
 // experience
 exports.enterOrClickEventStream = function(options) {
+    var button = $(options.button),
+        performSearchClickStream = button.asEventStream("click"),
+        enterKeyPressStream = exports.enterKeyPressStream(options);
+
+    return Bacon.mergeAll(
+        enterKeyPressStream,
+        performSearchClickStream);
+};
+
+exports.enterKeyPressStream = function(options) {
     var inputs = $(options.inputs),
-        button = $(options.button),
         enterKeyPressStream = inputs
             .asEventStream("keyup")
-            .filter(isEnterKey),
-
-        performSearchClickStream = button.asEventStream("click"),
-
-        triggerEventStream = enterKeyPressStream.merge(
-            performSearchClickStream);
+            .filter(isEnterKey);
 
     // When enter is pressed blur the text input that caused it to close
     // any touch keyboards that may be open
     enterKeyPressStream.map('.target').map($).onValue('.blur');
 
-    return triggerEventStream;
+    return enterKeyPressStream;
 };
 
 exports.leafletEventStream = function(leafletThing, event) {

--- a/opentreemap/treemap/templates/treemap/partials/search_location.html
+++ b/opentreemap/treemap/templates/treemap/partials/search_location.html
@@ -3,7 +3,7 @@
 <!-- Location Search -->
 <div class="search-block">
   <label class="boundary-search-label">{% trans "Search by Location" %}</label>
-  <div class="search-field-group">
+  <div class="autocomplete-group">
     <a class="typeahead-toggle" id="boundary-toggle"><i class="icon-menu"></i></a>
     <input type="text"
            data-class="search"

--- a/opentreemap/treemap/templates/treemap/partials/search_species.html
+++ b/opentreemap/treemap/templates/treemap/partials/search_species.html
@@ -5,7 +5,7 @@
 <div class="search-block species-search-block">
     <div class="search-field-wrapper">
         <label>{% trans "Search by Species" %}</label>
-        <div class="search-field-group">
+        <div class="autocomplete-group">
             <button class="typeahead-toggle" id="species-toggle"><i class="icon-menu"></i></button>
             <input type="text"
                    data-class="search"


### PR DESCRIPTION
* Expose more information from otmTypeahead.js
* Split a utility from BaconUtils.js
* Rename `search-field-group` to `autocomplete-group` and move to `layout.scss` so it can be shared
* Update modeling styles
