### PR TITLE
Polygonal search tool not available on xs mobile

### DIFF
--- a/assets/css/sass/partials/_header.scss
+++ b/assets/css/sass/partials/_header.scss
@@ -201,7 +201,11 @@
             width: calc(100% - #{$mobile-search-button-group-width});
         }
         .draw-area {
-            display: none;
+            // JS add/removes 'style="display: inline;"' for desktop users.
+            // Overriding with '!important' for mobile without having to
+            // either make the JS conditional on screen size, or use
+            // a `hidden` class instead of `.show()`, `.hide()`
+            display: none !important;
         }
         &:not(.expanded) {
             &.collapsed {


### PR DESCRIPTION
Easier to add an `!important` than to figure out where `style="display: inline"` is being assigned to the dom element and make it stop doing that.

--

Connects to #3063