### PR TITLE
Update ecoservice cache invalidation to not call Redis in top-level code

### DIFF
--- a/opentreemap/treemap/ecocache.py
+++ b/opentreemap/treemap/ecocache.py
@@ -82,51 +82,45 @@ def _get_key(prefix, filter):
 # ----------------------------------------------------------------
 # The ecoservice keeps a cache of i-Tree code overrides.
 # Store a cache buster in Redis, and keep a local copy.
-# If the local copy is stale, invalidate the ecoservice cache.
+# If the local copy is stale, invalidate the cache of the local ecoservice.
 
 _ITREE_CODE_OVERRIDE_REV_KEY = 'itree_code_override_rev'
 my_itree_code_override_rev = None
 
 
-def _init_ecoservice_cache_handling():
-    global my_itree_code_override_rev
-    my_itree_code_override_rev = _get_cached_rev()
-
-    post_save.connect(_increment_itree_code_override_rev,
-                      sender=ITreeCodeOverride)
-    post_delete.connect(_increment_itree_code_override_rev,
-                        sender=ITreeCodeOverride)
-
-
-def _get_cached_rev():
-    cached_rev = cache.get(_ITREE_CODE_OVERRIDE_REV_KEY)
-    if not cached_rev:
-        timeout = 60 * 60 * 24 * 365 * 10  # 10 years
-        cache.set(_ITREE_CODE_OVERRIDE_REV_KEY, 1, timeout)
-    return cached_rev
-
-
 def _increment_itree_code_override_rev(*args, **kwargs):
-    # This line added only for tests, where the cache key may not have been
-    # created. Redis incr() creates the key if absent, but django_redis
-    # doesn't because it's a Django cache backend. (Explained in this issue
-    # from a different Django Redis cache backend -
-    # https://github.com/sebleier/django-redis-cache/issues/113)
-    _get_cached_rev()
-
+    _init_if_needed()
     cache.incr(_ITREE_CODE_OVERRIDE_REV_KEY)
 
 
 def invalidate_ecoservice_cache_if_stale():
     from treemap import ecobackend
     global my_itree_code_override_rev
-    cached_rev = cache.get(_ITREE_CODE_OVERRIDE_REV_KEY)
+
+    cached_rev = _init_if_needed()
+
     if my_itree_code_override_rev != cached_rev:
         __, err = ecobackend.json_benefits_call('invalidate_cache', {})
         if err:
             raise Exception('Failed to invalidate ecoservice cache')
         my_itree_code_override_rev = cached_rev
+
+
+def _init_if_needed():
+    global my_itree_code_override_rev
+
+    cached_rev = cache.get(_ITREE_CODE_OVERRIDE_REV_KEY)
+    if cached_rev is None:
+        timeout = 60 * 60 * 24 * 365 * 10  # 10 years
+        cache.set(_ITREE_CODE_OVERRIDE_REV_KEY, 1, timeout)
+        cached_rev = 1
+
+    if my_itree_code_override_rev is None:
+        my_itree_code_override_rev = cached_rev
+
     return cached_rev
 
 
-_init_ecoservice_cache_handling()
+post_save.connect(_increment_itree_code_override_rev, sender=ITreeCodeOverride)
+post_delete.connect(_increment_itree_code_override_rev,
+                    sender=ITreeCodeOverride)


### PR DESCRIPTION
In the previous implementation, top-level Django app initialization code called Redis. That broke deployment because the Redis server was not available. Refactor to initialize `rev` values lazily.

Testing is the same as in #2953:
1. Restart celery
1. Create or use an instance centered on Seattle
1. Add a tree in downtown Seattle with species Acer rubrum and diameter 11 inches, and note your total ecobenefits
1. Do a bulk import of users/rmohr/data/importer/acerRubrumOverride.csv (note you may need to merge the species before adding it to the treemap)
1. Reload the map page -- the total ecobenefits should have changed

Connects #1975