### PR TITLE
Change species thumbprint if a species is deleted

### DIFF
--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -454,18 +454,17 @@ class Instance(models.Model):
         # or when the current instance's species are updated.
         #
         # To get a unique thumbprint across instances and species updates
-        # we use the instance's latest species update time if available,
-        # and otherwise its url name.
+        # we use the instance's url_name, latest species update time, and
+        # species count (to handle deletions).
         from treemap.models import Species
-        thumbprint = None
         my_species = Species.objects \
             .filter(instance_id=self.id) \
             .order_by('-updated_at')
-        try:
-            thumbprint = my_species[0].updated_at
-        except IndexError:
-            pass
-        return "%s_%s" % (self.url_name, thumbprint)
+        if my_species.exists():
+            return "%s_%s_%s" % (
+                self.url_name, my_species.count(), my_species[0].updated_at)
+        else:
+            return self.url_name
 
     @property
     def boundary_thumbprint(self):

--- a/opentreemap/treemap/tests/test_instance.py
+++ b/opentreemap/treemap/tests/test_instance.py
@@ -57,6 +57,11 @@ class ThumbprintTests(OTMTestCase):
         thumbprint2 = instance.species_thumbprint
         self.assertNotEqual(thumbprint1, thumbprint2)
 
+        s = Species.objects.filter(instance=instance, common_name='Acacia')
+        s.delete()
+        thumbprint3 = instance.species_thumbprint
+        self.assertNotEqual(thumbprint2, thumbprint3)
+
     def test_boundary_thumbprint(self):
         g = MultiPolygon(Polygon(((0, 0), (1, 0), (1, 1), (0, 1), (0, 0))))
         b = Boundary.objects.create(


### PR DESCRIPTION
While you can't currently delete a species via the UI, you'll be able to someday. And we sometimes need to delete them behind the scenes. Without this change, the previous species list is not removed from browser-local storage so the deleted species is still shown.