### PR TITLE
create tasks from search

### DIFF
--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -9,6 +9,17 @@ FEATURE_BACKEND_FUNCTION = None
 USER_ACTIVATION_FUNCTION = None
 INSTANCE_PERMISSIONS_FUNCTION = 'treemap.instance.get_instance_permission_spec'
 
+ENABLEABLE_FEATURES = {
+    'gsi': {
+        'feature_name': 'green_infrastructure',
+        'app_name': 'stormwater'
+    },
+    'wmm': {
+        'feature_name': 'works_management',
+        'app_name': 'works_management'
+    }
+}
+
 ECOSERVICE_NAME = 'ecoservice'
 
 UITEST_CREATE_INSTANCE_FUNCTION = 'treemap.tests.make_instance'

--- a/opentreemap/treemap/decorators.py
+++ b/opentreemap/treemap/decorators.py
@@ -168,9 +168,12 @@ def return_400_if_validation_errors(req):
             return req(*args, **kwargs)
         except ValidationError as e:
             if hasattr(e, 'message_dict'):
-                message_dict['fieldErrors'] = e.message_dict
                 message_dict['globalErrors'] = [_(
                     'One or more of the specified values are invalid.')]
+                if 'globalErrors' in e.message_dict:
+                    message_dict['globalErrors'] += \
+                        e.message_dict.pop('globalErrors')
+                message_dict['fieldErrors'] = e.message_dict
             else:
                 message_dict['globalErrors'] = e.messages
 

--- a/opentreemap/treemap/udf.py
+++ b/opentreemap/treemap/udf.py
@@ -8,9 +8,11 @@ import copy
 import re
 from datetime import date, datetime
 
-from django.core.exceptions import ValidationError, FieldError
+from django.core.exceptions import (ValidationError, FieldError,
+                                    ImproperlyConfigured)
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.gis.db import models
+from django.conf import settings
 from django.db import transaction
 from django.db.models import Q
 from django.db.models.fields.subclassing import Creator
@@ -24,6 +26,8 @@ from django.db.models.sql.query import Query
 from django_hstore.fields import DictionaryField, HStoreDict
 from django_hstore.managers import HStoreManager, HStoreGeoManager
 from django_hstore.query import HStoreGeoQuerySet
+
+from opentreemap.util import dotted_split
 
 from treemap.instance import Instance
 from treemap.audit import (UserTrackable, Audit, UserTrackingException,
@@ -58,6 +62,11 @@ from treemap.decorators import classproperty
 _UDF_NAME_REGEX = re.compile(r'^[^_"%.]+$')
 
 
+_APP_NAME_KEYS = {
+    v['app_name']: k for k, v in settings.ENABLEABLE_FEATURES.items()
+}
+
+
 def safe_get_udf_model_class(model_string):
     """
     In a couple of cases we want to be able to convert a string
@@ -70,12 +79,16 @@ def safe_get_udf_model_class(model_string):
     subtype of UDFModel
     """
     model_class = safe_get_model_class(model_string)
-
-    # It must have be a UDF subclass
-    if not isinstance(model_class(), UDFModel):
-        raise ValidationError(_('invalid model type - must subclass UDFModel'))
+    _validate_is_udf_class(model_class, model_string)
 
     return model_class
+
+
+def _validate_is_udf_class(model_class, name):
+    if not issubclass(model_class, UDFModel):
+        raise ValidationError(
+            _('invalid model type %(name) - must extend UDFModel') %
+            {'name': name})
 
 
 class UserDefinedCollectionValue(UserTrackable, models.Model):
@@ -592,22 +605,41 @@ class UserDefinedFieldDefinition(models.Model):
             self._update_choice_scalar(old_choice_value, new_choice_value)
 
     def validate(self):
-        model_type = self.model_type
+        class_name = model_type = self.model_type
+        if not model_type:
+            raise ValidationError(
+                {'udf.model': [_('Cannot save a custom field '
+                                 'with no model type')]})
+        key = 'all'
+        if '.' in model_type:
+            app_name, class_name = dotted_split(model_type, 2, maxsplit=1)
+            key = _APP_NAME_KEYS[app_name]
 
-        if model_type not in {cls.__name__ for cls
-                              in self.instance.editable_udf_models()['all']}:
+        classes = [cls for cls
+                   in self.instance.editable_udf_models()[key]
+                   if cls.__name__ == class_name]
+        if 0 == len(classes):
             raise ValidationError(
                 {'udf.model': [_("Invalid model '%(model_type)s'") %
                                {'model_type': model_type}]})
 
-        model_class = safe_get_udf_model_class(model_type)
+        if 1 < len(classes):
+            raise ImproperlyConfigured(
+                _('%(model_type)s matched %(count)d classes, '
+                  'but should only match one') %
+                {'model_type': model_type, 'count': len(classes)})
+
+        model_class = classes[0]
+        _validate_is_udf_class(model_class, model_type)
 
         field_names = [field.name for field in model_class._meta.fields]
 
         if self.name in field_names:
             raise ValidationError(
-                {'name': [_('Cannot use fields that already '
-                            'exist on the model')]})
+                {'name': [_(
+                    '%(name)s cannot be a custom field because '
+                    'it already exists on %(model)s') %
+                    {'name': self.name, 'model': class_name}]})
         if not self.name:
             raise ValidationError(
                 {'name': [_('Name cannot be blank')]})
