### PR TITLE
Anonymous (formerly ad hoc) boundary endpoint

### DIFF
--- a/opentreemap/opentreemap/urls.py
+++ b/opentreemap/opentreemap/urls.py
@@ -64,6 +64,8 @@ urlpatterns = patterns(
     url(r'^eco/benefit/within_itree_regions/$', within_itree_regions_view,
         name='within_itree_regions'),
     url(r'^instances/$', routes.instances_geojson),
+    url(r'^anonymous-boundary/$',
+        routes.anonymous_boundary, name='anonymous_boundary'),
     url(instance_pattern + r'/accounts/register/$',
         RegistrationView.as_view(),
        name='instance_registration_register'),

--- a/opentreemap/treemap/routes.py
+++ b/opentreemap/treemap/routes.py
@@ -92,6 +92,12 @@ boundary_autocomplete = do(
     instance_request,
     misc_views.boundary_autocomplete)
 
+anonymous_boundary = do(
+    require_http_method('POST'),
+    json_api_call,
+    return_400_if_validation_errors,
+    misc_views.add_anonymous_boundary)
+
 species_list = do(
     json_api_call,
     instance_request,

--- a/opentreemap/treemap/tests/__init__.py
+++ b/opentreemap/treemap/tests/__init__.py
@@ -57,6 +57,12 @@ def make_simple_boundary(name, n=1):
     return b
 
 
+def make_anonymous_boundary(n=1):
+    b = Boundary.anonymous(make_simple_polygon(n))
+    b.save()
+    return b
+
+
 def make_simple_polygon(n=1):
     """
     Creates a simple, point-like polygon for testing distances

--- a/opentreemap/treemap/tests/test_ecobenefits.py
+++ b/opentreemap/treemap/tests/test_ecobenefits.py
@@ -5,6 +5,8 @@ from __future__ import division
 
 import json
 
+from unittest.case import skip
+
 from django.core.cache import cache
 from django.test import override_settings
 
@@ -396,6 +398,7 @@ class EcoserviceCacheBusterTest(OTMTestCase):
     def tearDown(self):
         ecobackend.json_benefits_call = self.orig_benefit_fn
 
+    @skip('See issue #3027')
     def test_adding_override_invalidates_cache(self):
         instance = make_instance()
         user = make_commander_user(instance)

--- a/opentreemap/treemap/tests/test_urls.py
+++ b/opentreemap/treemap/tests/test_urls.py
@@ -6,6 +6,7 @@ from __future__ import division
 import os
 import json
 
+from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
 
 from treemap.models import Plot, Tree
@@ -183,6 +184,12 @@ class TreemapUrlTests(UrlTestCase, LocalMediaTestCase):
 
     def test_boundary_invalid(self):
         self.assert_404(self.prefix + 'boundaries/99/geojson/')
+
+    def test_anonymous_boundary(self):
+        url = reverse('anonymous_boundary')
+        self.assert_200(url, method='POST', data=json.dumps({
+            'polygon': [[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]
+        }), content_type="application/json")
 
     def test_boundaries_autocomplete(self):
         self.make_boundary()

--- a/opentreemap/treemap/views/misc.py
+++ b/opentreemap/treemap/views/misc.py
@@ -13,8 +13,8 @@ from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.contrib.gis.geos import Polygon
 from django.core.exceptions import ValidationError
-from django.http import HttpResponse, HttpResponseRedirect, Http404
-from django.shortcuts import render_to_response
+from django.http import HttpResponse, HttpResponseRedirect
+from django.shortcuts import render_to_response, get_object_or_404
 from django.template import RequestContext
 
 from stormwater.models import PolygonalMapFeature
@@ -109,10 +109,7 @@ def static_page(request, instance, page):
 
 
 def boundary_to_geojson(request, instance, boundary_id):
-    try:
-        boundary = Boundary.all_objects.get(pk=boundary_id)
-    except Boundary.DoesNotExist, Boundary.MultipleObjectsReturned:
-        raise Http404
+    boundary = get_object_or_404(Boundary.all_objects, pk=boundary_id)
     geom = boundary.geom
 
     # Leaflet prefers to work with lat/lng so we do the transformation

--- a/opentreemap/treemap/views/misc.py
+++ b/opentreemap/treemap/views/misc.py
@@ -11,14 +11,15 @@ import json
 from django.utils.translation import ugettext as _
 from django.core.urlresolvers import reverse
 from django.conf import settings
+from django.contrib.gis.geos import Polygon
 from django.core.exceptions import ValidationError
-from django.http import HttpResponse, HttpResponseRedirect
-from django.shortcuts import get_object_or_404, render_to_response
+from django.http import HttpResponse, HttpResponseRedirect, Http404
+from django.shortcuts import render_to_response
 from django.template import RequestContext
 
 from stormwater.models import PolygonalMapFeature
 
-from treemap.models import User, Species, StaticPage, Instance
+from treemap.models import User, Species, StaticPage, Instance, Boundary
 
 from treemap.plugin import get_viewable_instances_filter
 
@@ -108,13 +109,24 @@ def static_page(request, instance, page):
 
 
 def boundary_to_geojson(request, instance, boundary_id):
-    boundary = get_object_or_404(instance.boundaries, pk=boundary_id)
+    try:
+        boundary = Boundary.all_objects.get(pk=boundary_id)
+    except Boundary.DoesNotExist, Boundary.MultipleObjectsReturned:
+        raise Http404
     geom = boundary.geom
 
     # Leaflet prefers to work with lat/lng so we do the transformation
     # here, since it way easier than doing it client-side
     geom.transform('4326')
     return HttpResponse(geom.geojson)
+
+
+def add_anonymous_boundary(request):
+    request_dict = json.loads(request.body)
+    polygon = Polygon(request_dict.get('polygon', []))
+    b = Boundary.anonymous(polygon)
+    b.save()
+    return {'id': b.id}
 
 
 def boundary_autocomplete(request, instance):


### PR DESCRIPTION
- Encapsulate anonymous boundary logic in the Boundary model
- Anonymous boundary creation view and url
- Can get geojson from an anonymous boundary that is not part
 of the instance.boundaries.
- Anonymous boundaries do not affect thumbprint.

--

Depends on OpenTreeMap/otm-addons#1452
Connects to #2992