### PR TITLE
In API, set tree photo permission for iOS app versions <= 2.6.0

### DIFF
--- a/opentreemap/api/instance.py
+++ b/opentreemap/api/instance.py
@@ -221,6 +221,13 @@ def instance_info(request, instance):
     perms = {}
     add_perms(field_perms, perms)
     add_perms(always_writable, perms)
+    # Legacy iOS app versions (<= 2.6.0) enforce photo permissions using
+    # the `treephoto.image` field, so set it. This can be removed when we
+    # think all users are on a later version.
+    perms['treephoto.image'] = {
+        'can_write': perms_lib.photo_is_addable(role, Plot),
+        'data_type': 'string'
+    }
 
     def get_key_for_group(field_group):
         for key in ('collection_udf_keys', 'field_keys'):


### PR DESCRIPTION
The iOS app still enforces photo permissions using the old-style `treephoto.image` permission, so set that permission.

Testing:

1. Run OTM without these changes
1. Create a new instance
1. For the "Editor" role, turn off the "Can Add Tree Photo" permission
1. Assign a user the "Editor" role
1. From the iOS app, log in as that user and load the instance
1. Click "Add", place a tree, and click "Next". The "Picture" field should incorrectly say "Tree Picture", and allow you to try adding a photo, but the upload should fail.
1. Repeat steps 5-6 with these changes -- the "Picture" field should say "Picture cannot be changed".
1. For the "Editor" role, turn on the "Can Add Tree Photo" permission
1. Repeat steps 5-6 -- you should be able to create a tree with a photo

(Note I discovered https://github.com/OpenTreeMap/otm-ios/issues/343 when trying to then update the photo. But that issue is not related to this one, nor, I believe, to OpenTreeMap/otm-ios#337)

Connects OpenTreeMap/otm-clients#334