### PR TITLE
Implement protected UDF definitions and choices

### DIFF
--- a/opentreemap/treemap/lib/udf.py
+++ b/opentreemap/treemap/lib/udf.py
@@ -70,6 +70,8 @@ def _parse_params(params):
 
     if udf_type in ('choice', 'multichoice'):
         datatype['choices'] = params.get('udf.choices', None)
+        datatype['protected_choices'] = \
+            params.get('udf.protected_choices', None)
 
     datatype = json.dumps(datatype)
 

--- a/opentreemap/treemap/migrations/0044_userdefinedfielddefinition_is_protected.py
+++ b/opentreemap/treemap/migrations/0044_userdefinedfielddefinition_is_protected.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0043_works_management_access'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='userdefinedfielddefinition',
+            name='is_protected',
+            field=models.NullBooleanField(default=False),
+        ),
+    ]

--- a/opentreemap/treemap/templatetags/form_extras.py
+++ b/opentreemap/treemap/templatetags/form_extras.py
@@ -247,14 +247,11 @@ def _is_udf(model, udf_field_name):
             udf_field_name in model.udf_field_names)
 
 
-def _udf_dict(model, field_name):
-    matches = [field.datatype_dict
-               for field in model.get_user_defined_fields()
-               if field.name == field_name.replace('udf:', '')]
-    if matches:
-        return matches[0]
-    else:
-        raise Exception("Datatype for field %s not found" % field_name)
+def _get_udf(model, field_name):
+    for field in model.get_user_defined_fields():
+        if field.name == field_name.replace('udf:', ''):
+            return field
+    raise Exception("UDF '%s' not defined on model" % field_name)
 
 
 # Should a blank choice be added for choice and multichoice fields?
@@ -284,12 +281,13 @@ def field_type_label_choices(model, field_name, label=None,
         if choices and field.null:
             choices = [{'value': '', 'display_value': ''}] + choices
     else:
-        udf_dict = _udf_dict(model, field_name)
+        udf = _get_udf(model, field_name)
+        udf_dict = udf.datatype_dict
         field_type = udf_dict['type']
         label = label if label else udf_field_name
         if 'choices' in udf_dict:
             choices = [{'value': value, 'display_value': value}
-                       for value in udf_dict['choices']]
+                       for value in udf.all_choices]
             if add_blank == ADD_BLANK_ALWAYS or (
                 add_blank == ADD_BLANK_IF_CHOICE_FIELD
                     and field_type == 'choice'

--- a/opentreemap/treemap/tests/test_udfs.py
+++ b/opentreemap/treemap/tests/test_udfs.py
@@ -1306,6 +1306,61 @@ class UdfDeleteTest(OTMTestCase):
         self.assertEquals(1, len(updated_instance.mobile_api_fields))
 
 
+class ProtectedUDFTestCase(OTMTestCase):
+    def setUp(self):
+        User._system_user.save_base()
+
+        self.instance = make_instance()
+        create_stewardship_udfs(self.instance)
+        self.user = make_commander_user(self.instance)
+
+        set_write_permissions(self.instance, self.user,
+                              'Plot', ['udf:Test choice'])
+
+        self.udf = UserDefinedFieldDefinition.objects.create(
+            instance=self.instance,
+            model_type='Plot',
+            datatype=json.dumps({'type': 'choice',
+                                 'protected_choices': ['a'],
+                                 'choices': ['b', 'c']}),
+            iscollection=False,
+            is_protected=True,
+            name='Test choice')
+
+        p = Point(0, 0)
+        self.plot = Plot(geom=p, instance=self.instance)
+        self.plot.save_with_user(self.user)
+
+    def test_cannot_delete_protected_udf(self):
+        with self.assertRaises(AuthorizeException):
+            self.udf.delete()
+
+    def test_can_pick_protected_udf_choice(self):
+        # Assert that ValidationError is not raised
+        self.plot.udfs['Test choice'] = 'a'
+        self.plot.save_with_user(self.user)
+
+    def test_cannot_modify_protected_udf_choice(self):
+        with self.assertRaises(ValidationError):
+            self.udf.add_choice('a')
+        with self.assertRaises(ValidationError):
+            self.udf.delete_choice('a')
+        with self.assertRaises(ValidationError):
+            self.udf.update_choice('a', 'z')
+
+    def test_protected_udf_choice_order(self):
+        self.assertEqual(['a', 'b', 'c'], self.udf.all_choices)
+
+    def test_invalid_udf_definition(self):
+        # Ensure that UDFs cannot be created with *only* protected choices.
+        # The "choices" key must always exist.
+        body = {'udf.name': 'cool udf',
+                'udf.model': 'Plot',
+                'udf.type': 'choice',
+                'udf.protected_choices': ['a']}
+        self.assertRaises(ValidationError, udf_create, body, self.instance)
+
+
 class UdfCRUTestCase(OTMTestCase):
     def setUp(self):
         User._system_user.save_base()

--- a/opentreemap/treemap/udf.py
+++ b/opentreemap/treemap/udf.py
@@ -402,11 +402,9 @@ class UserDefinedFieldDefinition(models.Model):
                     _("Can't modify protected choice '%(choice)s'") % {
                         'choice': old_choice_value}]})
 
