### PR TITLE
Fix polygon area calculation

### DIFF
--- a/opentreemap/treemap/js/src/lib/utility.js
+++ b/opentreemap/treemap/js/src/lib/utility.js
@@ -141,8 +141,20 @@ exports.makeZoomLatLngQuery = function(zoomLatLng) {
 // TODO: Respect instance units configuration.
 // https://github.com/OpenTreeMap/otm-addons/issues/326
 exports.getPolygonDisplayArea = function(poly) {
-    var latLngs = poly.getLatLngs()[0],
-        areaSqMeters = L.GeometryUtil.geodesicArea(latLngs),
+    function totalAreaInMeters(collection) {
+        if (_.isArray(collection[0])) {
+            return _.chain(collection)
+                    .map(totalAreaInMeters)
+                    .reduce(function(sum, num) {
+                        return sum + num;
+                    })
+                    .value();
+        } else {
+            return L.GeometryUtil.geodesicArea(collection);
+        }
+    }
+
+    var areaSqMeters = totalAreaInMeters(poly.getLatLngs()),
         areaSqFeet = areaSqMeters * 10.7639;
     return areaSqFeet;
 };


### PR DESCRIPTION
The `getPolygonDisplayArea` function began returning zero when passed the results of calling `getLatLngs` on a boundary polygon. The `getLatLngs` method was producing a doubly-nested array and the `geodesicArea` function only works on a 1-dimensional array. I fixed `getPolygonDisplayArea` by making it recursively descend through an arbitrary number of nested arrays and sum the results of calling `geodesicArea` on any "leaf" array it finds.

---

##### Testing

- Selecting a modeling distribution area created by loading a boundary should show a popup with the correctly calculated area.
- The area should still be correctly calculated when editing a GSI polygon.

I tested the modeling case on PhillyTreeMap by selecting the city boundary which reports 3,819,786,060 sq/ft

<img width="351" alt="screen shot 2017-03-07 at 11 32 21 pm" src="https://cloud.githubusercontent.com/assets/17363/23692846/6da65904-038e-11e7-8911-840c3f10c3e4.png">

Wikipedia says that the area of Phildadelphia is 141.6 sq miles, which is 3.94758e+9 square feet.

---

Connects to https://github.com/OpenTreeMap/otm-modeling/issues/146