### PR TITLE
Fix search for IE 11

### DIFF
--- a/opentreemap/treemap/js/src/base.js
+++ b/opentreemap/treemap/js/src/base.js
@@ -7,3 +7,11 @@ require("../../../../assets/css/sass/main.scss");
 require("autotrack");
 require("treemap/lib/buttonEnabler.js").run();
 require("treemap/lib/export.js").run();
+
+// Polyfill for String.startsWith(), not supported in IE 11
+if (!String.prototype.startsWith) {
+    String.prototype.startsWith = function (searchString, position) {
+        position = position || 0;
+        return this.indexOf(searchString, position) === position;
+    };
+}


### PR DESCRIPTION
Add polyfill for `String.startsWith()`, not supported by IE 11.

Note: I verified that search now works on IE 11.

Connects OpenTreeMap/otm-clients#328