### PR TITLE
Create sequential Work Order numbers and Task numbers per instance

### DIFF
--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -771,6 +771,38 @@ class Instance(models.Model):
         if errors:
             raise_errors(errors)
 
+    @transaction.atomic
+    def get_next_task_sequence(self, how_many=1):
+        """
+        Return next sequence value and increment counter by `how_many`.
+
+        Arguments:
+        how_many - Amount of sequence values to allocate
+        """
+        if how_many < 1:
+            raise ValueError('how_many must be >= 1')
+        qs = Instance.objects.filter(id=self.id).select_for_update()
+        old_value = qs[0].task_sequence_number
+        new_value = F('task_sequence_number') + how_many
+        qs.update(task_sequence_number=new_value)
+        return old_value
+
+    @transaction.atomic
+    def get_next_work_order_sequence(self, how_many=1):
+        """
+        Return next sequence value and increment counter by `how_many`.
+
+        Arguments:
+        how_many - Amount of sequence values to allocate
+        """
+        if how_many < 1:
+            raise ValueError('how_many must be >= 1')
+        qs = Instance.objects.filter(id=self.id).select_for_update()
+        old_value = qs[0].work_order_sequence_number
+        new_value = F('work_order_sequence_number') + how_many
+        qs.update(work_order_sequence_number=new_value)
+        return old_value
+
     def save(self, *args, **kwargs):
         self.full_clean()
 

--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -245,6 +245,9 @@ class Instance(models.Model):
                                         null=True, blank=True)
     eco_rev = models.IntegerField(default=_DEFAULT_REV)
 
+    task_sequence_number = models.IntegerField(default=1, null=True)
+    work_order_sequence_number = models.IntegerField(default=1, null=True)
+
     eco_benefits_conversion = models.ForeignKey(
         'BenefitCurrencyConversion', null=True, blank=True)
 

--- a/opentreemap/treemap/migrations/0045_sequence_number.py
+++ b/opentreemap/treemap/migrations/0045_sequence_number.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('treemap', '0044_userdefinedfielddefinition_is_protected'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='instance',
+            name='task_sequence_number',
+            field=models.IntegerField(default=1, null=True),
+        ),
+        migrations.AddField(
+            model_name='instance',
+            name='work_order_sequence_number',
+            field=models.IntegerField(default=1, null=True),
+        ),
+    ]

--- a/opentreemap/works_management/migrations/0002_reference_number_field.py
+++ b/opentreemap/works_management/migrations/0002_reference_number_field.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('works_management', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='task',
+            name='reference_number',
+            field=models.IntegerField(null=True),
+        ),
+        migrations.AddField(
+            model_name='workorder',
+            name='reference_number',
+            field=models.IntegerField(null=True),
+        ),
+    ]

--- a/opentreemap/works_management/migrations/0003_reference_number_default.py
+++ b/opentreemap/works_management/migrations/0003_reference_number_default.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models, transaction
+
+from treemap.models import Instance
+
+
+def assign_task_reference_numbers(apps):
+    """
+    Populate reference_number on Tasks and update
+    next sequence value on each Instance.
+    """
+    Task = apps.get_model('works_management', 'Task')
+    tasks = Task.objects.filter(reference_number=None) \
+        .values_list('id', 'instance_id')
+    for task_id, instance_id in tasks:
+        instance = Instance.objects.get(id=instance_id)
+        reference_number = instance.get_next_task_sequence()
+        # To bypass save_with_user
+        Task.objects.filter(id=task_id) \
+            .update(reference_number=reference_number)
+
+
+def assign_work_order_reference_numbers(apps):
+    """
+    Populate reference_number on WorkOrders and update
+    next sequence value on each Instance.
+    """
+    WorkOrder = apps.get_model('works_management', 'WorkOrder')
+    work_orders = WorkOrder.objects.filter(reference_number=None) \
+        .values_list('id', 'instance_id')
+    for work_order_id, instance_id in work_orders:
+        instance = Instance.objects.get(id=instance_id)
+        reference_number = instance.get_next_work_order_sequence()
+        # To bypass save_with_user
+        WorkOrder.objects.filter(id=work_order_id) \
+            .update(reference_number=reference_number)
+
+
+def forward(apps, schema_editor):
+    """
+    Populate nullable reference_number fields on WM models.
+    """
+    assign_task_reference_numbers(apps)
+    assign_work_order_reference_numbers(apps)
+
+
+def backward(apps, schema_editor):
+    # Nothing to do.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('works_management', '0002_reference_number_field'),
+    ]
+
+    operations = [
+        migrations.RunPython(forward, backward)
+    ]

