### PR TITLE
Feature/rtb/search by user

### DIFF
--- a/assets/css/sass/partials/_layout.scss
+++ b/assets/css/sass/partials/_layout.scss
@@ -277,6 +277,10 @@ body {
         &::placeholder {
             text-overflow: ellipsis !important;
         }
+
+        &.no-hamburger {
+            padding-left: 8px;
+        }
     }
     .typeahead-toggle {
         padding: 9px 4px 7px;

--- a/assets/css/sass/partials/_subheader.scss
+++ b/assets/css/sass/partials/_subheader.scss
@@ -122,6 +122,11 @@
             min-width: 300px;
             max-height: 350px;
             overflow: auto;
+            .tt-menu.tt-open {
+                .tt-suggestion {
+                    color: #333;
+                }
+            }
         }
 
         .field-group {
@@ -210,6 +215,11 @@
             color: lighten($primary-color, 45%);
             font-size: 1.4rem;
             font-weight: 400;
+        }
+
+        #adv-search-category-mapFeature+.dropdown-menu {
+            overflow: visible;
+            max-height: none;
         }
     }
 

--- a/opentreemap/treemap/js/src/lib/search.js
+++ b/opentreemap/treemap/js/src/lib/search.js
@@ -182,6 +182,8 @@ function buildFilterObject () {
                 // will make numeric comparison more flexible, and range
                 // searches on text don't make sense.
                 val = parseFloat(val);
+            } else if ($elem.is('[data-remote]')) {
+                val = parseInt(val, 10);
             } else {
                 val = val;
             }
@@ -226,9 +228,6 @@ function buildDisplayList() {
 // applyFilter: Function to call when filter changes.
 exports.init = function(searchStream, applyFilter) {
     searchStream.onValue(applyFilter);
-
-    // Clear any previous search results
-    searchStream.map('').onValue($('#search-results'), 'html');
 
     var completedSearch = searchStream
         .flatMap(executeSearch);

--- a/opentreemap/treemap/js/src/lib/searchBar.js
+++ b/opentreemap/treemap/js/src/lib/searchBar.js
@@ -47,6 +47,7 @@ var dom = {
     speciesSearchToggle: '#species-toggle',
     speciesSearchContainer: '#species-search-wrapper',
     locationSearchTypeahead: '#boundary-typeahead',
+    foreignKey: '[data-foreign-key]',
 };
 
 // Placed onto the jquery object
@@ -109,6 +110,22 @@ function initSearchUi(searchStream) {
         sortKeys: ['sortOrder', 'value'],
         geocoder: true,
         geocoderBbox: config.instance.extent
+    });
+
+    var $query_typeaheads = $('.search-right .autocomplete-group');
+    $query_typeaheads.each(function () {
+        var $textInput = $(this).find('[type="text"]');
+        var $hiddenInput = $(this).find('[type="hidden"]');
+
+        otmTypeahead.create({
+            remote: $textInput.data('remote'),
+            display: $textInput.data('display'),
+            input: $textInput,
+            template: '#' + $textInput.data('qualifier') + '-template',
+            hidden: $hiddenInput,
+            reverse: "id",
+            minLength: 1
+        });
     });
 
     // Keep dropdowns open when controls in them are clicked

--- a/opentreemap/treemap/migrations/0041_search_by_user.py
+++ b/opentreemap/treemap/migrations/0041_search_by_user.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from copy import deepcopy
+
+from django.db import migrations
+
+from treemap.DotDict import DotDict
+
+
+identifier = u'mapFeature.updated_by'
+
+
+def update_config_property(apps, update_fn, *categories):
+    Instance = apps.get_model("treemap", "Instance")
+    for instance in Instance.objects.filter(
+            config__contains='\"search_config\":'):
+        instance.config = update_fn(instance.config, *categories)
+        instance.save()
+
+
+def add_to_config(config, *categories):
+    config = DotDict(deepcopy(config or {}))
+    for category in categories:
+        lookup = '.'.join(['search_config', category])
+        specs = config.setdefault(lookup, [])
+        if 0 == len([v for s in specs for v in s.values() if v == identifier]):
+            # mutates config[lookup]
+            specs.append({u'identifier': identifier})
+
+    return config
+
+
+def add_custom_id_forward(apps, schema_editor):
+    update_config_property(apps, add_to_config, 'general')
+
+
+def remove_from_config(config, *categories):
+    config = DotDict(deepcopy(config or {}))
+    for category in categories:
+        lookup = '.'.join(['search_config', category])
+        specs = config.get(lookup)
+        if specs:
+            find_index = [i for i, s in enumerate(specs)
+                          if identifier in s.values()]
+            if 0 < len(find_index):
+                specs.pop(find_index[0])
+
+    return config
+
+
+def add_custom_id_backward(apps, schema_editor):
+    update_config_property(apps, remove_from_config, 'general')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0040_expand_itree_regions'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_custom_id_forward, add_custom_id_backward),
+    ]

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -574,7 +574,8 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
     # efficient.
     updated_at = models.DateTimeField(default=timezone.now,
                                       verbose_name=_("Last Updated"))
