### PR TITLE
Restore instance API field identifiers

### DIFF
--- a/opentreemap/api/instance.py
+++ b/opentreemap/api/instance.py
@@ -229,6 +229,20 @@ def instance_info(request, instance):
         'data_type': 'string'
     }
 
+    # These identifiers are not included in `perms` for instances
+    # created after the transtion to model-level permissions, but the
+    # identifiers are referenced in the default mobile search
+    # configuration. Versions of the iOS application depend on all the
+    # identifiers in the search config being respresented in the
+    # `perms` dictionary if the user is allowed to see the field
+    # value. Species and photos are always visible, so we can hard
+    # code a non-None value for these identifiers.
+    for identifier in ('species.id', 'mapFeaturePhoto.id'):
+        if identifier not in perms:
+            perms[identifier] = {
+                'data_type': 'string'
+            }
+
     def get_key_for_group(field_group):
         for key in ('collection_udf_keys', 'field_keys'):
             if key in field_group:


### PR DESCRIPTION
**NOTE**: In my testing, this PR resolves the issue reported in https://github.com/OpenTreeMap/otm-ios/issues/346 without impacting the Android application but I am not sure if this is the best solution to the problem.

Versions of the iOS application use the presence of identifiers in the `fields` dictionary returned from the instance info API to determine whether or not a field in the search configuration should be invisible to the currently logged in user. The identifiers in this commit were not included in fields dictionary for instances created after the transition to model-level permissions, but the identifiers are referenced in the default mobile search configuration. Species and photos are always visible, so we can hard code a non-None value for these identifiers to restore the structure assumed by the iOS
application.

I opted to handle these special case fields in the backend rather than the iOS application so that we hard code as little special case logic outside of the server code, which is easier to deploy.

--- 

##### Testing

Manual testing requires the running the iOS application against a VM running this branch.

I ran my tests using PhillyTreeMap as my "pre model-level features" instance and a freshly created test instance to represent "post model-level features." Before this commit, the filter view on PhillyTreeMap showed all the fields, but the filter view on the new test instance did not show species or missing tree photo fields. After this commit, both instances have all filter options.

---

Connects to https://github.com/OpenTreeMap/otm-ios/issues/346