### PR TITLE
User can create plot but not tree

### DIFF
--- a/opentreemap/treemap/templates/treemap/map-add-tree.html
+++ b/opentreemap/treemap/templates/treemap/map-add-tree.html
@@ -1,3 +1,4 @@
+{% load auth_extras %}
 {% load form_extras %}
 {% load i18n %}
 
@@ -7,6 +8,7 @@
     <h3>{% trans "Add a Tree" %}</h3>
     <div class="add-step-container" id="add-tree-container">
         {% include "treemap/partials/step_set_location.html" with first=True feature_name="tree" %}
+        {% usercancreate tree %}
         <div class="add-step">
             <div class="add-step-header">
                 {% trans "Add species and additional info" %}
@@ -28,6 +30,7 @@
             </div>
             {% include 'treemap/partials/step_controls.html' %}
         </div>
+        {% endusercancreate %}
         <div class="add-step">
             <div class="add-step-header">
                 {% trans "Finalize this tree" %}
@@ -47,7 +50,7 @@
                     </label>
                 </div>
                 <div>
-                    <input type="radio" name="addFeatureOptions" value="new" id="addtree-addnew" 
+                    <input type="radio" name="addFeatureOptions" value="new" id="addtree-addnew"
                            data-event-category="add-tree" data-event-action="done-add-new" /><label for="addtree-addnew">
                         {% trans "Add another tree with new details" %}
                     </label>

--- a/opentreemap/treemap/views/misc.py
+++ b/opentreemap/treemap/views/misc.py
@@ -18,7 +18,7 @@ from django.template import RequestContext
 
 from stormwater.models import PolygonalMapFeature
 
-from treemap.models import User, Species, StaticPage, Instance
+from treemap.models import User, Species, Tree, Plot, StaticPage, Instance
 
 from treemap.plugin import get_viewable_instances_filter
 
@@ -71,6 +71,8 @@ def index(request, instance):
 
 
 def get_map_view_context(request, instance):
+    def make_dummy_tree():
+        return Tree(instance=instance, plot=Plot(geom=instance.center))
     if request.user and not request.user.is_anonymous():
         iuser = request.user.get_instance_user(instance)
         resource_classes = [resource for resource in instance.resource_classes
@@ -82,6 +84,8 @@ def get_map_view_context(request, instance):
         'fields_for_add_tree': [
             (_('Tree Height'), 'Tree.height')
         ],
+        # Needed for checking add-tree permission
+        'tree': make_dummy_tree(),
         'resource_classes': resource_classes,
         'only_one_resource_class': len(resource_classes) == 1,
     }


### PR DESCRIPTION
When the user has permissions to create a plot but not to create a tree,
remove the second step of the add plot/tree wizard.

--

Connects to #2852