--- a/opentreemap/works_management/migrations/0004_reference_number_unique.py
+++ b/opentreemap/works_management/migrations/0004_reference_number_unique.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('works_management', '0003_reference_number_default'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='task',
+            name='reference_number',
+            field=models.IntegerField(),
+        ),
+        migrations.AlterField(
+            model_name='workorder',
+            name='reference_number',
+            field=models.IntegerField(),
+        ),
+        migrations.AlterUniqueTogether(
+            name='task',
+            unique_together=set([('instance', 'reference_number')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='workorder',
+            unique_together=set([('instance', 'reference_number')]),
+        ),
+    ]

--- a/opentreemap/works_management/migrations/0005_blank_fields.py
+++ b/opentreemap/works_management/migrations/0005_blank_fields.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('works_management', '0004_reference_number_unique'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='task',
+            name='field_notes',
+            field=models.TextField(blank=True),
+        ),
+        migrations.AlterField(
+            model_name='task',
+            name='office_notes',
+            field=models.TextField(blank=True),
+        ),
+        migrations.AlterField(
+            model_name='task',
+            name='team',
+            field=models.ForeignKey(blank=True, to='works_management.Team', null=True),
+        ),
+        migrations.AlterField(
+            model_name='task',
+            name='work_order',
+            field=models.ForeignKey(blank=True, to='works_management.WorkOrder', null=True),
+        ),
+    ]

--- a/opentreemap/works_management/models.py
+++ b/opentreemap/works_management/models.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from __future__ import division
 
 from django.contrib.gis.db import models
+from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 from django.utils import timezone
 
@@ -25,6 +26,24 @@ class WorkOrder(Auditable, models.Model):
     created_by = models.ForeignKey(User)
     updated_at = models.DateTimeField(auto_now=True)
 
+    # This value comes from `instance.work_order_sequence_number`
+    reference_number = models.IntegerField()
+
+    class Meta:
+        unique_together = ('instance', 'reference_number')
+
+    def clean(self):
+        if not self.reference_number:
+            raise ValidationError({
+                'reference_number': [_('Reference number is required.')]})
+
+    def save_with_user(self, user, *args, **kwargs):
+        """
+        Update WorkOrder fields when Task is saved.
+        """
+        self.full_clean()
+        super(WorkOrder, self).save_with_user(user, *args, **kwargs)
+
 
 class Task(UDFModel, Auditable):
     REQUESTED = 0
@@ -41,11 +60,11 @@ class Task(UDFModel, Auditable):
 
     instance = models.ForeignKey(Instance)
     map_feature = models.ForeignKey(MapFeature)
-    work_order = models.ForeignKey(WorkOrder, null=True, related_name='tasks')
-    team = models.ForeignKey(Team, null=True)
+    work_order = models.ForeignKey(WorkOrder, null=True, blank=True)
+    team = models.ForeignKey(Team, null=True, blank=True)
 
