### PR TITLE
Invalidate ecoservice cache when an i-Tree code override is created

### DIFF
--- a/opentreemap/treemap/ecocache.py
+++ b/opentreemap/treemap/ecocache.py
@@ -6,8 +6,9 @@ import hashlib
 
 from django.conf import settings
 from django.core.cache import cache
+from django.db.models.signals import post_save, post_delete
 
-from treemap.models import Plot
+from treemap.models import Plot, ITreeCodeOverride
 
 # Cache the results of plot counts and tree ecobenefit summary requests.
 #
@@ -76,3 +77,56 @@ def _get_key(prefix, filter):
                            version,
                            filter_hash)
     return key
+
+
+# ----------------------------------------------------------------
+# The ecoservice keeps a cache of i-Tree code overrides.
+# Store a cache buster in Redis, and keep a local copy.
+# If the local copy is stale, invalidate the ecoservice cache.
+
+_ITREE_CODE_OVERRIDE_REV_KEY = 'itree_code_override_rev'
+my_itree_code_override_rev = None
+
+
+def _init_ecoservice_cache_handling():
+    global my_itree_code_override_rev
+    my_itree_code_override_rev = _get_cached_rev()
+
+    post_save.connect(_increment_itree_code_override_rev,
+                      sender=ITreeCodeOverride)
+    post_delete.connect(_increment_itree_code_override_rev,
+                        sender=ITreeCodeOverride)
+
+
+def _get_cached_rev():
+    cached_rev = cache.get(_ITREE_CODE_OVERRIDE_REV_KEY)
+    if not cached_rev:
+        timeout = 60 * 60 * 24 * 365 * 10  # 10 years
+        cache.set(_ITREE_CODE_OVERRIDE_REV_KEY, 1, timeout)
+    return cached_rev
+
+
+def _increment_itree_code_override_rev(*args, **kwargs):
+    # This line added only for tests, where the cache key may not have been
+    # created. Redis incr() creates the key if absent, but django_redis
+    # doesn't because it's a Django cache backend. (Explained in this issue
+    # from a different Django Redis cache backend -
+    # https://github.com/sebleier/django-redis-cache/issues/113)
+    _get_cached_rev()
+
+    cache.incr(_ITREE_CODE_OVERRIDE_REV_KEY)
+
+
+def invalidate_ecoservice_cache_if_stale():
+    from treemap import ecobackend
+    global my_itree_code_override_rev
+    cached_rev = cache.get(_ITREE_CODE_OVERRIDE_REV_KEY)
+    if my_itree_code_override_rev != cached_rev:
+        __, err = ecobackend.json_benefits_call('invalidate_cache', {})
+        if err:
+            raise Exception('Failed to invalidate ecoservice cache')
+        my_itree_code_override_rev = cached_rev
+    return cached_rev
+
+
+_init_ecoservice_cache_handling()

--- a/opentreemap/treemap/species/codes.py
+++ b/opentreemap/treemap/species/codes.py
@@ -41,6 +41,8 @@ def get_itree_code(region_code, otm_code):
 # to a species changes depending on where that species
 # is located geographically.
 
+# NOTE: if you change this, also recreate otm-ecoservice/data/species.json
+
 _CODES = {
 ##################################################
     'CaNCCoJBK': {


### PR DESCRIPTION
* Note that the ecoservice caches i-Tree code overrides for all instances, and that invalidating the cache reloads overrides for all instances.
* Store in Redis an `itree_code_override_rev` cache buster for all instances
* When a Django app launches, store the current value of the cache buster in a static variable
* Create signal handlers so that any `ITreeCodeOverride` change increments the cache buster in Redis
* When making any ecoservice call, if the cache buster is stale, invalidate the ecoservice cache

Here's an example of how this works with 2 app servers, A and B:
1. A calls `_init_ecoservice_cache_handling`, setting the Redis rev and `my_itree_code_override_rev` to 1.
1. B calls `_init_ecoservice_cache_handling`, reading the Redis rev and setting `my_itree_code_override_rev` to 1.
1. A saves an `ITreeCodeOverride`, causing `_increment_itree_code_override_rev` to set the Redis rev to 2.
1. B makes an ecoservice call, which calls `invalidate_ecoservice_cache_if_stale`. Since B's `my_itree_code_override_rev` is still 1, B calls `invalidate_cache` on its ecoservice and sets `my_itree_code_override_rev` to 2.
1. A makes an ecoservice call, which calls `invalidate_ecoservice_cache_if_stale`. Since A's `my_itree_code_override_rev` is still 1, A calls `invalidate_cache` on its ecoservice and sets `my_itree_code_override_rev` to 2.

Testing:
1. Create a new instance centered on Seattle
1. Add a tree in downtown Seattle with species Acer rubrum and diameter 11 inches, and note your total ecobenefits
1. Restart celery
1. Do a bulk import of users/rmohr/data/importer/acerRubrumOverride.csv
1. Reload the map page -- the total ecobenefits should have changed

Connects #1975