### PR TITLE
fixed issue where modeling toolbar elements overlapped less than 992px

### DIFF
--- a/assets/css/sass/partials/pages/_modeling.scss
+++ b/assets/css/sass/partials/pages/_modeling.scss
@@ -25,10 +25,23 @@ $blue-to-red: #2791c3 10%,
 
         .toolbar-wrapper {
             top: 50px;
+
+            @media (max-width: 991px) {
+                left: initial;
+                width: 60%;
+
+                #toolbar {
+                    width: 100%;
+                }
+            }
         }
 
         .search-wrapper {
             top: 55px;
+
+            @media (max-width: 991px) {
+                left: 62%;
+            }
         }
 
         .action-block {
@@ -60,6 +73,14 @@ $blue-to-red: #2791c3 10%,
             #autosave-message {
                 font-size: 1.2rem;
                 color: lighten($main-text-color, 70%);
+            }
+
+            @media (max-width: 991px) {
+                margin: 0;
+                border: none;
+                padding-left: 0;
+                padding-right: 0;
+                border-right: 1px solid #ddd;
             }
         }
 
@@ -104,6 +125,14 @@ $blue-to-red: #2791c3 10%,
                 margin-top: 30px;
                 padding: 6px 0 6px 9px;
                 color: $subtext-color;
+            }
+
+            @media (max-width: 991px) {
+                width: 100%;
+
+                .search-block {
+                    width: 70%;
+                }
             }
         }
     }


### PR DESCRIPTION
fixes https://github.com/OpenTreeMap/otm-addons/issues/1388

Added some media queries to fix the overlapping issue. Since modeling is not fully mobile responsive I worried only about small desktop - tablet size screens.

![screen shot 2017-01-09 at 3 07 00 pm](https://cloud.githubusercontent.com/assets/1928955/21781496/9b200710-d67d-11e6-8778-f7d8c769eff6.png)
