### PR TITLE
fixes modeling toolbar button height and various sidebar issues

### DIFF
--- a/assets/css/sass/partials/pages/_modeling.scss
+++ b/assets/css/sass/partials/pages/_modeling.scss
@@ -141,6 +141,13 @@ $blue-to-red: #2791c3 10%,
                 padding: 9px 13px;
                 border-radius: 0;
                 border-left: 2px solid #ddd;
+                border-left: 2px solid #ddd;
+                height: 37px; // equal to height of scenario toolbar
+
+                i {
+                    padding: 0;
+                    margin: 0;
+                }
             }
         }
 
@@ -207,7 +214,7 @@ $blue-to-red: #2791c3 10%,
             right: auto;
             left: 0;
             border: none;
-            bottom: 40px;
+            bottom: 0;
 
             .templates {
                 height: 50px;
@@ -307,23 +314,24 @@ $blue-to-red: #2791c3 10%,
                 }
             }
             .scenario-trees-total {
-                width: 260px;
-                position: absolute;
-                bottom: 15px;
-                right: -285px;
+                position: fixed;
+                bottom: 40px;
+                right: initial;
+                left: 355px;
                 background: white;
-                padding: 7px 12px 8px;
+                padding: 2px 10px;
                 font-size: 1.4rem;
-                border-radius: 6px;
+                border-radius: 4px;
                 box-shadow: 0 1px 7px rgba(0, 0, 0, 0.4);
                 z-index: 1;
-
+                margin: 10px;
 
                 p {
                     color: darken($subtext-color, 10%);
                     margin: 5px;
                     font-weight: 600;
                     font-size: 13px;
+                    display: inline-block;
 
                     > span {
                         color: $primary-color;


### PR DESCRIPTION
- fixes https://github.com/OpenTreeMap/otm-addons/issues/1378
- fixes https://github.com/OpenTreeMap/otm-addons/issues/1390

Button now has the border below it consistent with the toolbar:
![screen shot 2017-01-09 at 3 51 20 pm](https://cloud.githubusercontent.com/assets/1928955/21783016/8005509c-d683-11e6-9a29-5e899c109c2b.png)

The sidebar will now span the full height available to it:
![screen shot 2017-01-09 at 3 48 49 pm](https://cloud.githubusercontent.com/assets/1928955/21783187/42ecdfd0-d684-11e6-81d4-345fb8fd0d69.png)

Additionally, the scenario summary is no longer hidden below the planting areas legend. I don't believe this has been previously documented as an issue. It was always there, just being covered by the legend. This is also only visible when in a scenario.
![screen shot 2017-01-09 at 3 49 19 pm](https://cloud.githubusercontent.com/assets/1928955/21783186/42ea4144-d684-11e6-9fac-b7f550e3d213.png)
