### PR TITLE
Mode change cleanup

### DIFF
--- a/opentreemap/treemap/js/src/lib/plotMarker.js
+++ b/opentreemap/treemap/js/src/lib/plotMarker.js
@@ -13,7 +13,6 @@ var $ = require('jquery'),
 
 var marker,
     shouldUseTreeIcon,
-    markerDraggingContext,
     firstMoveBus = new Bacon.Bus(),
     moveBus = new Bacon.Bus(),
     markerWasMoved,
@@ -176,7 +175,7 @@ function enableMoving(options) {
 
 // Prevent user from dragging the marker
 function disableMoving() {
-    if (marker.dragging) {
+    if (marker && marker.dragging) {
         marker.dragging.disable();
     }
     if (map.hasLayer(marker)) {

--- a/opentreemap/treemap/js/src/mapPage/addResourceMode.js
+++ b/opentreemap/treemap/js/src/mapPage/addResourceMode.js
@@ -2,10 +2,10 @@
 
 var $ = require('jquery'),
     _ = require('lodash'),
-    L = require('leaflet'),
     U = require('treemap/lib/utility.js'),
     addMapFeature = require('treemap/mapPage/addMapFeature.js'),
     polylineEditor = require('treemap/lib/polylineEditor.js'),
+    plotMarker = require('treemap/lib/plotMarker.js'),
     config = require('treemap/lib/config.js'),
     reverse = require('reverse');
 
@@ -25,12 +25,8 @@ function init(options) {
         $resourceType = U.$find('input[name="addResourceType"]', $sidebar),
         $form = U.$find(options.formSelector, $sidebar),
         $summaryHead = U.$find('.summaryHead', $sidebar),
-        $summarySubhead = U.$find('.summarySubhead', $sidebar),
         $continueLink = $('#addresource-viewdetails'),
-        mapManager = options.mapManager,
-        plotMarker = options.plotMarker,
         areaFieldIdentifier,
-        hideSearch,
         editor = polylineEditor(options),
         onlyOneResourceType = $resourceType.length === 1;
 
@@ -44,14 +40,11 @@ function init(options) {
         plotMarker.useTreeIcon(false);
         initSteps(type);
         $('body').addClass('add-feature');
-        hideSearch = $('body').hasClass('hide-search');
     };
 
     deactivateMode = function () {
         editor.removeAreaPolygon();
         manager.deactivate();
-        $('body').removeClass('add-feature');
-        $('body').toggleClass('hide-search', hideSearch);
     };
 
     function onResourceTypeChosen() {
@@ -198,8 +191,8 @@ function init(options) {
     }
 }
 
-function activate(type) {
-    activateMode(type);
+function activate(options) {
+    activateMode(options.mapFeatureType);
 }
 
 function deactivate() {

--- a/opentreemap/treemap/js/src/mapPage/addTreeMode.js
+++ b/opentreemap/treemap/js/src/mapPage/addTreeMode.js
@@ -5,6 +5,7 @@ var $ = require('jquery'),
     U = require('treemap/lib/utility.js'),
     addMapFeature = require('treemap/mapPage/addMapFeature.js'),
     otmTypeahead = require('treemap/lib/otmTypeahead.js'),
+    plotMarker = require('treemap/lib/plotMarker.js'),
     diameterCalculator = require('treemap/lib/diameterCalculator.js');
 
 var activateMode = _.identity,
@@ -14,18 +15,15 @@ var activateMode = _.identity,
     STEP_FINAL = 2;
 
 function init(options) {
-    var plotMarker = options.plotMarker,
-        $sidebar = $(options.sidebar),
+    var $sidebar = $(options.sidebar),
         $speciesTypeahead = U.$find('#add-tree-species-typeahead', $sidebar),
-        $speciesInput = U.$find('[data-typeahead-input="tree.species"]', $sidebar),
         $summaryHead = U.$find('.summaryHead', $sidebar),
         $summarySubhead = U.$find('.summarySubhead', $sidebar),
         typeahead = otmTypeahead.create(options.typeahead),
         clearEditControls = function() {
             typeahead.clear();
         },
-        manager = addMapFeature.init(_.extend({clearEditControls: clearEditControls}, options)),
-        hideSearch;
+        manager = addMapFeature.init(_.extend({clearEditControls: clearEditControls}, options));
 
     activateMode = function() {
         manager.activate();
@@ -33,14 +31,11 @@ function init(options) {
         plotMarker.useTreeIcon(true);
         plotMarker.enablePlacing();
         $('body').addClass('add-feature');
-        hideSearch = $('body').hasClass('hide-search');
     };
 
     deactivateMode = function() {
         typeahead.clear();
         manager.deactivate();
-        $('body').removeClass('add-feature');
-        $('body').toggleClass('hide-search', hideSearch);
     };
 
     diameterCalculator({ formSelector: options.formSelector,

--- a/opentreemap/treemap/js/src/mapPage/drawAreaMode.js
+++ b/opentreemap/treemap/js/src/mapPage/drawAreaMode.js
@@ -2,8 +2,7 @@
 
 var $ = require('jquery'),
     L = require('leaflet'),
-    locationSearchUI = require('treemap/mapPage/locationSearchUI.js'),
-    plotMarker = require('treemap/lib/plotMarker.js');
+    locationSearchUI = require('treemap/mapPage/locationSearchUI.js');
 
 var map,
     modes,
@@ -29,7 +28,6 @@ function init(options) {
 }
 
 function activate() {
-    plotMarker.hide();
     locationSearchUI.showDrawAreaControls();
     setTooltips(customTooltips);
     drawer.enable();
@@ -41,7 +39,7 @@ function activate() {
 function onDrawComplete(e) {
     locationSearchUI.setPolygon(e.layer);
     polygonComplete = true;
-    modes.activateBrowseTreesMode(true);
+    modes.activateBrowseTreesMode();
 }
 
 function onKeyDown(e) {
@@ -51,7 +49,7 @@ function onKeyDown(e) {
 }
 
 function cancelDraw() {
-    modes.activateBrowseTreesMode(true);
+    modes.activateBrowseTreesMode();
 }
 
 function deactivate() {

--- a/opentreemap/treemap/js/src/mapPage/editAreaMode.js
+++ b/opentreemap/treemap/js/src/mapPage/editAreaMode.js
@@ -2,8 +2,7 @@
 
 var $ = require('jquery'),
     L = require('leaflet'),
-    locationSearchUI = require('treemap/mapPage/locationSearchUI.js'),
-    plotMarker = require('treemap/lib/plotMarker.js');
+    locationSearchUI = require('treemap/mapPage/locationSearchUI.js');
 
 var map,
     modes,
@@ -33,7 +32,6 @@ function init(options) {
 }
 
 function activate() {
-    plotMarker.hide();
     setTooltips(customTooltip);
     locationSearchUI.showEditAreaControls();
 
@@ -55,11 +53,11 @@ function onKeyDown(e) {
 function saveArea() {
     editor.save();
     editsSaved = true;
-    modes.activateBrowseTreesMode(true);
+    modes.activateBrowseTreesMode();
 }
 
 function cancelEditing() {
-    modes.activateBrowseTreesMode(true);
+    modes.activateBrowseTreesMode();
 }
 
 function deactivate() {

--- a/opentreemap/treemap/js/src/mapPage/editTreeDetailsMode.js
+++ b/opentreemap/treemap/js/src/mapPage/editTreeDetailsMode.js
@@ -2,23 +2,24 @@
 
 var $ = require('jquery'),
     _ = require('lodash'),
-    L = require('leaflet'),
     toastr = require('toastr'),
     otmTypeahead = require('treemap/lib/otmTypeahead.js'),
     geometryMover = require('treemap/lib/geometryMover.js'),
     diameterCalculator = require('treemap/lib/diameterCalculator.js'),
+    plotMarker = require('treemap/lib/plotMarker.js'),
     reverseGeocodeStreamAndUpdateAddressesOnForm =
         require('treemap/lib/reverseGeocodeStreamAndUpdateAddressesOnForm.js');
 
 var dom = {
     form: '#details-form',
-    ecoBenefits: '.benefit-values'
+    ecoBenefits: '.benefit-values',
+    mapFeatureAccordion: '#map-feature-accordion',
+    treeDetailAccordion: '#tree-detail'
 };
 
 var mapManager,
     inlineEditForm,
     typeaheads,
-    plotMarker,
     calculator,
     currentPlotMover;
 
@@ -26,7 +27,6 @@ function init(options) {
     mapManager = options.mapManager;
     inlineEditForm = options.inlineEditForm;
     typeaheads = options.typeaheads;
-    plotMarker = options.plotMarker;
 
     inlineEditForm.inEditModeProperty.onValue(function (inEditMode) {
         $(dom.ecoBenefits).toggle(!inEditMode);
@@ -78,11 +78,21 @@ function activate() {
     });
 }
 
-function deactivate() {
+function deactivate(options) {
     calculator.destroy();
     inlineEditForm.cancel();
-
     mapManager.map.off('click', onClick);
+    var keepSelection = options && options.keepSelection;
+    if (!keepSelection) {
+        clearSelection();
+    }
+}
+
+function clearSelection() {
+    $(dom.mapFeatureAccordion).html('');
+    $(dom.treeDetailAccordion).collapse('hide');
+    $('body').removeClass('feature-selected');  // for mobile
+    plotMarker.hide();
 }
 
 function onSaveBefore(data) {

--- a/opentreemap/treemap/js/src/mapPage/modes.js
+++ b/opentreemap/treemap/js/src/mapPage/modes.js
@@ -1,15 +1,19 @@
 "use strict";
 
-// The main "map" page has several modes -- browse trees, add a tree, and edit
-// tree details. Each mode has a div in the sidebar to show its UI and a JS
+// The main "map" page has several modes -- e.g. browse trees, add a tree, and
+// edit tree details. Each mode has a div in the sidebar to show its UI and a JS
 // module to handle UI events. This module initializes the mode modules and
 // orchestrates switching between modes.
+
+// Mode changes are initiated by calling one of the exported activation functions
+// (e.g. activateAddTreeMode, activateBrowseTreesMode). Note that calls to these
+// functions are not isolated in a single controller module due to the differing
+// requirements of the code that calls them.
 
 var $                   = require('jquery'),
     _                   = require('lodash'),
     reverse             = require('reverse'),
     config              = require('treemap/lib/config.js'),
-    U                   = require('treemap/lib/utility.js'),
     browseTreesMode     = require('treemap/mapPage/browseTreesMode.js'),
     drawAreaMode        = require('treemap/mapPage/drawAreaMode.js'),
     editAreaMode        = require('treemap/mapPage/editAreaMode.js'),
@@ -20,74 +24,76 @@ var $                   = require('jquery'),
     urlState            = require('treemap/lib/urlState.js'),
     plotMarker          = require('treemap/lib/plotMarker.js'),
     statePrompter       = require('treemap/lib/statePrompter.js'),
-    stickyTitles        = require('treemap/lib/stickyTitles.js'),
+    stickyTitles        = require('treemap/lib/stickyTitles.js');
+
+var sidebarBrowseTrees = '#sidebar-browse-trees',
+    sidebarAddTree     = '#sidebar-add-tree',
+    sidebarAddResource = '#sidebar-add-resource',
+    map,
     prompter,
-    currentMode, currentType;
+    currentMode,
+    currentMapFeatureType;
 
-var sidebarBrowseTrees          = '#sidebar-browse-trees',
-    sidebarAddTree              = '#sidebar-add-tree',
-    sidebarAddResource          = '#sidebar-add-resource',
-    $treeDetailAccordionSection = U.$find('#tree-detail'),
-    $fullDetailsButton          = U.$find('#full-details-button'),
-    $treeDetailButtonGroup      = U.$find('#map-plot-details-button'),
-    $exploreMapHeaderLink       = U.$find('.navbar li.explore-map'),
-    $addFeatureHeaderLink       = U.$find('.navbar li[data-feature=add_plot]');
+function activateBrowseTreesMode(options) {
+    activateMode(browseTreesMode, sidebarBrowseTrees, options);
+}
+function activateDrawAreaMode(options) {
+    activateMode(drawAreaMode, sidebarBrowseTrees, options);
+}
+function activateEditAreaMode(options) {
+    activateMode(editAreaMode, sidebarBrowseTrees, options);
+}
+function activateAddTreeMode(options) {
+    activateMode(addTreeMode, sidebarAddTree, options);
+}
+function activateEditTreeDetailsMode(options) {
+    activateMode(editTreeDetailsMode, sidebarBrowseTrees, options);
+}
+function activateAddResourceMode(options) {
+    activateMode(addResourceMode, sidebarAddResource, options);
+}
 
-function activateMode(mode, sidebar, safeTransition, type) {
+// All changes between modes use this function.
+// It deactivates the current mode, activates the new mode, displays the
+// appropriate sidebar, and manages "are you sure you want to exit" queries.
 
-    // each mode activator takes an argument that determines
-    // whether or not to lock the prompter, or in other words,
-    // whether or not activateMode should prompt the user before
-    // changing modes.
-    if (safeTransition === true) {
+function activateMode(mode, sidebar, options) {
+
+    if (options && options.skipPrompt) {
+        // Caller knows we don't need an "are you sure" query
+        // (e.g. when switching from edit trees mode to browse trees mode)
         prompter.unlock();
     }
-    if ((mode !== currentMode || type !== currentType) &&
+
+    var mapFeatureType = options && options.mapFeatureType;
+    if ((mode !== currentMode || mapFeatureType !== currentMapFeatureType) &&
         prompter.canProceed()) {
+
         if (currentMode && currentMode.deactivate) {
-            currentMode.deactivate();
+            currentMode.deactivate(options);
         }
+        if (mode.activate) {
+            mode.activate(options);
+        }
+        currentMode = mode;
+        currentMapFeatureType = mapFeatureType;
+
         $(sidebar).siblings().hide();
         $(sidebar).show();
-        if (mode.activate) {
-            mode.activate(type);
+
+        if (mode.lockOnActivate === true) {
+            prompter.lock();  // Ask "are you sure" when leaving mode
+        } else {
+            prompter.unlock();  // Don't ask "are you sure" when leaving mode
         }
 
-        // lockOnActivate will specify whether to leave the
-        // prompter in a locked state, which causes a
-        // prompt on mode changes and page navigation.
-        if (mode.lockOnActivate === true) {
-            prompter.lock();
-        } else {
-            prompter.unlock();
-        }
+        // On mobile we hide the search bar in some modes
         if ('hideSearch' in mode) {
             $('body').toggleClass('hide-search', mode.hideSearch);
         }
-        urlState.setModeName(mode.name);
-        urlState.setModeType(type);
-        currentMode = mode;
-        currentType = type;
+        // On mobile some transitions change the size of the map
+        map.invalidateSize();
     }
-}
-
-function activateBrowseTreesMode(safeTransition) {
-    activateMode(browseTreesMode, sidebarBrowseTrees, safeTransition);
-}
-function activateDrawAreaMode(safeTransition) {
-    activateMode(drawAreaMode, sidebarBrowseTrees, safeTransition);
-}
-function activateEditAreaMode(safeTransition) {
-    activateMode(editAreaMode, sidebarBrowseTrees, safeTransition);
-}
-function activateAddTreeMode(safeTransition) {
-    activateMode(addTreeMode, sidebarAddTree, safeTransition);
-}
-function activateEditTreeDetailsMode(safeTransition) {
-    activateMode(editTreeDetailsMode, sidebarBrowseTrees, safeTransition);
-}
-function activateAddResourceMode(safeTransition, type) {
-    activateMode(addResourceMode, sidebarAddResource, safeTransition, type);
 }
 
 function inBrowseTreesMode() { return currentMode === browseTreesMode; }
@@ -96,6 +102,8 @@ function inEditTreeMode()    { return currentMode === editTreeDetailsMode; }
 function inAddResourceMode() { return currentMode === addResourceMode; }
 
 function init(mapManager, triggerSearchBus, embed, completedSearchStream) {
+    map = mapManager.map;
+
     // browseTreesMode and editTreeDetailsMode share an inlineEditForm,
     // so initialize it here.
     var form = inlineEditForm.init({
@@ -118,25 +126,24 @@ function init(mapManager, triggerSearchBus, embed, completedSearchStream) {
     form.inEditModeProperty.onValue(function (inEditMode) {
         // Form is changing to edit mode or display mode
         if (inEditMode) {
-            activateEditTreeDetailsMode(true);
+            activateEditTreeDetailsMode({keepSelection: true});
         } else {
-            activateBrowseTreesMode(true);
+            activateBrowseTreesMode({
+                keepSelection: true,
+                skipPrompt: true
+            });
         }
     });
     form.saveOkStream.onValue(triggerSearchBus.push);
 
-    plotMarker.init(mapManager.map);
+    plotMarker.init(map);
 
     browseTreesMode.init({
-        map: mapManager.map,
+        map: map,
         embed: embed,
         completedSearchStream: completedSearchStream,
         inMyMode: inBrowseTreesMode,
-        $treeDetailAccordionSection: $treeDetailAccordionSection,
-        $fullDetailsButton: $fullDetailsButton,
-        inlineEditForm: form,
-        plotMarker: plotMarker,
-        $buttonGroup: $treeDetailButtonGroup
+        inlineEditForm: form
     });
 
     // As discussed in http://stackoverflow.com/a/21424911, using "this" could
@@ -145,25 +152,22 @@ function init(mapManager, triggerSearchBus, embed, completedSearchStream) {
     /*jshint validthis: true */
 
     drawAreaMode.init({
-        map: mapManager.map,
+        map: map,
         modes: this,
         tooltipStrings: config.trans.tooltipsForDrawArea
     });
 
     editAreaMode.init({
-        map: mapManager.map,
+        map: map,
         modes: this,
         tooltipStrings: config.trans.tooltipForEditArea
     });
 
     addTreeMode.init({
-        $addFeatureHeaderLink: $addFeatureHeaderLink,
-        $exploreMapHeaderLink: $exploreMapHeaderLink,
         mapManager: mapManager,
-        plotMarker: plotMarker,
+        activateBrowseTreesMode: activateBrowseTreesMode,
         inMyMode: inAddTreeMode,
         sidebar: sidebarAddTree,
-        onClose: _.partial(activateBrowseTreesMode, true),
         formSelector: '#add-tree-form',
         validationFields: '#add-tree-container [data-class="error"]',
         indexOfSetLocationStep: 0,
@@ -175,19 +179,15 @@ function init(mapManager, triggerSearchBus, embed, completedSearchStream) {
     editTreeDetailsMode.init({
         mapManager: mapManager,
         inlineEditForm: form,
-        plotMarker: plotMarker,
         inMyMode: inEditTreeMode,
         typeaheads: [getSpeciesTypeaheadOptions("edit-tree-species")]
     });
 
     addResourceMode.init({
-        $addFeatureHeaderLink: $addFeatureHeaderLink,
-        $exploreMapHeaderLink: $exploreMapHeaderLink,
         mapManager: mapManager,
-        plotMarker: plotMarker,
+        activateBrowseTreesMode: activateBrowseTreesMode,
         inMyMode: inAddResourceMode,
         sidebar: sidebarAddResource,
-        onClose: _.partial(activateBrowseTreesMode, true),
         formSelector: '#add-resource-form',
         validationFields: '#add-resource-container [data-class="error"]',
         indexOfSetLocationStep: 1,

--- a/opentreemap/treemap/templates/treemap/map-browse-trees.html
+++ b/opentreemap/treemap/templates/treemap/map-browse-trees.html
@@ -8,7 +8,7 @@
     </div>
     <div id="tree-detail" class="panel-body collapse">
       <div class="panel-body-buttons-wrapper">
-        <div class="panel-body-buttons" id="map-plot-details-button" style="display: none;">
+        <div class="panel-body-buttons" id="map-plot-details-button">
           <a class="btn" data-class="display" id="full-details-button">{% trans "More Details" %}</a>
           {% if not embed %}
           <button class="btn"


### PR DESCRIPTION
Functional changes:
* Hide "Details" sidebar when switching out of browse or edit mode
* Don't update URL when adding a tree or resource from the treemap page. The only reason for having `m=addTree` in the URL is so we can initiate adding a tree or resource from another page. There's no value in updating the URL when adding a tree or resource from the treemap page, so don't.

Simplify and clarify `modes.js` and mode modules
* Refactor activation methods to use options instead of named arguments
* Pass `activateBrowseTreesMode` to "add" modes rather than `onClose` function
* Cleaner mode transitions for mobile
* Remove logic to show accordion buttons -- they were never hidden anyway
* Use `dom.` pattern rather than passing selectors in `options`
* Require `plotMarker.js` rather than passing it in `options`
* Remove unused `require`s and `var`s

Testing -- both desktop and mobile

Browse and edit trees
* Select, deselect, and edit trees
  * The "Details" sidebar should behave correctly
  * Saving or cancelling edits should not ask "are you sure"?
* If a tree is selected, it should be deselected (and the "details" sidebar cleared) when you start adding a tree or drawing or editing a custom area.

Add trees and resources
* Add a tree and a resource
* While adding
  * Changing to a different mode (e.g. draw a polygon or add a different kind of resource) should ask "are you sure"?
  * Finishing or cancelling should not ask "are you sure"?
  * The URL should not change

Connects #3000