### PR TITLE
Fix IE11 issues

### DIFF
--- a/opentreemap/opentreemap/middleware.py
+++ b/opentreemap/opentreemap/middleware.py
@@ -5,7 +5,8 @@ from django.conf import settings
 import logging
 logger = logging.getLogger(__name__)
 
-_ie_version_regex = re.compile(r'MSIE\s+([\d]+)')
+# http://stackoverflow.com/a/30907476
+_ie_version_regex = re.compile(r'(MSIE\s+|Trident.*rv[ :])([\d]+)')
 
 CONTENT_TYPE_PASS_THROUGHS = ('application/json', 'text/csv')
 
@@ -30,7 +31,7 @@ class InternetExplorerRedirectMiddleware:
     def _parse_major_ie_version_from_user_agent(self, user_agent):
         search_result = _ie_version_regex.search(user_agent)
         if search_result:
-            return int(search_result.groups()[0])
+            return int(search_result.groups()[1])
         else:
             return None
 

--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -405,9 +405,7 @@ IMPORT_BATCH_SIZE = 85
 # The rate limit for how frequently batches of imports can happen per worker
 IMPORT_COMMIT_RATE_LIMIT = "1/m"
 
-# We have... issues on IE9 right now
-# Disable it on production, but enable it in Debug mode
-IE_VERSION_MINIMUM = 9 if DEBUG else 11
+IE_VERSION_MINIMUM = 11
 
 IE_VERSION_UNSUPPORTED_REDIRECT_PATH = '/unsupported'
 

--- a/opentreemap/treemap/js/src/lib/MapManager.js
+++ b/opentreemap/treemap/js/src/lib/MapManager.js
@@ -23,6 +23,7 @@ var $ = require('jquery'),
 // Leaflet extensions
 require('utfgrid');
 require('leafletbing');
+require('es6-promise').polyfill(); // https://gitlab.com/IvanSanchez/Leaflet.GridLayer.GoogleMutant
 require('leaflet.gridlayer.googlemutant');
 require('esri-leaflet');
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "console-browserify": "~1.0.1",
     "dragula": "^2.0.2",
     "esri-leaflet": "~1.0.2",
+    "es6-promise": "~4.1.0",
     "leaflet": "~1.0.3",
     "leaflet-draw": "~0.4.9",
     "leaflet.gridlayer.googlemutant ": "~0.4.3",


### PR DESCRIPTION
* Update browser detection regex
* Include promise polyfill
* Declare IE11 compatibility in HTML header so that `indexOf` is defined (http://stackoverflow.com/a/41830202)
* Require IE 11 even in debug mode
* Update tests

Connects OpenTreeMap/otm-clients#353