### PR TITLE
As GSI polygon is modified, display its area

### DIFF
--- a/opentreemap/treemap/js/src/lib/addResourceMode.js
+++ b/opentreemap/treemap/js/src/lib/addResourceMode.js
@@ -128,6 +128,7 @@ function init(options) {
     function initSteps(type) {
         plotMarker.hide();
         editor.removeAreaPolygon();
+        editor.areaStream.onValue($('.js-area'), 'html');
         hideSubquestions();
         var $type = _.isUndefined(type) ? $() : $resourceType.filter('[value="' + type + '"]');
         if ($type.length === 1) {

--- a/opentreemap/treemap/js/src/lib/geometryMover.js
+++ b/opentreemap/treemap/js/src/lib/geometryMover.js
@@ -146,7 +146,7 @@ exports.polygonMover = function (options) {
         },
 
         disable: function (options) {
-            this.editor.removeAreaPolygon();
+            this.editor.removeAreaPolygon(options.isCancel);
         },
 
         enable: function () {

--- a/opentreemap/treemap/js/src/lib/utility.js
+++ b/opentreemap/treemap/js/src/lib/utility.js
@@ -129,6 +129,15 @@ exports.offsetLatLngByMeters = function(latLng, dx, dy) {
     return { lat: newLat, lng: newLng };
 };
 
+// TODO: Respect instance units configuration.
+// https://github.com/OpenTreeMap/otm-addons/issues/326
+exports.getPolygonDisplayArea = function(poly) {
+    var latLngs = poly.getLatLngs()[0],
+        areaSqMeters = L.GeometryUtil.geodesicArea(latLngs),
+        areaSqFeet = areaSqMeters * 10.7639;
+    return areaSqFeet;
+};
+
 var endsWith = exports.endsWith = function(str, ends) {
     if (ends === '') return true;
     if (str === null || ends === null) return false;

--- a/opentreemap/treemap/js/src/mapFeatureDetail.js
+++ b/opentreemap/treemap/js/src/mapFeatureDetail.js
@@ -42,6 +42,7 @@ var dom = {
             edit: '#edit-location',
             cancel: '#cancel-edit-location',
         },
+        polygonAreaDisplay: '.js-area'
     };
 
 function init() {
@@ -168,6 +169,7 @@ function init() {
 
     if (window.otm.mapFeature.isEditablePolygon) {
         currentMover = geometryMover.polygonMover(moverOptions);
+        currentMover.editor.areaStream.onValue(showUpdatedArea);
     } else {
         plotMarker.init(mapManager.map);
         plotMarker.useTreeIcon(window.otm.mapFeature.useTreeIcon);
@@ -254,6 +256,10 @@ function handleFavoriteClick() {
             e.preventDefault();
         });
     }
+}
+
+function showUpdatedArea(area) {
+    $(dom.polygonAreaDisplay).html(area);
 }
 
 init();

--- a/opentreemap/treemap/lib/map_feature.py
+++ b/opentreemap/treemap/lib/map_feature.py
@@ -356,12 +356,15 @@ def context_dict_for_resource(request, resource, **kwargs):
 
     if isinstance(resource, PolygonalMapFeature):
         context['contained_plots'] = resource.contained_plots()
+        area = resource.calculate_area()
         __, display_area = get_display_value(instance,
                                              'greenInfrastructure', 'area',
-                                             resource.calculate_area())
+                                             area, digits=0)
         display_units = get_unit_abbreviation(
             get_units(instance, 'greenInfrastructure', 'area'))
-        context['area'] = '{} {}'.format(display_area, display_units)
+        context['area'] = area
+        context['display_area'] = display_area
+        context['area_units'] = display_units
 
     return context
 

--- a/opentreemap/treemap/templates/treemap/partials/map_add_resource.html
+++ b/opentreemap/treemap/templates/treemap/partials/map_add_resource.html
@@ -54,6 +54,9 @@
             <div class="add-step-content">
                 <div class="alert alert-info">Move the squares on the blue polygon to define the borders of your {{ term.Resource.singular.lower }}.
                 </div>
+                {% trans "Area" %}:&nbsp;
+                <span class="inline js-area"></span>
+                {{ polygon_area_units }}
             </div>
           {% endif %}
             {% include 'treemap/partials/step_controls.html' %}

--- a/opentreemap/treemap/templates/treemap/partials/resource_detail.html
+++ b/opentreemap/treemap/templates/treemap/partials/resource_detail.html
@@ -20,7 +20,12 @@
         {% if area %}
             <tr>
                 <td>{% trans "Area" %}</td>
-                <td>{{ area }}</td>
+                <td>
+                    <span class="js-area">
+                        {{ display_area }}
+                    </span>
+                    {{ area_units }}
+                </td>
             </tr>
         {% endif %}
 

--- a/opentreemap/treemap/views/misc.py
+++ b/opentreemap/treemap/views/misc.py
@@ -25,6 +25,7 @@ from treemap.plugin import get_viewable_instances_filter
 from treemap.lib.user import get_audits, get_audits_params
 from treemap.lib import COLOR_RE
 from treemap.lib.perms import map_feature_is_creatable
+from treemap.units import get_unit_abbreviation, get_units
 from treemap.util import leaf_models_of_class
 
 
@@ -83,6 +84,8 @@ def get_map_view_context(request, instance):
         ],
         'resource_classes': resource_classes,
         'only_one_resource_class': len(resource_classes) == 1,
+        'polygon_area_units': get_unit_abbreviation(
+            get_units(instance, 'greenInfrastructure', 'area')),
         'q': request.GET.get('q'),
     }
     add_map_info_to_context(context, instance)


### PR DESCRIPTION
* Use `leaflet-draw` "edit vertex" events for notifications when a polygon vertex is moved
* Add `getPolygonDisplayArea` utility function (previously in modeling code)
* `polylineEditor.js` exports `areaStream`, with current area as user modifies polygon
* `polylineEditor.js` retains `initialArea` so display can be restored if polygon editing is canceled
* Use `areaStream` to show area in "Resource Detail" table
* Use `areaStream` to show area in "Add Resource" sidebar

Testing:
* On resource detail page:
  * area should update as you edit the polygon
  * area should revert when you cancel editing or "Cancel Move Location"
  * area should not revert when you save
  * multiple edit/save cycles should work correctly
* When adding a resource, area should update as you edit the polygon

Connects #2905