### PR TITLE
Fix exporting of geometry fields for tree exports.

### DIFF
--- a/opentreemap/exporter/tests.py
+++ b/opentreemap/exporter/tests.py
@@ -139,16 +139,6 @@ class ExportTreeTaskTest(AsyncCSVTestCase):
 
     @media_dir
     @override_settings(FEATURE_BACKEND_FUNCTION=None)
-    def test_export_view_permission_failure(self):
-        request = make_request(user=self.unprivileged_user)
-        begin_ctx = begin_export(request, self.instance, 'tree')
-        check_ctx = check_export(request, self.instance, begin_ctx['job_id'])
-        self.assertEqual(check_ctx['status'], 'MODEL_PERMISSION_ERROR')
-        self.assertEqual(check_ctx['message'],
-                         'User has no permissions on this model')
-
-    @media_dir
-    @override_settings(FEATURE_BACKEND_FUNCTION=None)
     def test_psuedo_async_tree_export(self):
         self.assertPsuedoAsyncTaskWorks('tree', self.user, 'Diameter', '2.0',
                                         '.*tree_export(_\d+)?\.csv')


### PR DESCRIPTION
Use `Model.visible_fields(user)` instead field permissions in
exporter in order to get fields that are always writable.

This also gives us a bunch of fields we don't want, so I added some
more fields to the list to be omitted.

Connects to #2538
Connects to OpenTreeMap/otm-clients#341