### PR TITLE
Skeletal Work Orders page

### DIFF
--- a/opentreemap/opentreemap/urls.py
+++ b/opentreemap/opentreemap/urls.py
@@ -74,6 +74,7 @@ urlpatterns = patterns(
                                                   namespace='importer')),
     url(instance_pattern + r'/export/', include('exporter.urls')),
     url(instance_pattern + r'/comments/', include('otm_comments.urls')),
+    url(instance_pattern + r'/', include('works_management.urls')),
 )
 
 if settings.USE_JS_I18N:

--- a/opentreemap/treemap/templates/instance_base.html
+++ b/opentreemap/treemap/templates/instance_base.html
@@ -83,6 +83,16 @@ ga('set', 'page', pathname);
 </li>
 {% endif %}
 
+{% if request.instance|feature_enabled:'works_management' %}
+  {% if last_effective_instance_user|has_permission:'access_works_management' %}
+    <li class="{% block activeworkorders %}{% endblock %} hidden-xs">
+      <a href="{% url 'work_orders' instance_url_name=request.instance.url_name %}">
+        <span>{% trans "Work Orders" %}</span>
+      </a>
+    </li>
+  {% endif %}
+{% endif %}
+
 {% if settings.MANAGEMENT_VIEW_NAME and last_effective_instance_user.admin %}
 <li class="hidden-xs {% block activemanagement %}{% endblock %}">
   <a href="{% url settings.MANAGEMENT_VIEW_NAME instance_url_name=request.instance.url_name %}">{% trans "Manage" %}</a>

--- a/opentreemap/works_management/js/src/workOrders.js
+++ b/opentreemap/works_management/js/src/workOrders.js
@@ -1,0 +1,5 @@
+"use strict";
+
+var toastr = require('toastr');
+
+toastr.success("I am working.");

--- a/opentreemap/works_management/routes.py
+++ b/opentreemap/works_management/routes.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from functools import partial
+
+from django_tinsel.utils import decorate as do
+from django_tinsel.decorators import render_template
+
+from treemap.decorators import (instance_request, requires_feature,
+                                requires_permission, require_http_method)
+from treemap.instance import PERMISSION_ACCESS_WORKS_MANAGEMENT
+
+from works_management import views
+
+
+def works_management_instance_request(view_fn, redirect=True):
+    return do(
+        partial(instance_request, redirect=redirect),
+        requires_feature('works_management'),
+        requires_permission(PERMISSION_ACCESS_WORKS_MANAGEMENT),
+        view_fn)
+
+
+work_orders = do(
+    works_management_instance_request,
+    require_http_method('GET'),
+    render_template('works_management/work_orders.html'),
+    views.work_orders)

--- a/opentreemap/works_management/templates/works_management/work_orders.html
+++ b/opentreemap/works_management/templates/works_management/work_orders.html
@@ -1,0 +1,26 @@
+{% extends "instance_base.html" %}
+{% load render_bundle from webpack_loader %}
+{% load i18n %}
+
+{% block page_title %} | {% trans "Work Orders" %} {% endblock %}
+
+{% block activeexplore %}{% endblock %}
+{% block activeworkorders %}active{% endblock %}
+
+{% block search %}{# hide search inputs #}{% endblock search %}
+{% block searchoptions %}{# hide search buttons #}{% endblock searchoptions %}
+{% block subhead %}{# hide search results #}{% endblock subhead %}
+
+{% block content %}
+    <div class="container contained">
+        <h1>I order you to work!</h1>
+        <h1>I order you to work!</h1>
+        <h1>I order you to work!</h1>
+    </div>
+{% endblock content %}
+
+{% block searchscripts %}{# omit code for searching the map #}{% endblock searchscripts %}
+
+{% block scripts %}
+    {% render_bundle 'js/works_management/workOrders' %}
+{% endblock scripts %}

--- a/opentreemap/works_management/urls.py
+++ b/opentreemap/works_management/urls.py
@@ -1,1 +1,14 @@
-# place app url patterns here
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django.conf.urls import patterns, url
+
+from works_management import routes
+
+
+urlpatterns = patterns(
+    '',
+    url(r'^work-orders/$', routes.work_orders, name='work_orders'),
+)

--- a/opentreemap/works_management/views.py
+++ b/opentreemap/works_management/views.py
@@ -1,1 +1,2 @@
-# Create your views here.
+def work_orders(request, instance):
+    return {}


### PR DESCRIPTION
Testing:

Logged in as a user whose role has "Works Management" permission (e.g. `Administrator`)
* You should see a "Work Orders" menu item
* Clicking it should take you to the (vanilla) Work Orders page
* When the Work Orders page is displayed:
  * You should see "I am working" toast (showing that JS code is hooked up right)
  * The "Work Orders" menu item should be highlighted

Logged in as a user whose role lacks "Works Management" permission (e.g. `Editor`)
* You should not see a "Work Orders" menu item
* Loading `/work-orders/` should give a "Page Restricted" page

Connects #3052