### PR TITLE
Fix UI test

### DIFF
--- a/opentreemap/treemap/tests/ui/__init__.py
+++ b/opentreemap/treemap/tests/ui/__init__.py
@@ -85,6 +85,10 @@ class UITestCase(StaticLiveServerTestCase):
     def find_id(self, id):
         return self.driver.find_element_by_id(id)
 
+    def is_visible(self, selector):
+        element = self.find(selector)
+        return element is not None and element.is_displayed()
+
     def process_login_form(self, username, password):
         username_elmt = self.wait_until_present('[name="username"]')
         password_elmt = self.find_name('password')

--- a/opentreemap/treemap/tests/ui/uitest_map.py
+++ b/opentreemap/treemap/tests/ui/uitest_map.py
@@ -255,11 +255,11 @@ class ModeChangeTest(TreemapUITestCase):
             alert = self.driver.switch_to_alert()
             self.assertEqual(alert.text, expected_alert_text)
             alert.dismiss()
-            self.assertFalse(self.driver.current_url.endswith('addTree'))
+            self.assertFalse(self.is_visible('#sidebar-add-tree'))
 
             self.click_add_tree()
             alert = self.driver.switch_to_alert()
             self.assertEqual(alert.text, expected_alert_text)
 
             alert.accept()
-            self.assertTrue(self.driver.current_url.endswith('addTree'))
+            self.assertTrue(self.is_visible('#sidebar-add-tree'))


### PR DESCRIPTION
When you're adding a tree we no longer put `m=addTree` in the URL. So check whether the "Add Tree" sidebar is visible.