### PR TITLE
Prevent error on Celery launch

### DIFF
--- a/opentreemap/opentreemap/celery.py
+++ b/opentreemap/opentreemap/celery.py
@@ -7,8 +7,6 @@ import rollbar
 from celery import Celery
 from celery.signals import task_failure
 
-from django_statsd.celery import register_celery_events
-
 from django.conf import settings
 
 # set the default Django settings module for the 'celery' program.
@@ -23,6 +21,9 @@ app.config_from_object('django.conf:settings')
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 
 if getattr(settings, 'STATSD_CELERY_SIGNALS', False):
+    # Import here to prevent error on Celery launch
+    # that settings module is not defined
+    from django_statsd.celery import register_celery_events
     register_celery_events()
 
 rollbar_settings = getattr(settings, 'ROLLBAR', {})


### PR DESCRIPTION
In a standalone installation Celery failed to launch, giving the error below. Delaying the import of `register_celery_events` fixes the problem.

```
Traceback (most recent call last):
  File "/usr/local/bin/celery", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/dist-packages/celery/__main__.py", line 30, in main
    main()
  File "/usr/local/lib/python2.7/dist-packages/celery/bin/celery.py", line 81, in main
    cmd.execute_from_commandline(argv)
  File "/usr/local/lib/python2.7/dist-packages/celery/bin/celery.py", line 793, in execute_from_\
commandline
    super(CeleryCommand, self).execute_from_commandline(argv)))
  File "/usr/local/lib/python2.7/dist-packages/celery/bin/base.py", line 309, in execute_from_co\
mmandline
    argv = self.setup_app_from_commandline(argv)
  File "/usr/local/lib/python2.7/dist-packages/celery/bin/base.py", line 469, in setup_app_from_\
commandline
    self.app = self.find_app(app)
  File "/usr/local/lib/python2.7/dist-packages/celery/bin/base.py", line 489, in find_app
    return find_app(app, symbol_by_name=self.symbol_by_name)
  File "/usr/local/lib/python2.7/dist-packages/celery/app/utils.py", line 235, in find_app
    sym = symbol_by_name(app, imp=imp)
  File "/usr/local/lib/python2.7/dist-packages/celery/bin/base.py", line 492, in symbol_by_name
    return symbol_by_name(name, imp=imp)
  File "/usr/local/lib/python2.7/dist-packages/kombu/utils/__init__.py", line 96, in symbol_by_n\
ame
    module = imp(module_name, package=package, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/celery/utils/imports.py", line 101, in import_fro\
m_cwd
    return imp(module, package=package)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/opt/app/core/opentreemap/opentreemap/celery.py", line 10, in <module>
    from django_statsd.celery import register_celery_events
  File "/usr/local/lib/python2.7/dist-packages/django_statsd/__init__.py", line 1, in <module>
    from django_statsd import patches
  File "/usr/local/lib/python2.7/dist-packages/django_statsd/patches/__init__.py", line 8, in <m\
odule>
    patches = getattr(settings, 'STATSD_PATCHES', [])
  File "/usr/local/lib/python2.7/dist-packages/django/conf/__init__.py", line 48, in __getattr__
    self._setup(name)
  File "/usr/local/lib/python2.7/dist-packages/django/conf/__init__.py", line 42, in _setup
    % (desc, ENVIRONMENT_VARIABLE))
django.core.exceptions.ImproperlyConfigured: Requested setting STATSD_PATCHES, but settings are \
not configured. You must either define the environment variable DJANGO_SETTINGS_MODULE or call s\
ettings.configure() before accessing settings.
```