### PR TITLE
Support address search with accented characters

### DIFF
--- a/opentreemap/geocode/views.py
+++ b/opentreemap/geocode/views.py
@@ -85,7 +85,7 @@ def geocode(request):
     Search for specified address, returning candidates with lat/long
     """
     key = request.REQUEST.get('key')
-    address = request.REQUEST.get('address')
+    address = request.REQUEST.get('address').encode('utf-8')
 
     if key:
         # See settings.OMGEO_SETTINGS for configuration


### PR DESCRIPTION
OMGEO calls `urllib.urlencode`, which calls `str()` on the address and errors out.

Solution is to encode the address using UTF-8.

Connects #3087