### PR TITLE
Preserve location when going from plot detail to main map

### DIFF
--- a/opentreemap/treemap/js/src/lib/mapFeatureDelete.js
+++ b/opentreemap/treemap/js/src/lib/mapFeatureDelete.js
@@ -1,6 +1,9 @@
 "use strict";
 
 var $ = require('jquery'),
+    _ = require('lodash'),
+    U = require('treemap/lib/utility.js'),
+    MapManager = require('treemap/lib/MapManager.js'),
     toastr = require('toastr'),
     reverse = require('reverse'),
     config = require('treemap/lib/config.js');
@@ -18,7 +21,7 @@ exports.init = function(options) {
 
     $(dom.deleteConfirm).click(function () {
         var deleteUrl = options.deleteUrl || document.URL,
-            successUrl = options.successUrl || reverse.map(config.instance.url_name);
+            successUrl = options.successUrl || mapPageUrl();
         $(dom.spinner).show();
         $.ajax({
             url: deleteUrl,
@@ -39,3 +42,14 @@ exports.init = function(options) {
         $(dom.deleteConfirmationBox).show();
     });
 };
+
+function mapPageUrl() {
+    // Make a URL for the map page, zoomed to the current feature location
+    var location = window.otm.mapFeature.location.point,
+        latlng = U.webMercatorToLatLng(location.x, location.y),
+        zoom = (new MapManager()).ZOOM_PLOT,
+        zoomLatLng = _.extend({zoom: zoom}, latlng),
+        query = U.makeZoomLatLngQuery(zoomLatLng),
+        url = reverse.map(config.instance.url_name) + '?z=' + query;
+    return url;
+}

--- a/opentreemap/treemap/js/src/lib/urlState.js
+++ b/opentreemap/treemap/js/src/lib/urlState.js
@@ -11,6 +11,7 @@
 
 var _ = require('lodash'),
     Bacon = require('baconjs'),
+    U = require('treemap/lib/utility.js'),
     url = require('url'),
 
     modeNamesForUrl = [
@@ -63,11 +64,7 @@ function WindowApi() {
 var serializers = {
     zoomLatLng: function(state, query) {
         if (state.zoomLatLng) {
-            var zoom = state.zoomLatLng.zoom,
-                precision = Math.max(0, Math.ceil(Math.log(zoom) / Math.LN2)),
-                lat = state.zoomLatLng.lat.toFixed(precision),
-                lng = state.zoomLatLng.lng.toFixed(precision);
-            query.z = [zoom, lat, lng].join('/');
+            query.z = U.makeZoomLatLngQuery(state.zoomLatLng);
         }
     },
 

--- a/opentreemap/treemap/js/src/lib/utility.js
+++ b/opentreemap/treemap/js/src/lib/utility.js
@@ -129,6 +129,15 @@ exports.offsetLatLngByMeters = function(latLng, dx, dy) {
     return { lat: newLat, lng: newLng };
 };
 
+exports.makeZoomLatLngQuery = function(zoomLatLng) {
+    var zoom = zoomLatLng.zoom,
+        precision = Math.max(0, Math.ceil(Math.log(zoom) / Math.LN2)),
+        lat = zoomLatLng.lat.toFixed(precision),
+        lng = zoomLatLng.lng.toFixed(precision),
+        query = [zoom, lat, lng].join('/');
+    return query;
+};
+
 // TODO: Respect instance units configuration.
 // https://github.com/OpenTreeMap/otm-addons/issues/326
 exports.getPolygonDisplayArea = function(poly) {

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -9,6 +9,7 @@ import re
 from copy import copy
 
 from django.conf import settings
+from django.contrib.gis.geos import Point
 from django.core.mail import send_mail
 from django.core.exceptions import (ValidationError, MultipleObjectsReturned,
                                     ObjectDoesNotExist)
@@ -622,6 +623,12 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
     @classproperty
     def geom_field_name(cls):
         return "%s.geom" % to_object_name(cls.map_feature_type)
+
+    @property
+    def latlon(self):
+        latlon = Point(self.geom.x, self.geom.y, srid=3857)
+        latlon.transform(4326)
+        return latlon
 
     @property
     def is_plot(self):

--- a/opentreemap/treemap/templates/instance_base.html
+++ b/opentreemap/treemap/templates/instance_base.html
@@ -57,7 +57,8 @@ ga('set', 'page', pathname);
 {% endif %}
 
 <li class="explore-map {% block activeexplore %}active{% endblock %}">
-    <a href="{% url 'map' instance_url_name=request.instance.url_name %}" {% if embed %}target="_blank"{% endif %}>
+    <a href="{% url 'map' instance_url_name=request.instance.url_name %}{% block map_query %}{% endblock %}"
+       {% if embed %}target="_blank"{% endif %}>
     <span class="hidden-xs">{% trans "Explore Map" %}</span>
     <!-- We hide the logo on mobile, so we show the instance name instead of "Explore Map" to give context about which map you are on -->
     <span class="visible-xs-inline">{{ request.instance.name }}</span>

--- a/opentreemap/treemap/templates/treemap/map_feature_detail.html
+++ b/opentreemap/treemap/templates/treemap/map_feature_detail.html
@@ -19,6 +19,8 @@
     <meta property="og:site_name" content="{{ request.instance.name }}" />
 {% endblock head_extra %}
 
+{% block map_query %}{{ map_query }}{% endblock %}
+
 {% block subhead_exports %}
     {# Exporting is not available from the detail page #}
 {% endblock subhead_exports %}

--- a/opentreemap/treemap/views/map_feature.py
+++ b/opentreemap/treemap/views/map_feature.py
@@ -89,6 +89,8 @@ def map_feature_detail(request, instance, feature_id,
     if render:
         template = 'treemap/map_feature_detail.html'
         context['map_feature_partial'] = partial
+        latlon = context['feature'].latlon
+        context['map_query'] = '?z=%s/%s/%s' % (18, latlon.y, latlon.x)
         return render_to_response(template, context, RequestContext(request))
     else:
         return context

--- a/opentreemap/treemap/views/tree.py
+++ b/opentreemap/treemap/views/tree.py
@@ -131,8 +131,7 @@ def _single_result_context(instance, n_plots, n_resources, filter):
                 if qs.count() == 1:
                     break
         feature = qs[0]
-        latlon = feature.geom
-        latlon.transform(4326)
+        latlon = feature.latlon
         return {
             'id': feature.id,
             'lon': latlon.x,


### PR DESCRIPTION
Preserve location when clicking "Explore Map" from a detail page
* When loading a detail page, construct `map_query` string and append to "Explore Map" URL.

Preserve location after deleting a map feature
* Extract `U.makeZoomLatLngQuery` from `urlState.js`
* Use it in `mapFeatureDelete.js` to zoom map correctly after deleting a map feature

Connects #2934