### PR TITLE
Support for modeling module

### DIFF
--- a/opentreemap/treemap/decorators.py
+++ b/opentreemap/treemap/decorators.py
@@ -23,7 +23,6 @@ from opentreemap.util import request_is_embedded
 from treemap.util import (add_visited_instance,
                           get_instance_or_404, login_redirect,
                           can_read_as_super_admin)
-from treemap.exceptions import FeatureNotEnabledException
 
 
 def instance_request(view_fn, redirect=True):
@@ -123,7 +122,7 @@ def requires_feature(ft):
             if instance.feature_enabled(ft):
                 return view_fn(request, instance, *args, **kwargs)
             else:
-                raise FeatureNotEnabledException('Feature Not Enabled')
+                raise PermissionDenied
 
         return wrapped
 
@@ -212,8 +211,7 @@ def creates_instance_user(view_fn):
                     role=instance.default_role
                 ).save_with_user(request.user)
             else:
-                raise FeatureNotEnabledException(
-                    'Users cannot join this map automatically')
+                raise PermissionDenied
 
         return view_fn(request, instance, *args, **kwargs)
 

--- a/opentreemap/treemap/exceptions.py
+++ b/opentreemap/treemap/exceptions.py
@@ -11,10 +11,6 @@ class InvalidInstanceException(Exception):
     pass
 
 
-class FeatureNotEnabledException(Exception):
-    pass
-
-
 class JSONResponseForbidden(HttpResponseForbidden):
     def __init__(self, *args, **kwargs):
         super(JSONResponseForbidden, self).__init__(


### PR DESCRIPTION
Replace FeatureNotEnabledException by PermissionDenied,
which django magically translates into a 403 Forbidden,
and returns the 403.html template.

--

Connects to OpenTreeMap/otm-addons#1359
Depends on OpenTreeMap/otm-addons#1371
Depends on OpenTreeMap/otm-website#146