### PR TITLE
django toolbar transitive dependency prevents build

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 django-debug-toolbar==1.5     # https://django-debug-toolbar.readthedocs.io/en/stable/changes.html
+setuptools==33.1.1
 django-extensions==1.7.4
 ipython==5.1.0
 ipdb==0.10.1


### PR DESCRIPTION
Commenting the django toolbar out of `dev-requirements.txt` for now.

--

Connects to OpenTreeMap/otm-cloud#346