### PR TITLE
Disable search while editing custom area

### DIFF
--- a/assets/css/sass/partials/_header.scss
+++ b/assets/css/sass/partials/_header.scss
@@ -115,7 +115,7 @@
 
     #perform-search {
         margin-top: 2px;
-        padding: 4px 0 5px;
+        padding: 3px 0 5px;
     }
 
     .btn-group {

--- a/assets/css/sass/partials/_layout.scss
+++ b/assets/css/sass/partials/_layout.scss
@@ -311,7 +311,7 @@ body {
 
 .location-search-alternate {
     position: relative;
-    padding: 4px 23px 6px 7px;
+    padding: 3px 23px 5px 7px;
     border: 2px solid $primary-color;
     border-radius: 6px;
     background-color: #f1f2f2;

--- a/opentreemap/treemap/js/src/mapPage/editAreaMode.js
+++ b/opentreemap/treemap/js/src/mapPage/editAreaMode.js
@@ -16,7 +16,8 @@ var map,
 var dom = {
     editArea: '.edit-area',
     saveArea: '.save-area',
-    cancelEdit: '.cancel-edit'
+    cancelEdit: '.cancel-edit',
+    searchTriggers: '#perform-search, #species-typeahead'
 };
 
 function init(options) {
@@ -35,6 +36,7 @@ function init(options) {
 function activate() {
     setTooltips(customTooltip);
     locationSearchUI.showEditAreaControls();
+    enableSearch(false);
 
     polygonFeatureGroup.addLayer(boundarySelect.getCurrentLayer());
     editor.enable();
@@ -65,12 +67,17 @@ function cancelEditing() {
 function deactivate() {
     setTooltips(originalTooltip);
     locationSearchUI.showCustomAreaControls();
+    enableSearch(true);
     if (!editsSaved) {
         editor.revertLayers();
     }
     polygonFeatureGroup.clearLayers();
     editor.disable();
     $(document).off('keydown', onKeyDown);
+}
+
+function enableSearch(shouldEnable) {
+    $(dom.searchTriggers).prop("disabled", !shouldEnable);
 }
 
 function formatTooltip(strings) {

--- a/opentreemap/treemap/templates/instance_base.html
+++ b/opentreemap/treemap/templates/instance_base.html
@@ -190,8 +190,8 @@ ga('set', 'page', pathname);
     <button id="search-reset" class="btn btn-default btn-sm"
         data-event-category="search" data-event-action="reset">{% trans "Reset" %}</button>
   </div>
-  <a id="perform-search" class="btn btn-primary btn-lg btn-block"
-        data-event-category="search" data-event-action="do-search">{% trans "Search" %}</a>
+  <button id="perform-search" class="btn btn-primary btn-lg btn-block"
+        data-event-category="search" data-event-action="do-search">{% trans "Search" %}</button>
 </div>
 {% endblock searchoptions %}
 


### PR DESCRIPTION
* Change "Search" button from `a` to `button` to allow easy disabling
* Disable/enable searching on activate/deactivate of "edit area" mode
* Tweak alignment of top controls

Connects #3092