### PR TITLE
Support for updating instance bounds

### DIFF
--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -7,7 +7,8 @@ from copy import deepcopy
 
 from django.contrib.gis.db import models
 from django.contrib.gis.db.models import Extent
-from django.contrib.gis.geos import MultiPolygon, Polygon
+from django.contrib.gis.gdal import SpatialReference
+from django.contrib.gis.geos import MultiPolygon, Polygon, GEOSGeometry
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import RegexValidator
 from django.conf import settings
@@ -137,6 +138,27 @@ class InstanceBounds(models.Model):
                           (x_max, y_min),
                           (x_min, y_min)))
         bounds = MultiPolygon((bounds, ))
+        return InstanceBounds.objects.create(geom=bounds)
+
+    @classmethod
+    def create_from_geojson(cls, geojson):
+        """Create from GeoJSON (lon/lat coordinates)"""
+        geojson_dict = json.loads(geojson)
+        if geojson_dict['type'] != 'FeatureCollection':
+            raise ValidationError('GeoJSON must contain a FeatureCollection')
+
+        geoms = []
+        web_mercator = SpatialReference(3857)
+        for feature in geojson_dict['features']:
+            geom_dict = feature['geometry']
+            if geom_dict['type'] != 'Polygon':
+                raise ValidationError('GeoJSON features must be Polygons')
+            geom = GEOSGeometry(json.dumps(geom_dict), 4326)
+            geom.transform(web_mercator)
+            geoms.append(geom)
+
+        bounds = MultiPolygon(geoms)
+
         return InstanceBounds.objects.create(geom=bounds)
 
     def __str__(self):

--- a/opentreemap/treemap/js/src/lib/imageUploadPanel.js
+++ b/opentreemap/treemap/js/src/lib/imageUploadPanel.js
@@ -21,7 +21,7 @@ require('jqueryFileUpload');
 module.exports.init = function(options) {
     var $panel = $(options.panelId),
         $image = $(options.imageElement),
-        $error = $(options.error),
+        $error = $(options.error || '.js-image-upload-error'),
         $imageContainer = $(options.imageContainer),
         loadImageCarouselHtml = photoCarousel.getImageCarouselLoader({
             $imageContainer: $imageContainer
@@ -53,12 +53,12 @@ module.exports.init = function(options) {
             $progressBar.width(progress + '%');
         },
         always: function (e, data) {
-            $panel.modal('hide');
             $progressBar.width('0%');
 
             loadImageCarouselHtml(data.result);
         },
         done: function (e, data) {
+            $panel.modal('hide');
             if ($image.length > 0) {
                 $image.attr('src', data.result.url);
             }
@@ -108,6 +108,14 @@ module.exports.init = function(options) {
             return defer.promise();
         });
     });
+
+    $panel.on('hidden.bs.modal', function() {
+        $error.hide();
+    });
+
+    // TODO: all following code is specific to the map feature detail page.
+    // Move it to a separate module, since above code is generic and used in
+    // several other places.
 
     $imageContainer.on('slide', function(e) {
         var $thumbnailList = $imageContainer.find('.carousel-indicators'),

--- a/opentreemap/treemap/js/src/user.js
+++ b/opentreemap/treemap/js/src/user.js
@@ -28,7 +28,5 @@ recentEdits.init({
 
 imageUploadPanel.init({
     panelId: '#set-photo-modal',
-    show: '#toggle-set-photo-modal',
-    error: '#upload-photo-error',
     imageElement: '#user-photo'
 });

--- a/opentreemap/treemap/templates/treemap/partials/upload_image.html
+++ b/opentreemap/treemap/templates/treemap/partials/upload_image.html
@@ -5,7 +5,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-        <h2>{{ title }}</h2>
+        <h3>{{ title }}</h3>
       </div>
       <div class="modal-body">
         <p>
@@ -13,13 +13,18 @@
             Maximum file size: {{ max_image_size }}MB
           {% endblocktrans %}
         </p>
-        <input class="fileChooser" type="file" name="file" data-url="{{ upload_photo_endpoint }}" accept="image/*">
+        <p>
+          <input class="fileChooser" type="file" name="file"
+                 data-url="{{ upload_photo_endpoint }}"
+                 accept={{ accept|default_if_none:"image/*" }}>
+        </p>
         <div class="progress">
           <div class="progress-bar-info" style="width: 0%; height: 100%"></div>
         </div>
+        <div class="alert alert-danger js-image-upload-error" style="display: none;"></div>
       </div>
       <div class="modal-footer">
-        <a href="javascript:;" class="btn" data-dismiss="modal">Cancel</a>
+        <a href="javascript:;" class="btn" data-dismiss="modal">{% trans "Cancel" %}</a>
       </div>
     </div>
   </div>

--- a/opentreemap/treemap/templates/treemap/user.html
+++ b/opentreemap/treemap/templates/treemap/user.html
@@ -63,7 +63,6 @@ ga('global.set', 'page', pathname);
                 </h1>
             </div>
             {% usercontent for user %}
-            <div id="upload-photo-error" class="text-danger" style="display: none"></div>
             <button id="edit-user" data-class="display" class="btn btn-sm btn-info">{% trans "Edit Profile" %}</button>
             <button id="save-edit" data-class="edit" class="btn btn-sm btn-primary" style="display: none;">{% trans "Save" %}</button>
             <button id="cancel-edit" data-class="edit" class="btn btn-sm" style="display: none;">{% trans "Cancel" %}</button>


### PR DESCRIPTION
Add `InstanceBounds.create_from_geojson()`
* For now, require a `FeatureCollection` containing `Polygon`s

Refactor (slightly) `treemap/js/src/lib/imageUploadPanel.js` and `treemap/partials/upload_image.html`:
* Template's `accept` argument defaults to images but can specify another file type
* Show errors in the modal unless specified otherwise
* Clean up the formatting

Tweak `user.js` image upload to show errors in the modal and remove unused `show` option