### PR TITLE
Show polygon outline correctly after modify + save + modify

### DIFF
--- a/opentreemap/treemap/js/src/lib/inlineEditForm.js
+++ b/opentreemap/treemap/js/src/lib/inlineEditForm.js
@@ -27,7 +27,6 @@ exports.init = function(options) {
         validationFields = options.validationFields || section + ' [data-class="error"]',
         globalErrorSection = options.globalErrorSection,
         errorCallback = options.errorCallback || $.noop,
-        onSaveAfter = options.onSaveAfter || _.identity,
         dontUpdateOnSaveOk = options.dontUpdateOnSaveOk || false,
 
         showSavePending = function (saveIsPending) {
@@ -298,8 +297,6 @@ exports.init = function(options) {
             editForm.hideAndShowElements(fields, actions, action);
         }
     }
-
-    responseStream.onValue(onSaveAfter);
 
     globalCancelStream.onValue(showSavePending, false);
 

--- a/opentreemap/treemap/js/src/lib/plotMarker.js
+++ b/opentreemap/treemap/js/src/lib/plotMarker.js
@@ -171,25 +171,13 @@ function enableMoving(options) {
     } else {
         showMarker(true);
     }
-
-    // Normally we'd simply use:
-    // marker.dragging.enable/disable
-    //
-    // However, the dragging context gets lost
-    // somewhere between here and "disableMoving"
-    //
-    // Once lost we can't unbind the drag handler
-    // and we're stuck. The workaround is to
-    // hang on to the most recently added context
-    // and disable when needed
-    markerDraggingContext = marker.dragging;
-    markerDraggingContext.enable();
+    marker.dragging.enable();
 }
 
 // Prevent user from dragging the marker
 function disableMoving() {
-    if (markerDraggingContext) {
-        markerDraggingContext.disable();
+    if (marker.dragging) {
+        marker.dragging.disable();
     }
     if (map.hasLayer(marker)) {
         showViewMarker();

--- a/opentreemap/treemap/js/src/mapFeatureDetail.js
+++ b/opentreemap/treemap/js/src/mapFeatureDetail.js
@@ -90,7 +90,6 @@ function init() {
         shouldBeInEditModeStream: shouldBeInEditModeStream,
         errorCallback: alerts.errorCallback,
         onSaveBefore: function (data) { currentMover.onSaveBefore(data); },
-        onSaveAfter: function (data) { currentMover.onSaveAfter(data); },
         dontUpdateOnSaveOk: true
     });
 


### PR DESCRIPTION
* Remove marker dragging workaround now that we're on Leaflet 1.0
* Remove `InlineEditForm.onSaveAfter` in favor of the existing `InlineEditForm.saveOkStream`
* In `geometryMover.js` rename `onSaveAfter` methods to `onSaveOk`
* In `geometryMover.js` replace `onCancel` with `isCancel` argument to `disable` (this will be important when showing the area of a polygon as it is modified)
* Refactor `geometryMover.js` so that `onSaveOk` is called before `disable`, fixing #2975

Connects #2975