@@ -1204,12 +1236,12 @@ class UDFModel(UserTrackable, models.Model):
 
     def get_user_defined_fields(self):
         if hasattr(self, 'instance'):
-            return udf_defs(self.instance, self._model_name)
+            return udf_defs(self.instance, self.model_name)
         else:
             return []
 
     def audits(self):
-        regular_audits = Q(model=self._model_name,
+        regular_audits = Q(model=self.model_name,
                            model_id=self.pk,
                            instance=self.instance)
 
@@ -1221,7 +1253,7 @@ class UDFModel(UserTrackable, models.Model):
         return Audit.objects.filter(all_audits).order_by('created')
 
     def search_slug(self):
-        return to_object_name(self.__class__.__name__)
+        return to_object_name(self.model_name)
 
     def collection_udfs_audit_ids(self):
         return self.static_collection_udfs_audit_ids(
@@ -1262,7 +1294,11 @@ class UDFModel(UserTrackable, models.Model):
     def save(self, *args, **kwargs):
         raise UserTrackingException(
             'All changes to %s objects must be saved via "save_with_user"' %
-            (self._model_name))
+            (self.model_name))
+
+    @property
+    def model_name(self):
+        return self.__class__.__name__
 
     @property
     def udf_field_names(self):
@@ -1270,14 +1306,14 @@ class UDFModel(UserTrackable, models.Model):
 
     @property
     def scalar_udf_names_and_fields(self):
-        model_name = to_object_name(self.__class__.__name__)
+        model_name = to_object_name(self.model_name)
         return [(field.name, model_name + ".udf:" + field.name)
                 for field in self.get_user_defined_fields()
                 if not field.iscollection]
 
     @property
     def collection_udf_names_and_fields(self):
-        model_name = to_object_name(self.__class__.__name__)
+        model_name = to_object_name(self.model_name)
         return [(field.name, model_name + ".udf:" + field.name)
                 for field in self.collection_udfs]
 
@@ -1297,7 +1333,7 @@ class UDFModel(UserTrackable, models.Model):
         return [udf.collection_audit_name for udf in self.collection_udfs]
 
     def collection_udfs_search_names(self):
-        object_name = to_object_name(self.__class__.__name__)
+        object_name = to_object_name(self.model_name)
         return ['udf:%s:%s' % (object_name, udf.pk)
                 for udf in self.collection_udfs]
 

--- a/opentreemap/treemap/util.py
+++ b/opentreemap/treemap/util.py
@@ -14,39 +14,55 @@ from django.http import HttpResponse
 from django.utils.encoding import force_str
 from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.conf import settings
-from django.core.exceptions import ValidationError, MultipleObjectsReturned
+from django.core.exceptions import (ValidationError, MultipleObjectsReturned,
+                                    ImproperlyConfigured)
 from django.utils.translation import ugettext_lazy as _
 
-from opentreemap.util import dict_pop
-from treemap.instance import Instance
+from opentreemap.util import dict_pop, dotted_split
 
 
 def safe_get_model_class(model_string):
     """
-    In a couple of cases we want to be able to convert a string
-    into a valid django model class. For instance, if we have
-    'Plot' we want to get the actual class for 'treemap.models.Plot'
-    in a safe way.
+    Given a string describing a model, return the actual model class.
 
-    This function returns the class represented by the given model
-    if it exists in 'treemap.models'
+    If the string contains a dot, it should be of the form
+    "<app_name>.<ModelName>".
+
+    If the string does not contain a dot, it should either be
+    in the `treemap` app or extend `treemap.MapFeature`.
+
+    If it can't find the class for the string, it raises
+    django.core.exceptions.ValidationError.
+
+    Dotless is the old way.
+
+    Dotted is more robust in that model names do not have to be
+    unique across apps.
     """
-    from treemap.models import MapFeature
 
-    # All of our base models live in 'treemap.models', so
-    # we can start with that namespace
-    models_module = __import__('treemap.models')
-    wmm_models_module = __import__('works_management.models')
-
-    if hasattr(models_module.models, model_string):
-        return getattr(models_module.models, model_string)
-    elif hasattr(wmm_models_module.models, model_string):
-        return getattr(wmm_models_module.models, model_string)
-    elif MapFeature.has_subclass(model_string):
-        return MapFeature.get_subclass(model_string)
-    else:
+    try:
+        class SplitException(Exception):
+            pass
+        app_name, model_name = dotted_split(model_string, 2, maxsplit=1,
+                                            cls=SplitException)
+        models_module = apps.get_app(app_name)
+        return getattr(models_module, model_name)
+    except (ImproperlyConfigured, AttributeError):
         raise ValidationError(
             _('invalid model type: "%s"') % model_string)
+    except (SplitException):
+        # All of our base models live in 'treemap.models', so
+        # we can start with that namespace
+        from treemap.models import MapFeature
+        models_module = __import__('treemap.models')
+
+        if hasattr(models_module.models, model_string):
+            return getattr(models_module.models, model_string)
+        elif MapFeature.has_subclass(model_string):
+            return MapFeature.get_subclass(model_string)
+        else:
+            raise ValidationError(
+                _('invalid model type: "%s"') % model_string)
 
 
 def get_model_for_instance(object_name, instance=None):
@@ -93,6 +109,7 @@ def get_last_visited_instance(request):
             # visited_instances have entries '(<pk>, <timestamp>)'
             instance_id = visited_instances[-1][0]
             try:
+                from treemap.instance import Instance
                 instance = Instance.objects.get(pk=instance_id)
             except (Instance.DoesNotExist, MultipleObjectsReturned):
                 instance = None
@@ -127,6 +144,7 @@ def get_instance_or_404(**kwargs):
     url_name, found = dict_pop(kwargs, 'url_name')
     if found:
         kwargs['url_name__iexact'] = url_name
+    from treemap.instance import Instance
     return get_object_or_404(Instance, **kwargs)
 
 
@@ -187,6 +205,12 @@ def get_filterable_audit_models():
     models = map_features + ['Tree']
 
     return models
+
+
+def get_models_by_app_name(app_name):
+    models_module = apps.get_app(app_name)
+    return [m for m in apps.get_models()
+            if m.__module__ == models_module.__name__]
 
 
 def get_csv_response(filename):

--- a/opentreemap/works_management/forms.py
+++ b/opentreemap/works_management/forms.py
@@ -15,6 +15,9 @@ class TaskFormException(Exception):
     pass
 
 
+# Use a ModelForm strictly for validation,
+# in order to validate the input without having to create all the tasks
+# for bulk creation, and also do the bulk_create.
 class TaskForm(ModelForm):
     class Meta:
         model = Task

--- a/opentreemap/works_management/forms.py
+++ b/opentreemap/works_management/forms.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+import json
+
+from django.forms import ModelForm
+from django.core.exceptions import ValidationError
+
+from works_management.models import Task
+
+
+class TaskFormException(Exception):
+    pass
+
+
+class TaskForm(ModelForm):
+    class Meta:
+        model = Task
+        fields = ['instance', 'work_order', 'team', 'office_notes',
+                  'field_notes', 'status', 'requested_on', 'created_by',
+                  'reference_number', 'priority', 'udfs']
+
+    def add_error(self, field, error):
+        if hasattr(error, 'message_dict'):
+            # udf messages in the error.message_dict need to be added
+            # with the key 'udfs' in order for ModelForm to
+            # associate them with the 'udfs' field.
+            new_message_dict = {'udfs': []}
+            for key, message in error.message_dict.items():
+                if key.startswith('udf:'):
+                    # ValidationError compresses its messages
+                    # so that only strings remain for each message_dict key.
+                    # That would lose the original key, so preserve it
+                    # in a json.dumps().
+                    new_message_dict['udfs'].append(json.dumps({
+                        key: message}))
+                else:
+                    new_message_dict[key] = message
+            if new_message_dict['udfs']:
+                error = ValidationError(new_message_dict)
+        super(TaskForm, self).add_error(field, error)

--- a/opentreemap/works_management/migrations/0006_task_fields_null_blank_default.py
+++ b/opentreemap/works_management/migrations/0006_task_fields_null_blank_default.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('works_management', '0005_blank_fields'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='task',
+            name='closed_on',
+            field=models.DateField(default=None, null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='task',
+            name='field_notes',
+            field=models.TextField(default='', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='task',
+            name='office_notes',
+            field=models.TextField(default='', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='task',
+            name='scheduled_on',
+            field=models.DateField(default=None, null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='task',
+            name='status',
+            field=models.IntegerField(default=0, blank=True, choices=[(0, 'Requested'), (1, 'Scheduled'), (2, 'Completed'), (3, 'Canceled')]),
+        ),
+        migrations.AlterField(
+            model_name='task',
+            name='work_order',
+            field=models.ForeignKey(default=None, to='works_management.WorkOrder'),
+        ),
+    ]

--- a/opentreemap/works_management/migrations/0007_merge.py
+++ b/opentreemap/works_management/migrations/0007_merge.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('works_management', '0006_task_fields_null_blank_default'),
+        ('works_management', '0006_task_priority'),
+    ]
+
+    operations = [
+    ]

--- a/opentreemap/works_management/migrations/0008_task_choice_blank_false.py
+++ b/opentreemap/works_management/migrations/0008_task_choice_blank_false.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('works_management', '0007_merge'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='task',
+            name='status',
+            field=models.IntegerField(default=0, choices=[(0, 'Requested'), (1, 'Scheduled'), (2, 'Completed'), (3, 'Canceled')]),
+        ),
+    ]

--- a/opentreemap/works_management/models.py
+++ b/opentreemap/works_management/models.py
@@ -18,6 +18,10 @@ class Team(models.Model):
     instance = models.ForeignKey(Instance)
     name = models.CharField(max_length=255, null=False, blank=False)
 
+    @property
+    def model_name(self):
+        return 'works_management.' + self.__class__.__name__
+
 
 class WorkOrder(Auditable, models.Model):
     instance = models.ForeignKey(Instance)
@@ -33,16 +37,27 @@ class WorkOrder(Auditable, models.Model):
         unique_together = ('instance', 'reference_number')
 
     def clean(self):
+        super(WorkOrder, self).clean()
         if not self.reference_number:
             raise ValidationError({
                 'reference_number': [_('Reference number is required.')]})
 
     def save_with_user(self, user, *args, **kwargs):
         """
-        Update WorkOrder fields when Task is saved.
+        Save the WorkOrder, and
+        - create audit records for its fields
+        - set the reference_number to the next instance work order sequence
+          (which has the side effect of updating the instance in the db)
         """
+        if not self.id:
+            self.reference_number = self.instance\
+                .get_next_work_order_sequence()
         self.full_clean()
         super(WorkOrder, self).save_with_user(user, *args, **kwargs)
+
+    @property
+    def model_name(self):
+        return 'works_management.' + self.__class__.__name__
 
 
 class Task(UDFModel, Auditable):
@@ -72,11 +87,11 @@ class Task(UDFModel, Auditable):
 
     instance = models.ForeignKey(Instance)
     map_feature = models.ForeignKey(MapFeature)
-    work_order = models.ForeignKey(WorkOrder, null=True, blank=True)
     team = models.ForeignKey(Team, null=True, blank=True)
+    work_order = models.ForeignKey(WorkOrder, default=None)
 
-    office_notes = models.TextField(blank=True)
-    field_notes = models.TextField(blank=True)
+    office_notes = models.TextField(blank=True, default='')
+    field_notes = models.TextField(blank=True, default='')
 
     status = models.IntegerField(
         choices=STATUS_CHOICES,
@@ -87,8 +102,8 @@ class Task(UDFModel, Auditable):
         default=MEDIUM)
 
     requested_on = models.DateField()
-    scheduled_on = models.DateField()
-    closed_on = models.DateField()
+    scheduled_on = models.DateField(null=True, blank=True, default=None)
+    closed_on = models.DateField(null=True, blank=True, default=None)
 
     created_at = models.DateTimeField(auto_now_add=True)
     created_by = models.ForeignKey(User)
@@ -120,14 +135,22 @@ class Task(UDFModel, Auditable):
         return _('Task')
 
     def clean(self):
+        super(Task, self).clean()
         if not self.reference_number:
             raise ValidationError({
                 'reference_number': [_('Reference number is required.')]})
 
     def save_with_user(self, user, *args, **kwargs):
         """
-        Update WorkOrder fields when Task is saved.
+        Save the WorkOrder, and
+        - create audit records for its fields
+        - update WorkOrder updated_at field
+        - set the reference_number to the next instance work order sequence
+          (which has the side effect of updating the instance in the db)
         """
+        if not self.id:
+            self.reference_number = self.instance.get_next_task_sequence()
+
         self.full_clean()
 
         if self.work_order:
@@ -135,3 +158,7 @@ class Task(UDFModel, Auditable):
             self.work_order.save_with_user(user, *args, **kwargs)
 
         super(Task, self).save_with_user(user, *args, **kwargs)
+
+    @property
+    def model_name(self):
+        return 'works_management.' + self.__class__.__name__

--- a/opentreemap/works_management/routes.py
+++ b/opentreemap/works_management/routes.py
@@ -6,7 +6,7 @@ from __future__ import division
 from functools import partial
 
 from django_tinsel.utils import decorate as do
-from django_tinsel.decorators import render_template
+from django_tinsel.decorators import render_template, json_api_call
 
 from treemap.decorators import (instance_request, requires_feature,
                                 requires_permission, require_http_method)
@@ -28,3 +28,9 @@ work_orders = do(
     require_http_method('GET'),
     render_template('works_management/work_orders.html'),
     views.work_orders)
+
+create_tasks = do(
+    works_management_instance_request,
+    require_http_method('POST'),
+    json_api_call,
+    views.create_tasks)

--- a/opentreemap/works_management/tests.py
+++ b/opentreemap/works_management/tests.py
@@ -3,16 +3,21 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
+import json
+
+from django.core.exceptions import ValidationError
 from django.contrib.gis.geos import Point
 from django.utils import timezone
 from django.test.utils import override_settings
 
-from treemap.audit import UserTrackingException
-from treemap.models import Plot
+from treemap.audit import UserTrackingException, Audit, bulk_create_with_user
+from treemap.search import Filter
+from treemap.models import Plot, Tree, Species
 from treemap.tests.base import OTMTestCase
-from treemap.tests import make_instance, make_commander_user
+from treemap.tests import make_instance, make_commander_user, make_request
 
 from works_management.models import Team, Task, WorkOrder
+from works_management.views import create_tasks
 
 
 def make_team(instance, name='Test Team'):
@@ -29,38 +34,44 @@ def make_work_order(instance, user, name='Test Work Order', save=True):
     w.instance = instance
     w.created_by = user
     if save:
-        w.reference_number = instance.get_next_work_order_sequence()
         w.save_with_user(user)
     return w
 
 
-def make_task(instance, user, map_feature, team=None, save=True):
+def make_task(instance, user, map_feature, work_order, team=None, save=True):
     t = Task()
     t.instance = instance
     t.map_feature = map_feature
     t.team = team
+    t.work_order = work_order
     t.created_by = user
     t.requested_on = timezone.now()
     t.scheduled_on = timezone.now()
     t.closed_on = timezone.now()
     if save:
-        t.reference_number = instance.get_next_task_sequence()
         t.save_with_user(user)
     return t
 
 
-def make_plot(instance, user):
-    p = Point(0, 0)
+def make_plot(instance, user, n=0):
+    p = Point(n, n)
     plot = Plot(geom=p, instance=instance)
     plot.save_with_user(user)
     return plot
 
 
+def make_tree(instance, user, plot, species=None, diameter=None):
+    tree = Tree(instance=instance, plot=plot, species=species,
+                diameter=diameter)
+    tree.save_with_user(user)
+    return tree
+
+
 @override_settings(FEATURE_BACKEND_FUNCTION=None)
-class WorksManagementTests(OTMTestCase):
+class WorksManagementModelTests(OTMTestCase):
     def setUp(self):
         self.instance = make_instance()
-        self.instance.initialize_udfs([Task.__name__], [Task])
+        self.instance.initialize_udfs([Task.__name__], [Task], dot=True)
         self.user = make_commander_user(self.instance)
         self.team = make_team(self.instance)
         self.plot = make_plot(self.instance, self.user)
@@ -68,9 +79,7 @@ class WorksManagementTests(OTMTestCase):
     def test_work_order(self):
         w = make_work_order(self.instance, self.user)
 
-        t = make_task(self.instance, self.user, self.plot)
-        t.work_order = w
-        t.save_with_user(self.user)
+        t = make_task(self.instance, self.user, self.plot, w)
         self.assertEqual(1, w.task_set.count())
 
         # Test that WorkOrder updated_at field updates when Tasks update
@@ -89,13 +98,15 @@ class WorksManagementTests(OTMTestCase):
 
     def test_cannot_call_save_on_task(self):
         # Task is Auditible and should only allow calling save_with_user.
-        t = make_task(self.instance, self.user, self.plot)
+        w = make_work_order(self.instance, self.user)
+        t = make_task(self.instance, self.user, self.plot, w, save=False)
         with self.assertRaises(UserTrackingException):
             t.save()
 
     def test_task_udf(self):
         t = make_task(self.instance, self.user,
-                      make_plot(self.instance, self.user))
+                      make_plot(self.instance, self.user),
+                      make_work_order(self.instance, self.user))
         t.udfs['Action'] = 'Plant Tree'
         t.save_with_user(self.user)
 
@@ -132,15 +143,19 @@ class WorksManagementTests(OTMTestCase):
         self.assertEqual(2, w2.reference_number)
 
     def test_task_sequence(self):
-        t1 = make_task(self.instance, self.user, self.plot)
-        t2 = make_task(self.instance, self.user, self.plot)
+        w = make_work_order(self.instance, self.user)
+        t1 = make_task(self.instance, self.user, self.plot, w)
+        t2 = make_task(self.instance, self.user, self.plot, w)
         self.assertEqual(1, t1.reference_number)
         self.assertEqual(2, t2.reference_number)
 
         # Sequence numbers should be unique by instance.
         other_instance = make_instance()
-        t1 = make_task(other_instance, self.user, self.plot)
-        t2 = make_task(other_instance, self.user, self.plot)
+        u = make_commander_user(other_instance, 'other_guy')
+        w = make_work_order(other_instance, u)
+        p = make_plot(other_instance, u)
+        t1 = make_task(other_instance, u, p, w)
+        t2 = make_task(other_instance, u, p, w)
         self.assertEqual(1, t1.reference_number)
         self.assertEqual(2, t2.reference_number)
 
@@ -158,7 +173,8 @@ class WorksManagementTests(OTMTestCase):
         self.assertEqual(11, self.instance.work_order_sequence_number)
 
     def test_task_sequence_bulk_create(self):
-        tasks = [make_task(self.instance, self.user, self.plot, save=False)
+        w = make_work_order(self.instance, self.user)
+        tasks = [make_task(self.instance, self.user, self.plot, w, save=False)
                  for _ in range(10)]
 
         value = self.instance.get_next_task_sequence(len(tasks))
@@ -169,3 +185,238 @@ class WorksManagementTests(OTMTestCase):
 
         self.instance.refresh_from_db()
         self.assertEqual(11, self.instance.task_sequence_number)
+
+    def test_task_sequence_audited_bulk_create(self):
+        w = make_work_order(self.instance, self.user)
+        tasks = [make_task(self.instance, self.user, self.plot, w, save=False)
+                 for _ in range(10)]
+
+        value = self.instance.get_next_task_sequence(len(tasks))
+        for i in range(len(tasks)):
+            tasks[i].reference_number = value + i
+
+        bulk_create_with_user(tasks, self.user)
+
+        self.instance.refresh_from_db()
+        self.assertEqual(11, self.instance.task_sequence_number)
+
+
+@override_settings(FEATURE_BACKEND_FUNCTION=None)
+class WorksManagementViewTests(OTMTestCase):
+    def setUp(self):
+        self.instance = make_instance()
+        self.instance.initialize_udfs([Task.__name__], [Task], dot=True)
+        self.user = make_commander_user(self.instance)
+        self.team = make_team(self.instance)
+
+        plot = make_plot(self.instance, self.user, 0)
+        self.species = Species(common_name='foo', instance=self.instance)
+        self.species.save_with_user(self.user)
+        make_tree(self.instance, self.user, plot, species=self.species,
+                  diameter=1)
+
+    def test_create_task_and_work_order(self):
+        work_order_name = 'Go Dog Go'
+        request_dict = {
+            'form_fields': {
+                'task.requested_on': '2016-01-01',
+                'workorder.name': work_order_name
+            },
+            'q': json.dumps({
+                'species.id': {'IS': self.species.pk}
+            })
+        }
+
+        self.assertEqual(WorkOrder.objects.count(), 0)
+        self.assertEqual(Task.objects.count(), 0)
+        self.assertEqual(Plot.objects.count(), 1)
+
+        request = make_request(method='POST', body=json.dumps(request_dict),
+                               instance=self.instance, user=self.user)
+        create_tasks(request, self.instance)
+
+        self.assertEqual(WorkOrder.objects.count(), 1)
+        self.assertEqual(Task.objects.count(), 1)
+
+    def test_bad_field_value(self):
+        work_order_name = 'Go Dog Go'
+        request_dict = {
+            'form_fields': {
+                'task.requested_on': 'not a date',
+                'workorder.name': work_order_name
+            },
+            'q': json.dumps({
+                'species.id': {'IS': self.species.pk}
+            })
+        }
+
+        self.assertEqual(WorkOrder.objects.count(), 0)
+        self.assertEqual(Task.objects.count(), 0)
+        self.assertEqual(Plot.objects.count(), 1)
+
+        request = make_request(method='POST', body=json.dumps(request_dict),
+                               instance=self.instance, user=self.user)
+        with self.assertRaises(ValidationError) as validation_error:
+            create_tasks(request, self.instance)
+
+        # Rollback occurred
+        self.assertEqual(WorkOrder.objects.count(), 0)
+        self.assertEqual(Task.objects.count(), 0)
+
+        # ValidationError.message_dict as expected by
+        # treemap.return_400_if_validation_errors
+        validation_exception = validation_error.exception
+        self.assertTrue(hasattr(validation_exception, 'message_dict'),
+                        'ValidationError must have a message_dict.')
+        message_dict = validation_exception.message_dict
+        self.assertIn('task.requested_on', message_dict)
+
+    def test_bad_field_values(self):
+        pass
+
+    def test_no_work_order(self):
+        pass
+
+    def test_set_protected_udf(self):
+        work_order_name = 'Go Dog Go'
+        action = 'Remove Tree'
+        request_dict = {
+            'form_fields': {
+                'task.requested_on': '2016-01-01',
+                'workorder.name': work_order_name,
+                'task.udf:Action': action
+            },
+            'q': json.dumps({
+                'species.id': {'IS': self.species.pk}
+            })
+        }
+        request = make_request(method='POST', body=json.dumps(request_dict),
+                               instance=self.instance, user=self.user)
+        create_tasks(request, self.instance)
+
+        task = Task.objects.get(instance=self.instance)
+        self.assertEqual(task.udfs['Action'], action)
+
+    def test_set_protected_udf_bad_value(self):
+        work_order_name = 'Go Dog Go'
+        action = 'Invalid choice'
+        request_dict = {
+            'form_fields': {
+                'task.requested_on': '2016-01-01',
+                'workorder.name': work_order_name,
+                'task.udf:Action': action
+            },
+            'q': json.dumps({
+                'species.id': {'IS': self.species.pk}
+            })
+        }
+        request = make_request(method='POST', body=json.dumps(request_dict),
+                               instance=self.instance, user=self.user)
+        with self.assertRaises(ValidationError) as validation_error:
+            create_tasks(request, self.instance)
+
+        self.assertEqual(Task.objects.count(), 0)
+
+        validation_exception = validation_error.exception
+        self.assertTrue(hasattr(validation_exception, 'message_dict'),
+                        'ValidationError must have a message_dict.')
+        message_dict = validation_exception.message_dict
+        self.assertIn('task.udf:Action', message_dict)
+
+    def test_set_multiple_udfs(self):
+        pass
+
+    def test_set_no_such_udf(self):
+        pass
+
+    def test_set_multiple_udfs_bad_values(self):
+        pass
+
+    def test_empty_search_results(self):
+        species = Species(common_name='bar', instance=self.instance)
+        species.save_with_user(self.user)
+
+        work_order_name = 'Go Dog Go'
+        action = 'Remove Tree'
+        request_dict = {
+            'form_fields': {
+                'task.requested_on': 'not a date',
+                'workorder.name': work_order_name,
+                'task.udf:Action': action
+            },
+            'q': json.dumps({
+                'species.id': {'IS': species.pk}
+            })
+        }
+
+        request = make_request(method='POST', body=json.dumps(request_dict),
+                               instance=self.instance, user=self.user)
+        with self.assertRaises(ValidationError) as validation_error:
+            create_tasks(request, self.instance)
+
+        validation_exception = validation_error.exception
+        self.assertTrue(hasattr(validation_exception, 'message_dict'),
+                        'ValidationError must have a message_dict.')
+        message_dict = validation_exception.message_dict
+        self.assertIn('task.requested_on', message_dict)
+        # Empty search should register as a global error
+        self.assertIn('globalErrors', message_dict)
+
+    def test_invalid_search(self):
+        work_order_name = 'Go Dog Go'
+        request_dict = {
+            'form_fields': {
+                'task.requested_on': '2016-01-01',
+                'workorder.name': work_order_name
+            },
+            'q': json.dumps({
+                'species.id': {'IS': 'not a species pk'}
+            })
+        }
+
+        request = make_request(method='POST', body=json.dumps(request_dict),
+                               instance=self.instance, user=self.user)
+        with self.assertRaises(ValidationError) as validation_error:
+            create_tasks(request, self.instance)
+
+        validation_exception = validation_error.exception
+        self.assertTrue(hasattr(validation_exception, 'message_dict'),
+                        'ValidationError must have a message_dict.')
+        message_dict = validation_exception.message_dict
+        # Empty search should register as a global error
+        self.assertIn('globalErrors', message_dict)
+
+    def test_audit_trail(self):
+        plots = [make_plot(self.instance, self.user, i) for i in range(1, 4)]
+        for p in plots:
+            make_tree(self.instance, self.user, p, species=self.species,
+                      diameter=1)
+        work_order_name = 'Go Dog Go'
+        request_dict = {
+            'form_fields': {
+                'task.team': self.team.pk,
+                'task.requested_on': '2016-01-01',
+                'workorder.name': work_order_name
+            },
+            'q': json.dumps({
+                'species.id': {'IS': self.species.pk}
+            })
+        }
+        filter = Filter(request_dict['q'], json.dumps(['Plot']),
+                        self.instance)
+        plots = filter.get_objects(Plot)
+        plot_ids = [p.pk for p in plots]
+
+        request = make_request(method='POST', body=json.dumps(request_dict),
+                               instance=self.instance, user=self.user)
+        create_tasks(request, self.instance)
+
+        self.assertEqual(WorkOrder.objects.count(), 1)
+        self.assertEqual(Task.objects.count(), len(plots))
+
+        audit_qs = Audit.objects.filter(
+            instance=self.instance, user=self.user,
+            action=Audit.Type.Insert, model='Task', field='map_feature',
+            current_value__in=plot_ids)
+
+        self.assertEqual(audit_qs.count(), len(plot_ids))

--- a/opentreemap/works_management/tests.py
+++ b/opentreemap/works_management/tests.py
@@ -271,9 +271,14 @@ class WorksManagementViewTests(OTMTestCase):
         message_dict = validation_exception.message_dict
         self.assertIn('task.requested_on', message_dict)
 
+    # TODO: Like test_bad_field_value, but with multiple bad values,
+    # and assert that the error dict contains complaints for each of them.
     def test_bad_field_values(self):
         pass
 
+    # TODO: Make a request that neither specifies a workorder.name
+    # nor a task.work_order, and assert that the error dict contains
+    # a complaint for task.work_order.
     def test_no_work_order(self):
         pass
 
@@ -323,12 +328,15 @@ class WorksManagementViewTests(OTMTestCase):
         message_dict = validation_exception.message_dict
         self.assertIn('task.udf:Action', message_dict)
 
+    # TODO: try setting values on more than one udf, and assert that
+    # they all get set. Mix protected with regular udfs.
     def test_set_multiple_udfs(self):
         pass
 
-    def test_set_no_such_udf(self):
-        pass
-
+    # TODO: try setting values on more than one udf, where
+    # the values are invalid for those udfs.
+    # Assert that the request throws a ValidationError,
+    # and that the error dict contains complaints for each of them.
     def test_set_multiple_udfs_bad_values(self):
         pass
 

--- a/opentreemap/works_management/urls.py
+++ b/opentreemap/works_management/urls.py
@@ -11,4 +11,5 @@ from works_management import routes
 urlpatterns = patterns(
     '',
     url(r'^work-orders/$', routes.work_orders, name='work_orders'),
+    url(r'^create-tasks/$', routes.create_tasks, name='create_tasks'),
 )

--- a/opentreemap/works_management/views.py
+++ b/opentreemap/works_management/views.py
@@ -46,11 +46,7 @@ def create_tasks(request, instance):
 
     May raise ValidationError.
 
-    On success, returns a dict:
-    {
-        task_ids: [],
-        task_fields: {}
-    }
+    On success, returns an empty dict.
     '''
     request_dict = json.loads(request.body)
     filter_str = request_dict.get('q', '')

--- a/opentreemap/works_management/views.py
+++ b/opentreemap/works_management/views.py
@@ -1,2 +1,170 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+import json
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from django.utils import timezone
+from django.utils.translation import ugettext as _
+
+from opentreemap.util import dotted_split
+
+# from treemap.lib.object_caches import udf_defs
+from treemap.audit import bulk_create_with_user
+from treemap.models import Plot
+from treemap.search import Filter
+from treemap.udf import UserDefinedFieldDefinition
+from treemap.util import package_field_errors
+
+from works_management.forms import TaskForm
+from works_management.models import WorkOrder, Task
+
+
 def work_orders(request, instance):
+    return {}
+
+
+WMM_MODEL_NAME = 'task'
+
+
+def _udf_defs_from_db(instance, model_name):
+    defs = UserDefinedFieldDefinition.objects.filter(instance=instance)
+    if model_name:
+        defs = defs.filter(model_type=model_name)
+    return list(defs)
+
+
+@transaction.atomic
+def create_tasks(request, instance):
+    '''
+    Bulk create Task objects corresponding to Plot objects found in
+    a search using the POST data search query, with field values
+    obtained from the POST data inline-edit form items.
+
+    May raise ValidationError.
+
+    On success, returns a dict:
+    {
+        task_ids: [],
+        task_fields: {}
+    }
+    '''
+    request_dict = json.loads(request.body)
+    filter_str = request_dict.get('q', '')
+    if not filter_str:
+        raise ValidationError(_('A search is required'))
+    form_fields = request_dict.get('form_fields', '')
+    if not form_fields:
+        raise ValidationError(_('The task form is required'))
+
+    SPLIT_TEMPLATE = 'Malformed request - invalid field %s'
+
+    work_order = None
+    create_kwargs = {
+        'instance': instance.pk,
+        'requested_on': timezone.now(),
+        'created_by': request.user.pk,
+        'status': Task.REQUESTED,
+        'priority': Task.MEDIUM
+    }
+
+    udf_kwargs = {}
+
+    validation_errors = {}
+
+    if 'task.work_order_id' in form_fields and \
+            form_fields['task.work_order_id'] is not None and \
+            0 < len(form_fields['task.work_order_id']):
+        work_order = WorkOrder.objects.get(form_fields['task.work_order_id'])
+        del form_fields['task.work_order_id']
+        if 'workorder.name' in form_fields:
+            del form_fields['workorder.name']
+    elif 'workorder.name' in form_fields and \
+            form_fields['workorder.name'] is not None and \
+            0 < len(form_fields['workorder.name']):
+        work_order = WorkOrder(instance=instance,
+                               name=form_fields['workorder.name'],
+                               created_by=request.user,
+                               created_at=timezone.now())
+        work_order.save_with_user(request.user)
+        del form_fields['workorder.name']
+        if 'task.work_order_id' in form_fields:
+            del form_fields['task.work_order_id']
+    else:
+        raise ValidationError(_('A work order must be specified'))
+
+    def validate_field_name(identifier):
+        MODEL_NAME = 'works_management.Task'
+        MESSAGE_FIELD = SPLIT_TEMPLATE % identifier
+        is_udf = False
+        object_name, field = dotted_split(identifier, 2,
+                                          failure_format_string=SPLIT_TEMPLATE)
+        if object_name != WMM_MODEL_NAME:
+            raise TypeError(_('Invalid field %s') % MESSAGE_FIELD)
+        if field.startswith('udf:'):
+            field = field[4:]
+
+            if field not in [udfd.name for udfd
+                             in _udf_defs_from_db(instance, MODEL_NAME)]:
+                raise AttributeError(
+                    _('No custom field with name %s') % MESSAGE_FIELD)
+            is_udf = True
+
+        elif field not in TaskForm._meta.fields:
+            raise AttributeError(_('Invalid field %s') % MESSAGE_FIELD)
+        return field, is_udf
+
+    for (identifier, value) in form_fields.iteritems():
+        field, is_udf = validate_field_name(identifier)
+        if is_udf:
+            udf_kwargs[field] = value
+        else:
+            create_kwargs[field] = value
+    create_kwargs['udfs'] = udf_kwargs
+
+    try:
+        plot_qs = Filter(filter_str, json.dumps(['Plot']), instance)\
+            .get_objects(Plot)
+        plot_count = plot_qs.count()
+    except:
+        plot_count = 0
+
+    if 0 == plot_count:
+        validation_errors['globalErrors'] = [_('No planting sites were found')]
+        create_kwargs['reference_number'] = instance.task_sequence_number
+    else:
+        create_kwargs['reference_number'] = \
+            instance.get_next_task_sequence(plot_count)
+    create_kwargs['work_order'] = work_order.pk
+
+    task_form = TaskForm(create_kwargs)
+    if not task_form.is_valid():
+        form_errors = task_form.errors.copy()
+        if 'udfs' in form_errors:
+            udf_errors = form_errors['udfs']
+            del form_errors['udfs']
+            for message in udf_errors:
+                form_errors.update(json.loads(message))
+        validation_errors.update(package_field_errors(
+            WMM_MODEL_NAME,
+            ValidationError(form_errors)))
+
+    if validation_errors:
+        raise ValidationError(validation_errors)
+
+    cleaned_data = task_form.cleaned_data.copy()
+
+    def task_with_plot(plot):
+        task_args = {'map_feature': plot}
+        task_args.update(cleaned_data)
+        t = Task(**task_args)
+        cleaned_data['reference_number'] += 1
+        return t
+
+    tasks = [task_with_plot(plot) for plot in plot_qs]
+    bulk_create_with_user(tasks, request.user)
+
     return {}


### PR DESCRIPTION
Migrations:
- Make `required_on` and `closed_on` nullable
- Make `Task.work_order` required
- Give the note fields a default value
- Merge
- Resolve that django forms make choice fields required
  even if the model field has a default, no matter what blank is

Other apps:
- Change the 404 decorator to receive additional global errors
  along with field errors
- Provide for model names in the form of <app_name>.<ModelName>
  in `treemap.util`, `treemap.udf`, and `treemap.instance`
- Safe generic utility to get models by app name
- A new setting to interface `treemap` to other apps in a
  more loosely coupled way
- Make UDFs safer by not instantiating the model
- Add `clz` kwarg to `treemap.instance.get_or_create_udf`,
  for cases where the caller already has the model class

Works management:
- Move ref number reservation into `save_with_user`
- Use a `ModelForm` to perform field value validation in the view
- Bulk create with user to produce an audit trail
- Correctly packaged errors on bad regular fields,
  bad udf values, and bad searches

--

Connects to #3051