### PR TITLE
Attempt to fix intermittent test failure

### DIFF
--- a/opentreemap/treemap/tests/ui/__init__.py
+++ b/opentreemap/treemap/tests/ui/__init__.py
@@ -100,7 +100,7 @@ class UITestCase(StaticLiveServerTestCase):
     def browse_to_instance_url(self, url, instance=None):
         instance = instance if instance is not None else self.instance
         self.driver.get('%s/%s/%s' % (self.live_server_url,
-                                      self.instance.url_name,
+                                      instance.url_name,
                                       url))
 
     def find_anchor_by_url(self, url):
@@ -161,6 +161,17 @@ class UITestCase(StaticLiveServerTestCase):
                 return True
 
         WebDriverWait(self.driver, timeout).until(is_invisible)
+        return element
+
+    def wait_for_input_value(self, element_or_selector, value, timeout=10):
+        """
+        Wait until 'element_or_selector' input has the specified value
+        """
+        element = self._get_element(element_or_selector)
+        WebDriverWait(self.driver, timeout).until(
+            # It seems wrong, but selenium fetches the value of an input
+            # element using get_attribute('value')
+            lambda driver: element.get_attribute('value') == value)
         return element
 
     def _get_element(self, element_or_selector):

--- a/opentreemap/treemap/tests/ui/uitest_map.py
+++ b/opentreemap/treemap/tests/ui/uitest_map.py
@@ -151,8 +151,9 @@ class MapTest(TreemapUITestCase):
         self.login_and_go_to_map_page()
         self.start_add_tree(20, 20)
 
-        diameter = self.driver.find_element_by_css_selector(
-            'input[data-class="diameter-input"]')
+        sel_diameter = 'input[data-class="diameter-input"]'
+        sel_circumference = 'input[data-class="circumference-input"]'
+        diameter = self.driver.find_element_by_css_selector(sel_diameter)
 
         diameter.send_keys('124.0')
 
@@ -185,11 +186,12 @@ class MapTest(TreemapUITestCase):
 
             self.click_when_visible('#quick-edit-button')
 
-            diameter = self.wait_until_visible(
-                'input[data-class="diameter-input"]')
+            diameter = self.wait_until_visible(sel_diameter)
 
             diameter.clear()
             diameter.send_keys('32.0')
+
+            self.wait_for_input_value(sel_circumference, '100.5')
 
             self.click('#save-details-button')
             self.wait_until_visible('#quick-edit-button')


### PR DESCRIPTION
The failure suggests that when typing "32" for diameter and hitting "Save", the new diameter is sometimes not saved. My only thought is that the "save" event is handled before the diameter calculator's JS code has finished updating everything. So, wait for the circumference value to be displayed before continuing.

Also fixed an unrelated oversight in `browse_to_instance_url`.

Connects #2982