### PR TITLE
Make Task scheduled_on and closed_on nullable.

### DIFF
--- a/opentreemap/works_management/migrations/0007_make_task_dates_nullable.py
+++ b/opentreemap/works_management/migrations/0007_make_task_dates_nullable.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('works_management', '0006_task_priority'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='task',
+            name='closed_on',
+            field=models.DateField(null=True),
+        ),
+        migrations.AlterField(
+            model_name='task',
+            name='scheduled_on',
+            field=models.DateField(null=True),
+        ),
+    ]

--- a/opentreemap/works_management/models.py
+++ b/opentreemap/works_management/models.py
@@ -87,8 +87,8 @@ class Task(UDFModel, Auditable):
         default=MEDIUM)
 
     requested_on = models.DateField()
-    scheduled_on = models.DateField()
-    closed_on = models.DateField()
+    scheduled_on = models.DateField(null=True)
+    closed_on = models.DateField(null=True)
 
     created_at = models.DateTimeField(auto_now_add=True)
     created_by = models.ForeignKey(User)


### PR DESCRIPTION
These dates are not required when a task is initially created.