-    updated_by = models.ForeignKey(User, null=True, blank=True)
+    updated_by = models.ForeignKey(User, null=True, blank=True,
+                                   verbose_name=_("Updated By"))
 
     objects = GeoHStoreUDFManager()
 

--- a/opentreemap/treemap/search_fields.py
+++ b/opentreemap/treemap/search_fields.py
@@ -28,7 +28,8 @@ DEFAULT_MOBILE_SEARCH_FIELDS = DotDict({
 
 DEFAULT_SEARCH_FIELDS = DotDict({
     'general': [
-        {'identifier': 'mapFeature.updated_at'}
+        {'identifier': 'mapFeature.updated_at'},
+        {'identifier': 'mapFeature.updated_by'}
     ],
     'missing': [
         {'identifier': 'species.id'},

--- a/opentreemap/treemap/templates/instance_base.html
+++ b/opentreemap/treemap/templates/instance_base.html
@@ -239,5 +239,12 @@ ga('set', 'page', pathname);
 </ul>
 </script>
 
+<script id="updated_by-template" type="text/x-mustache-template">
+<div>
+  <p class="pull-right">{{first_name}} {{last_name}}</p>
+  <p>{{username}}</p>
+</div>
+</script>
+
 {% endverbatim %}
 {% endblock templates %}

--- a/opentreemap/treemap/templates/treemap/field/inputs.html
+++ b/opentreemap/treemap/templates/treemap/field/inputs.html
@@ -1,5 +1,6 @@
 {% load l10n %}
 {% load dateformat %}
+{% load util %}
 {% if field.data_type == 'bool' or field.search_type == 'ISNULL' %}
     <input name="{{ field.identifier }}"
           {% if field.value %}
@@ -34,6 +35,8 @@
            class="{{ class|default_if_none:"" }} form-control"
            value="{{ field.value|default_if_none:""|unlocalize }}"
            {{ extra|default:"" }} ></textarea>
+{% elif field.typeahead_url %}
+    {% include "treemap/partials/autocomplete.html" %}
 {% else %}
   {% if field.units %}
   <div class="input-group">

--- a/opentreemap/treemap/templates/treemap/field/search.html
+++ b/opentreemap/treemap/templates/treemap/field/search.html
@@ -18,7 +18,7 @@
             {% endwith %}
         </div>
     {% else %}
-        <div class="form-group">
+        <div class="form-group{% if field.typeahead_url %} search-block{% endif %}">
             {% if field.search_type != 'ISNULL' %}
                 {# Label must precede input for most fields but must follow input for "missing data" checkboxes #}
                 <label for="{{ field.id }}">{{ field.label }}</label>

--- a/opentreemap/treemap/templates/treemap/partials/autocomplete.html
+++ b/opentreemap/treemap/templates/treemap/partials/autocomplete.html
@@ -1,0 +1,15 @@
+{% load i18n %}
+
+<!-- Location Search -->
+<div class="autocomplete-group">
+  <input type="text"
+         data-class="search"
+         id="{{ field.id }}-typeahead"
+         class="form-control no-hamburger"
+         placeholder="{{ field.placeholder }}"
+         data-qualifier="{{ field.qualifier }}"
+         data-display="{{ field.display }}"
+         data-remote="{{ field.typeahead_url }}"/>
+  <a class="btn btn-default search-button" id="{{ field.qualifier }}-perform-search"><i class="icon-search"></i></a>
+  <input name="{{ field.identifier }}_id" type="hidden" id="{{ field.id }}-value" {{ extra|default:"" }}/>
+</div>

--- a/opentreemap/treemap/views/user.py
+++ b/opentreemap/treemap/views/user.py
@@ -240,6 +240,8 @@ def users(request, instance):
         user = {
             'id': udict['user_id'],
             'username': udict['user__username'],
+            'first_name': '',
+            'last_name': ''
         }
         if udict['user__make_info_public']:
             user['first_name'] = udict['user__first_name']


### PR DESCRIPTION
Changes:

- Add foreign key handling to `form_extras` `SearchNode`
- Add HTML to express `SearchNode` foreign key fields
- `searchBar.js` translation of foreign key DOM into `otmTypeahead` options
- `otmTypeahead` now handles dynamic search without prefetch
- `search.js` adapts foreign key fields to tiler requests
- Reset resets both significant parts of the typeahead DOM
- Style fixes
- Remove a no-op bacon onValue

Complaints:

The General dropdown doesn't expand to include the typeahead
drop-down menu, which now appears to overlap the bottom of it.
Not pretty, but usable.

Not tested at all with responsive design.

--

Connects to #388
