### PR TITLE
Include always-writable fields in data returned by API "Instance info endpoint"

### DIFF
--- a/opentreemap/api/tests.py
+++ b/opentreemap/api/tests.py
@@ -1197,6 +1197,11 @@ class Instance(LocalMediaTestCase):
             {'field_keys': ['tree.date_planted']},
             info.get('field_key_groups')[0])
 
+    def test_adds_always_writable_api_fields(self):
+        request = sign_request_as_user(make_request(user=self.user), self.user)
+        fields = instance_info(request, self.instance)['fields']
+        self.assertTrue('plot.geom' in fields)
+
     def test_collection_udfs_v3(self):
         request = sign_request_as_user(make_request(user=self.user), self.user)
 


### PR DESCRIPTION
When creating or updating a tree, the iOS app sends only fields known to be writable by the current user. Previously all writable fields had DB `FieldPermission` objects, but after some recent changes that is no longer true for `plot.geom`. So for newly-created treemaps users can't create trees with the iOS app because `plot.geom` is not posted to the back end.

We now have a well-defined category of "always-writable" fields, which includes `plot.geom`. So,including always-writable fields in the data returned by the API "Instance info" endpoint allows the iOS app to once again post `plot.geom` to the back end.

I abstracted the function `add_perms` from the current code (without changes), and call it twice -- once with `FieldPermission` objects from the database (as before) and once with `FieldPermission` objects temporarily constructed from `always_writable` fields.

Connects OpenTreeMap/otm-ios#337