### PR TITLE
On plot detail page always show i-Tree code to admins

### DIFF
--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -1086,7 +1086,10 @@ class Tree(Convertible, UDFModel, PendingAuditable, ValidationMixin):
 
     @property
     def itree_code(self):
-        return self.species.get_itree_code(self.plot.itree_region.code)
+        if self.species:
+            return self.species.get_itree_code(self.plot.itree_region.code)
+        else:
+            return None
 
     ##########################
     # tree validation

--- a/opentreemap/treemap/templates/treemap/partials/plot_eco.html
+++ b/opentreemap/treemap/templates/treemap/partials/plot_eco.html
@@ -30,7 +30,7 @@
       <tr style="font-style: italic">
         <td>i-Tree region</td><td>{{ plot.itree_region }}</td><td></td>
       </tr>
-      {% if invalid_eco_pair or benefits.plot %}
+      {% if tree %}
       <tr style="font-style: italic">
         <td>i-Tree code</td><td>{{ tree.itree_code }}</td><td></td>
       </tr>


### PR DESCRIPTION
When debugging ecobenefit problems it's always useful to see the i-Tree code, and it doesn't hurt anything to show it as "None".