### PR TITLE
Ignore updated_at and updated_by field values when updating plots via the API.

### DIFF
--- a/opentreemap/api/plots.py
+++ b/opentreemap/api/plots.py
@@ -83,10 +83,14 @@ def update_or_create_plot(request, instance, plot_id=None):
             for key, val in request_dict[model].iteritems():
                 data["%s.%s" % (model, key)] = val
 
-    # We explicitly disallow setting a plot's tree id
+    # We explicitly disallow setting a plot's tree id.
+    # We ignore plot's updated at and by because
+    # auditing sets them automatically.
     keys = ["tree.plot",
             "tree.udfs",
             "tree.instance",
+            "plot.updated_at",
+            "plot.updated_by",
             "plot.instance",
             "plot.udfs"]
 

--- a/opentreemap/api/tests.py
+++ b/opentreemap/api/tests.py
@@ -596,11 +596,13 @@ class UpdatePlotAndTree(OTMTestCase):
 
         reputation_count = self.user.get_reputation(self.instance)
 
+        # Include `updated_by` because the app does send it,
+        # and the endpoint must ignore it.
         updated_values = {'plot':
-                          {'geom':
-                           {'y': 0.001, 'x': 0.001, 'srid': 4326},
+                          {'geom': {'y': 0.001, 'x': 0.001, 'srid': 4326},
                            'width': 11,
-                           'length': 22}}
+                           'length': 22,
+                           'updated_by': self.user.pk}}
 
         response = put_json("%s/instance/%s/plots/%d" %
                             (API_PFX, self.instance.url_name, test_plot.pk),
@@ -725,7 +727,10 @@ class UpdatePlotAndTree(OTMTestCase):
         test_tree.diameter = 2.3
         test_tree.save_with_user(self.user)
 
-        updated_values = {'tree': {'diameter': 3.9}}
+        # Include `updated_by` because the app does send it,
+        # and the endpoint must ignore it.
+        updated_values = {'tree': {'diameter': 3.9},
+                          'plot': {'updated_by': self.user.pk}}
         response = put_json("%s/instance/%s/plots/%d" %
                             (API_PFX, self.instance.url_name, test_plot.id),
                             updated_values, self.client, self.user)


### PR DESCRIPTION
The android app sends `updated_by`. It doesn't know it's a foreign key,
neither does the api, so it gets set to the `id` rather than the model.
This causes a `ValueError` in auditing.

The api already has a list of attributes to ignore.
`updated_by` can be safely ignored because it is set in auditing.
Same for `updated_at`. Since they are supposed to be set in auditing,
they really should both be ignored.

So ignore them.

--

Connects to https://github.com/OpenTreeMap/otm-android/issues/303
Connects to https://github.com/OpenTreeMap/otm-android/issues/304