-    office_notes = models.TextField()
-    field_notes = models.TextField()
+    office_notes = models.TextField(blank=True)
+    field_notes = models.TextField(blank=True)
 
     status = models.IntegerField(
         choices=STATUS_CHOICES,
@@ -58,6 +77,9 @@ class Task(UDFModel, Auditable):
     created_at = models.DateTimeField(auto_now_add=True)
     created_by = models.ForeignKey(User)
     updated_at = models.DateTimeField(auto_now=True)
+
+    # This value comes from `instance.task_sequence_number`
+    reference_number = models.IntegerField()
 
     udf_settings = {
         'Action': {
@@ -74,11 +96,22 @@ class Task(UDFModel, Auditable):
         },
     }
 
+    class Meta:
+        unique_together = ('instance', 'reference_number')
+
+    def clean(self):
+        if not self.reference_number:
+            raise ValidationError({
+                'reference_number': [_('Reference number is required.')]})
+
     def save_with_user(self, user, *args, **kwargs):
         """
         Update WorkOrder fields when Task is saved.
         """
+        self.full_clean()
+
         if self.work_order:
             self.work_order.updated_at = timezone.now()
             self.work_order.save_with_user(user, *args, **kwargs)
+
         super(Task, self).save_with_user(user, *args, **kwargs)

--- a/opentreemap/works_management/tests.py
+++ b/opentreemap/works_management/tests.py
@@ -22,20 +22,20 @@ def make_team(instance, name='Test Team'):
     return t
 
 
-def make_work_order(instance, user):
+def make_work_order(instance, user, name='Test Work Order'):
     w = WorkOrder()
+    w.name = name
     w.instance = instance
     w.created_by = user
     w.save_with_user(user)
     return w
 
 
-def make_task(instance, user, map_feature, name='Test Task', team=None):
+def make_task(instance, user, map_feature, team=None):
     t = Task()
     t.instance = instance
     t.map_feature = map_feature
     t.team = team
-    t.name = name
     t.created_by = user
     t.requested_on = timezone.now()
     t.scheduled_on = timezone.now()
@@ -64,7 +64,7 @@ class WorksManagementTests(OTMTestCase):
         t = make_task(self.instance, self.user, plot)
         t.work_order = w
         t.save_with_user(self.user)
-        self.assertEqual(1, w.tasks.count())
+        self.assertEqual(1, w.task_set.count())
 
         # Test that WorkOrder updated_at field updates when Tasks update
         old_updated_at = w.updated_at

--- a/opentreemap/works_management/tests.py
+++ b/opentreemap/works_management/tests.py
@@ -22,16 +22,18 @@ def make_team(instance, name='Test Team'):
     return t
 
 
-def make_work_order(instance, user, name='Test Work Order'):
+def make_work_order(instance, user, name='Test Work Order', save=True):
     w = WorkOrder()
     w.name = name
     w.instance = instance
     w.created_by = user
-    w.save_with_user(user)
+    if save:
+        w.reference_number = instance.get_next_work_order_sequence()
+        w.save_with_user(user)
     return w
 
 
-def make_task(instance, user, map_feature, team=None):
+def make_task(instance, user, map_feature, team=None, save=True):
     t = Task()
     t.instance = instance
     t.map_feature = map_feature
@@ -40,7 +42,9 @@ def make_task(instance, user, map_feature, team=None):
     t.requested_on = timezone.now()
     t.scheduled_on = timezone.now()
     t.closed_on = timezone.now()
-    t.save_with_user(user)
+    if save:
+        t.reference_number = instance.get_next_task_sequence()
+        t.save_with_user(user)
     return t
 
 
@@ -56,12 +60,12 @@ class WorksManagementTests(OTMTestCase):
         self.instance = make_instance()
         self.user = make_commander_user(self.instance)
         self.team = make_team(self.instance)
+        self.plot = make_plot(self.instance, self.user)
 
     def test_work_order(self):
         w = make_work_order(self.instance, self.user)
 
-        plot = make_plot(self.instance, self.user)
-        t = make_task(self.instance, self.user, plot)
+        t = make_task(self.instance, self.user, self.plot)
         t.work_order = w
         t.save_with_user(self.user)
         self.assertEqual(1, w.task_set.count())
@@ -74,7 +78,7 @@ class WorksManagementTests(OTMTestCase):
         w = WorkOrder.objects.get(id=w.id)
         self.assertTrue(w.updated_at > old_updated_at)
 
-    def test_cannot_call_save_on_workorder(self):
+    def test_cannot_call_save_on_work_order(self):
         # WorkOrder is Auditible and should only allow calling save_with_user.
         w = make_work_order(self.instance, self.user)
         with self.assertRaises(UserTrackingException):
@@ -82,7 +86,58 @@ class WorksManagementTests(OTMTestCase):
 
     def test_cannot_call_save_on_task(self):
         # Task is Auditible and should only allow calling save_with_user.
-        t = make_task(self.instance, self.user,
-                      make_plot(self.instance, self.user))
+        t = make_task(self.instance, self.user, self.plot)
         with self.assertRaises(UserTrackingException):
             t.save()
+
+    def test_work_order_sequence(self):
+        w1 = make_work_order(self.instance, self.user)
+        w2 = make_work_order(self.instance, self.user)
+        self.assertEqual(1, w1.reference_number)
+        self.assertEqual(2, w2.reference_number)
+
+        # Sequence numbers should be unique by instance.
+        other_instance = make_instance()
+        w1 = make_work_order(other_instance, self.user)
+        w2 = make_work_order(other_instance, self.user)
+        self.assertEqual(1, w1.reference_number)
+        self.assertEqual(2, w2.reference_number)
+
+    def test_task_sequence(self):
+        t1 = make_task(self.instance, self.user, self.plot)
+        t2 = make_task(self.instance, self.user, self.plot)
+        self.assertEqual(1, t1.reference_number)
+        self.assertEqual(2, t2.reference_number)
+
+        # Sequence numbers should be unique by instance.
+        other_instance = make_instance()
+        t1 = make_task(other_instance, self.user, self.plot)
+        t2 = make_task(other_instance, self.user, self.plot)
+        self.assertEqual(1, t1.reference_number)
+        self.assertEqual(2, t2.reference_number)
+
+    def test_work_order_sequence_bulk_create(self):
+        orders = [make_work_order(self.instance, self.user, save=False)
+                  for _ in range(10)]
+
+        value = self.instance.get_next_work_order_sequence(len(orders))
+        for i in range(len(orders)):
+            orders[i].reference_number = value + i
+
+        WorkOrder.objects.bulk_create(orders)
+
+        self.instance.refresh_from_db()
+        self.assertEqual(11, self.instance.work_order_sequence_number)
+
+    def test_task_sequence_bulk_create(self):
+        tasks = [make_task(self.instance, self.user, self.plot, save=False)
+                 for _ in range(10)]
+
+        value = self.instance.get_next_task_sequence(len(tasks))
+        for i in range(len(tasks)):
+            tasks[i].reference_number = value + i
+
+        Task.objects.bulk_create(tasks)
+
+        self.instance.refresh_from_db()
+        self.assertEqual(11, self.instance.task_sequence_number)

--- a/opentreemap/works_management/tests.py
+++ b/opentreemap/works_management/tests.py
@@ -90,6 +90,22 @@ class WorksManagementTests(OTMTestCase):
         with self.assertRaises(UserTrackingException):
             t.save()
 
+    def test_instance_sequence_helpers(self):
+        self.assertEqual(1, self.instance.get_next_task_sequence(9))
+        self.assertEqual(10, self.instance.get_next_task_sequence())
+
+        self.assertEqual(1, self.instance.get_next_work_order_sequence(9))
+        self.assertEqual(10, self.instance.get_next_work_order_sequence())
+
+        # Try to commit bad data.
+        self.instance.task_sequence_number = 0
+        self.instance.work_order_sequence_number = 0
+        self.instance.save()
+        self.instance.refresh_from_db()
+
+        self.assertEqual(11, self.instance.task_sequence_number)
+        self.assertEqual(11, self.instance.work_order_sequence_number)
+
     def test_work_order_sequence(self):
         w1 = make_work_order(self.instance, self.user)
         w2 = make_work_order(self.instance, self.user)


### PR DESCRIPTION
## Overview

Adds a new reference number field on WorkOrder and Task models, which
is sequential (starting from 1), and is distinct per instance.

Migrations have been split up into 3 parts:
1. Add new fields (nullable)
2. Set default values on null fields
3. Add unique key and non-nullable constraint

Connects #3049

## Testing Instructions

* Run migrations
* Run unit tests

```
> ./scripts/manage.sh test works_management.tests
```