### PR TITLE
Improve performance of instance and user edits pages

### DIFF
--- a/opentreemap/treemap/lib/user.py
+++ b/opentreemap/treemap/lib/user.py
@@ -116,19 +116,20 @@ def get_audits(logged_in_user, instance, query_vars, user=None,
     # By relying on the fact the our list is ordered by primary key from newest
     # to oldest, we can rely on the index on the primary key, which is faster.
     if start_id is not None:
-        audits = audits.filter(pk__lt=start_id)
+        audits = audits.filter(pk__lte=start_id)
 
     total_count = audits.count() if should_count else 0
     audits = audits[:page_size]
 
-    # Coerce the queryset into a list so we can get the last item on the page
+    # Coerce the queryset into a list so we can get the last audit row on the
+    # current page
     audits = list(audits)
 
     # We are using len(audits) instead of audits.count() because we
     # have already realized the queryset at this point
     if len(audits) == page_size:
         query_vars.setlist('prev', prev_start_ids + [audits[0].pk])
-        query_vars['start'] = audits[-1].pk
+        query_vars['start'] = audits[-1].pk - 1
         next_page = "?" + query_vars.urlencode()
     else:
         next_page = None

--- a/opentreemap/treemap/templatetags/util.py
+++ b/opentreemap/treemap/templatetags/util.py
@@ -163,7 +163,7 @@ def display_name(audit_or_model_or_name, instance=None):
 def is_filterable_audit_model(model_name):
     allowed_models = get_filterable_audit_models()
 
-    return model_name in allowed_models.values()
+    return model_name in allowed_models
 
 
 @register.filter

--- a/opentreemap/treemap/util.py
+++ b/opentreemap/treemap/util.py
@@ -183,7 +183,7 @@ def get_filterable_audit_models():
     map_features = [c.__name__ for c in leaf_models_of_class(MapFeature)]
     models = map_features + ['Tree']
 
-    return {model.lower(): model for model in models}
+    return models
 
 
 def get_csv_response(filename):

--- a/opentreemap/treemap/views/misc.py
+++ b/opentreemap/treemap/views/misc.py
@@ -52,8 +52,7 @@ def edits(request, instance):
        - page
          The page to return
     """
-    (page, page_size, models, model_id,
-     exclude_pending) = get_audits_params(request)
+    params = get_audits_params(request)
 
     user_id = request.GET.get('user', None)
     user = None
@@ -61,8 +60,8 @@ def edits(request, instance):
     if user_id is not None:
         user = User.objects.get(pk=user_id)
 
-    return get_audits(request.user, instance, request.REQUEST, user,
-                      models, model_id, page, page_size, exclude_pending)
+    return get_audits(request.user, instance, request.GET.copy(), user,
+                      **params)
 
 
 def index(request, instance):


### PR DESCRIPTION
The edits page had exceptionally poor performance when paging beyond the first
few pages, to the point that the requests would time out when attempting to
reach pages past the first dozen or so.

This is primarily caused by the complex query we use to ensure that users only
see edits for fields they have permission to view, but was greatly exacerbated
by the use of `OFFSET` to get pages beyond the first, which requires the
database to retrieve and discard all rows for all previous pages.

By relying on the fact that we show edits in a deterministic order (newest to
oldest), we can switch from passing a page parameter to passing the starting
`Audit.id` and eliminate the `OFFSET`, making performance on each page roughly
equal.

One downside of this is that we need to keep track of the previous page
starting positions for every previous page, which means the URL can grow
to be rather long, but this seems like an OK trade-off to me.

While I was changing the code, I also cleaned up the API for `get_audits` and `get_audits_params`, as the number of parameters being returned from `get_audits_params` was getting excessive.

Connects to #1818