### PR TITLE
anonymous boundary for custom area

### DIFF
--- a/opentreemap/treemap/js/src/lib/baconUtils.js
+++ b/opentreemap/treemap/js/src/lib/baconUtils.js
@@ -37,6 +37,8 @@ var isUndefined = exports.isUndefined = _.isUndefined;
 
 var isUndefinedOrEmpty = exports.isUndefinedOrEmpty = R.or(_.isUndefined, R.eq(''));
 
+var isNumber = exports.isNumber = R.and(R.not(_.isNaN), _.isNumber);
+
 // Used to get object property values
 // Needed for keys with '.' in them, as Bacon will treat a '.' a in key as an
 // indication that there are nested objects

--- a/opentreemap/treemap/js/src/lib/boundarySelect.js
+++ b/opentreemap/treemap/js/src/lib/boundarySelect.js
@@ -45,6 +45,8 @@ function parseGeoJson(style, geojson) {
         inner = layer.getLayers()[0],
         latLngs = inner.getLatLngs();
 
+    // Create a polygon instead of a geoJson layer
+    // to support custom area editing.
     if (1 === latLngs.length) {
         return L.polygon(latLngs[0][0], options);
     }

--- a/opentreemap/treemap/js/src/lib/mapPage.js
+++ b/opentreemap/treemap/js/src/lib/mapPage.js
@@ -53,6 +53,15 @@ module.exports.init = function (options) {
             geocodeEvents);
 
     if (options.shouldUseLocationSearchUI) {
+        // When loading the page from a URL with a BOUNDARY_ID search,
+        // we must wait for the location typeahead to populate the
+        // "Search by Location" input box (by fetching the boundary name
+        // from the server).
+        //
+        // That triggers an event on searchBar.programaticallyUpdatedStream,
+        // and we call locationSearchUI.onSearchChanged,
+        // which uses the presence of text in the "Search by Location" input box
+        // to distinguish between named and anonymous boundaries.
         builtSearchEvents
             .merge(searchBar.programmaticallyUpdatedStream)
             .onValue(locationSearchUI.onSearchChanged);

--- a/opentreemap/treemap/js/src/lib/searchBar.js
+++ b/opentreemap/treemap/js/src/lib/searchBar.js
@@ -380,7 +380,7 @@ module.exports = exports = {
         Search.reset();
     },
 
-    init: function () {
+    init: function (options) {
         var searchStream = Bacon.mergeAll(
                 initTopTypeaheads(),
                 BU.enterOrClickEventStream({
@@ -416,6 +416,10 @@ module.exports = exports = {
                     displayedResults: '.search-block [data-class="geocode-result"]'
                 });
 
+        if (options.anotherNonGeocodeObjectStream) {
+            filtersStream = filtersStream
+                .merge(options.anotherNonGeocodeObjectStream);
+        }
         geocodeResponseStream.onError(showGeocodeError);
         initSearchUi(searchStream);
 

--- a/opentreemap/treemap/js/src/mapPage/drawAreaMode.js
+++ b/opentreemap/treemap/js/src/mapPage/drawAreaMode.js
@@ -37,9 +37,10 @@ function activate() {
 }
 
 function onDrawComplete(e) {
-    locationSearchUI.setPolygon(e.layer);
-    polygonComplete = true;
-    modes.activateBrowseTreesMode();
+    locationSearchUI.completePolygon(e.layer).onValue(function () {
+        polygonComplete = true;
+        modes.activateBrowseTreesMode(true);
+    });
 }
 
 function onKeyDown(e) {

--- a/opentreemap/treemap/js/src/mapPage/drawAreaMode.js
+++ b/opentreemap/treemap/js/src/mapPage/drawAreaMode.js
@@ -37,10 +37,9 @@ function activate() {
 }
 
 function onDrawComplete(e) {
-    locationSearchUI.completePolygon(e.layer).onValue(function () {
-        polygonComplete = true;
-        modes.activateBrowseTreesMode(true);
-    });
+    locationSearchUI.completePolygon(e.layer);
+    polygonComplete = true;
+    modes.activateBrowseTreesMode(true);
 }
 
 function onKeyDown(e) {

--- a/opentreemap/treemap/js/src/mapPage/editAreaMode.js
+++ b/opentreemap/treemap/js/src/mapPage/editAreaMode.js
@@ -3,8 +3,7 @@
 var $ = require('jquery'),
     L = require('leaflet'),
     boundarySelect = require('treemap/lib/boundarySelect.js'),
-    locationSearchUI = require('treemap/mapPage/locationSearchUI.js'),
-    plotMarker = require('treemap/lib/plotMarker.js');
+    locationSearchUI = require('treemap/mapPage/locationSearchUI.js');
 
 var map,
     modes,
@@ -55,10 +54,8 @@ function onKeyDown(e) {
 function saveArea() {
     editor.save();
     editsSaved = true;
-    locationSearchUI.completePolygon(boundarySelect.getCurrentLayer())
-        .onValue(function () {
-            modes.activateBrowseTreesMode(true);
-        });
+    locationSearchUI.completePolygon(boundarySelect.getCurrentLayer());
+    modes.activateBrowseTreesMode(true);
 }
 
 function cancelEditing() {

--- a/opentreemap/treemap/js/src/mapPage/editAreaMode.js
+++ b/opentreemap/treemap/js/src/mapPage/editAreaMode.js
@@ -2,7 +2,9 @@
 
 var $ = require('jquery'),
     L = require('leaflet'),
-    locationSearchUI = require('treemap/mapPage/locationSearchUI.js');
+    boundarySelect = require('treemap/lib/boundarySelect.js'),
+    locationSearchUI = require('treemap/mapPage/locationSearchUI.js'),
+    plotMarker = require('treemap/lib/plotMarker.js');
 
 var map,
     modes,
@@ -35,7 +37,7 @@ function activate() {
     setTooltips(customTooltip);
     locationSearchUI.showEditAreaControls();
 
-    polygonFeatureGroup.addLayer(locationSearchUI.getPolygon());
+    polygonFeatureGroup.addLayer(boundarySelect.getCurrentLayer());
     editor.enable();
 
     $(document).on('keydown', onKeyDown);
@@ -53,7 +55,10 @@ function onKeyDown(e) {
 function saveArea() {
     editor.save();
     editsSaved = true;
-    modes.activateBrowseTreesMode();
+    locationSearchUI.completePolygon(boundarySelect.getCurrentLayer())
+        .onValue(function () {
+            modes.activateBrowseTreesMode(true);
+        });
 }
 
 function cancelEditing() {

--- a/opentreemap/treemap/js/src/treeMap.js
+++ b/opentreemap/treemap/js/src/treeMap.js
@@ -17,7 +17,8 @@ var mapPage = MapPage.init({
         domId: 'map',
         trackZoomLatLng: true,
         fillSearchBoundary: true,
-        saveSearchInUrl: true
+        saveSearchInUrl: true,
+        shouldUseLocationSearchUI: true
     }),
     mapManager = mapPage.mapManager,
 

--- a/opentreemap/treemap/js/src/treeMap.js
+++ b/opentreemap/treemap/js/src/treeMap.js
@@ -11,7 +11,6 @@ var $ = require('jquery'),
     buttonEnabler = require('treemap/lib/buttonEnabler.js'),
     MapPage = require('treemap/lib/mapPage.js'),
     modes = require('treemap/mapPage/modes.js'),
-    locationSearchUI = require('treemap/mapPage/locationSearchUI.js'),
     Search = require('treemap/lib/search.js');
 
 var mapPage = MapPage.init({
@@ -24,7 +23,7 @@ var mapPage = MapPage.init({
 
     triggerSearchFromSidebar = new Bacon.Bus(),
 
-    ecoBenefitsSearchEvents =
+    searchEvents =
         Bacon.mergeAll(
             mapPage.builtSearchEvents,
             triggerSearchFromSidebar.map(mapPage.getMapStateSearch)
@@ -33,8 +32,8 @@ var mapPage = MapPage.init({
     modeChangeStream = mapPage.mapStateChangeStream
         .filter(BU.isPropertyDefined('modeName')),
 
-    completedEcobenefitsSearchStream = Search.init(
-        ecoBenefitsSearchEvents,
+    completedSearchStream = Search.init(
+        searchEvents,
         _.bind(mapManager.setFilter, mapManager));
 
 
@@ -86,12 +85,7 @@ var performAdd = function (e, activateTheMode) {
 buttonEnabler.run();
 
 modes.init(mapManager, triggerSearchFromSidebar, mapPage.embed,
-    completedEcobenefitsSearchStream);
-
-locationSearchUI.init({
-    map: mapManager.map,
-    builtSearchEvents: mapPage.builtSearchEvents
-});
+    completedSearchStream);
 
 // Read state from current URL, initializing
 // zoom/lat/long/search/mode/selection

--- a/opentreemap/treemap/search.py
+++ b/opentreemap/treemap/search.py
@@ -290,7 +290,7 @@ def _parse_within_radius_value(predicate_value, field=None):
 
 
 def _parse_in_boundary(boundary_id, field=None):
-    boundary = Boundary.objects.get(pk=boundary_id)
+    boundary = Boundary.all_objects.get(pk=boundary_id)
     return {'__within': boundary.geom}
 
 

--- a/opentreemap/treemap/views/misc.py
+++ b/opentreemap/treemap/views/misc.py
@@ -120,7 +120,10 @@ def boundary_to_geojson(request, instance, boundary_id):
 
 def add_anonymous_boundary(request):
     request_dict = json.loads(request.body)
-    polygon = Polygon(request_dict.get('polygon', []))
+    srid = request_dict.get('srid', 4326)
+    polygon = Polygon(request_dict.get('polygon', []), srid=srid)
+    if srid != 3857:
+        polygon.transform(3857)
     b = Boundary.anonymous(polygon)
     b.save()
     return {'id': b.id}


### PR DESCRIPTION
Here is what it does.

Polygons are completed by user events:
- `mapPage/drawAreaMode.onDrawComplete`
- `mapPage/editAreaMode.saveArea`

When polygons are completed, `locationSearchUI.completePolygon` POSTs
to the backend `anonymous_boundary` url, and adds the polygon to the map.

The stream created by `anonymous_boundary` tells `drawAreaMode` to
set some state and activate browse-trees mode.

After some mapping, it also gets plugged into a bus, which `mapPage`
feeds into `boundarySelect.init`, after some merges and transformations.

`mapPage` also feeds it into a stream that triggers backend searches.

TODO: ajax errors from `anonymous_boundary` are presently ignored.

When `anonymous_boundary` succeeds, it returns `{"id": <boundary id>}`.
This is processed as follows:
- `onValue`,
  * inject the id into the hidden location value dom element
  * tell `boundarySelect` not to zoom on layer change
- send the boundary id on the bus that feeds into `boundarySelect`, which
  * requests geojson from the backend given the id
  * parses the returned geojson
  * displays it on the map
  * sends a notice on another stream, which `mapPage` previously passed
    to `locationSearchUI`, so the latter can remove the draw layer,
    with no "blink"
- on another stream that it feeds, trigger the backend search.

Polygons are cleared by user events:
- clicking the reset button, triggering `searchBar.resetStream`
- clicking the "Clear" control in the Location box

Either way, it calls `locationSearchUI.clearCustomArea`, which
- tells `boundarySelect` it's safe to zoom again
- sets the controls back to standard
- sets the hidden location value to empty
- pushes events out on the `locationChangeBus` where it goes through
  the same pipeline as `anonymous_boundary` success

The backend had to be changed, too.
- the `anonymous_boundary` endpoint has to transform the geometry.
- `search.py` has to use `Boundary.all_objects`

--

Connects to #2994