-        if new_choice_value:
-            choices = [c if c != old_choice_value else new_choice_value
-                       for c in choices]
-        else:
-            choices = [c for c in choices if c != old_choice_value]
+        choices = self._list_replace_or_remove(choices,
+                                               old_choice_value,
+                                               new_choice_value)
 
         datatype['choices'] = choices
         return datatype

--- a/opentreemap/treemap/udf.py
+++ b/opentreemap/treemap/udf.py
@@ -313,6 +313,11 @@ class UserDefinedFieldDefinition(models.Model):
     required:
 
     'choices' - An array of choice options
+
+    Specify choices that may not be modified with the 'protected_choices'
+    key (optional):
+
+    'protected_choices' - An array of choice options
     """
     datatype = models.TextField()
 
@@ -326,12 +331,36 @@ class UserDefinedFieldDefinition(models.Model):
     iscollection = models.BooleanField()
 
     """
+    Protected UDFs cannot be deleted.
+    """
+    # TODO: Change to BooleanField after production deployment
+    is_protected = models.NullBooleanField(default=False)
+
+    """
     Name of the UDFD
     """
     name = models.CharField(max_length=255)
 
     class Meta:
         unique_together = ('instance', 'model_type', 'name')
+
+    @property
+    def all_choices(self):
+        if self.iscollection:
+            raise ValueError(_('Property "all_choices" is invalid '
+                               'for collection UDFs'))
+        return UserDefinedFieldDefinition._all_choices(self.datatype_dict)
+
+    @classmethod
+    def _all_choices(cls, datatype):
+        if datatype['type'] in ('choice', 'multichoice'):
+            # There are situations where "choices" and "protected_choices"
+            # may exist, but the values are None. Default to an empty list
+            # so we can concatenate them.
+            choices = datatype['choices'] or []
+            protected_choices = datatype.get('protected_choices', None) or []
+            return protected_choices + choices
+        return None
 
     def __unicode__(self):
         return ('%s.%s%s' %
@@ -358,12 +387,21 @@ class UserDefinedFieldDefinition(models.Model):
                 {'datatype': [_("Can't change choices "
                                 "on a non-choice field")]})
 
-        if old_choice_value not in datatype['choices']:
+        choices = datatype['choices']
+        protected_choices = datatype.get('protected_choices', None) or []
+        all_choices = UserDefinedFieldDefinition._all_choices(datatype)
+
+        if old_choice_value not in all_choices:
             raise ValidationError(
                 {'datatype': [_("Choice '%(choice)s' not found") % {
                     'choice': old_choice_value}]})
 
-        choices = datatype['choices']
+        if old_choice_value in protected_choices:
+            raise ValidationError({
+                'datatype': [
+                    _("Can't modify protected choice '%(choice)s'") % {
+                        'choice': old_choice_value}]})
+
         if new_choice_value:
             choices = [c if c != old_choice_value else new_choice_value
                        for c in choices]
@@ -453,14 +491,22 @@ class UserDefinedFieldDefinition(models.Model):
              for choice in l])
         return new_l or None
 
-    def add_choice(self, new_choice_value, name=None):
+    def add_choice(self, new_choice_value, name=None, is_protected=False):
+        choices_key = 'protected_choices' if is_protected else 'choices'
+
+        def _list_append(datatype, key, value):
+            lst = datatype.get(key, None) or []
+            lst.append(value)
+            datatype[key] = lst
+
         if self.iscollection:
             if name is None:
                 raise ValidationError({
                     'name': [_('Name is required for collection fields')]})
 
             datatypes = {d['name']: d for d in self.datatype_dict}
-            datatypes[name]['choices'].append(new_choice_value)
+            datatype = datatypes[name]
+            _list_append(datatype, choices_key, new_choice_value)
 
             self.datatype = json.dumps(datatypes.values())
             self.save()
@@ -471,7 +517,7 @@ class UserDefinedFieldDefinition(models.Model):
                         'Name is allowed only for collection fields')]})
 
             datatype = self.datatype_dict
-            datatype['choices'].append(new_choice_value)
+            _list_append(datatype, choices_key, new_choice_value)
 
             self.datatype = json.dumps(datatype)
             self.save()
@@ -635,6 +681,8 @@ class UserDefinedFieldDefinition(models.Model):
             if choices is None:
                 raise ValidationError(_('Missing choices key'))
 
+            choices = UserDefinedFieldDefinition._all_choices(datatype)
+
             for choice in choices:
                 if not isinstance(choice, basestring):
                     raise ValidationError(_('Choice must be a string'))
@@ -664,6 +712,10 @@ class UserDefinedFieldDefinition(models.Model):
     @transaction.atomic
     def delete(self, *args, **kwargs):
         save_instance = False
+
+        if self.is_protected:
+            raise AuthorizeException("Cannot delete protected UDF '%s'"
+                                     % (self.name))
 
         if self.iscollection:
             UserDefinedCollectionValue.objects.filter(field_definition=self)\
@@ -856,12 +908,14 @@ class UserDefinedFieldDefinition(models.Model):
             return valid_date
 
         elif 'choices' in datatype_dict:
+            choices = UserDefinedFieldDefinition._all_choices(datatype_dict)
+
             def _validate(val):
-                if val not in datatype_dict['choices']:
+                if val not in choices:
                     raise ValidationError(
                         _('Invalid choice (%(given)s). Expecting %(allowed)s')
                         % {'given': val,
-                           'allowed': ', '.join(datatype_dict['choices'])})
+                           'allowed': ', '.join(choices)})
 
             if datatype == 'choice':
                 _validate(value)

--- a/opentreemap/works_management/models.py
+++ b/opentreemap/works_management/models.py
@@ -69,6 +69,7 @@ class Task(UDFModel, Auditable):
                     'Plant Tree',
                     'Remove Tree',
                 ],
+                'choices': [],
             }
         },
     }


### PR DESCRIPTION
## Overview

Adds a new field `is_protected` to the `UserDefinedFieldDefinition` Model which prevents anyone from deleting the UDF. A new property has also been added to the "choice" UDF called `protected_choices` which prevents renaming and deletion of the UDF choice.

The syntax implemented is based on feedback from #3022.

Connects #2996

## Notes

For this iteration, I decided to disable renaming and deleting protected UDFs & choices for **everyone**. In the future, it might make sense to waive this restriction for admins and superusers.

This *should* work out of the box with collection UDFs (all unit tests pass) but I have not created unit test cases specifically to verify this.

## Testing Instructions

* Run migrations
* Execute UDF test suite

```
./scripts/manage.sh test treemap.tests.test_udfs
```

* Create a protected UDF choice

```
> ./scripts/manage.sh shell
from treemap.udf import UserDefinedFieldDefinition
udf = UserDefinedFieldDefinition.objects.filter(id=366)[0] # PhillyTreeMap "Tree Condition" UDF
udf.add_choice('Protected Choice', is_protected=True)
```

* Verify that protected UDF choice is visible and editable on plot detail page
* Verify that UDF search works with protected UDF choice