### PR TITLE
fixed diameter inputs so in vs cm doesnt break layout

### DIFF
--- a/assets/css/sass/partials/pages/_scenarios.scss
+++ b/assets/css/sass/partials/pages/_scenarios.scss
@@ -125,6 +125,11 @@
                     
                     input.form-control {
                         font-size: 1.2rem;
+                        min-width: 33px;
+                    }
+
+                    .input-group-addon {
+                        padding: 5px;
                     }
                 }
             }


### PR DESCRIPTION
fixes https://github.com/OpenTreeMap/otm-addons/issues/239

I added a min-width to the input and made the padding small on the input-addon. The input will be big enough for both imperial and metric.

![screen shot 2017-01-09 at 2 52 34 pm](https://cloud.githubusercontent.com/assets/1928955/21780996/99ea0104-d67b-11e6-8698-e55205ba3866.png)
