### PR TITLE
Custom Field management page styling

### DIFF
--- a/assets/css/sass/partials/pages/_admin.scss
+++ b/assets/css/sass/partials/pages/_admin.scss
@@ -876,9 +876,39 @@
     min-height: 195px;
     position: relative;
 
-    .choice-item input {
-        border: 1px dashed #ccc;
-        box-shadow: none;
+    .choice-item {
+        input {
+            border: 1px dashed #ccc;
+            box-shadow: none;
+        }
+        margin-bottom: 4px;
+        // Error messagees normally hidden
+        div.error {
+            display: none;
+        }
+        &.blank-error {
+            [data-item="blank"] {
+                display: block;
+            }
+        }
+        &.reused-error {
+            [data-item="reused"] {
+                display: block;
+            }
+            // Only display one message at a time
+            [data-item="blank"] {
+                display: none;
+            }
+        }
+        &.duplicate-error {
+            [data-item="duplicate"] {
+                display: block;
+            }
+            // Only display one message at a time
+            [data-item="reused"], [data-item="blank"] {
+                display: none;
+            }
+        }
     }
     &:after {
         position: absolute;
@@ -925,9 +955,6 @@
                 display: none;
             }
         }
-    }
-    .choice-item {
-        margin-bottom: 4px;
     }
 }
 

--- a/assets/css/sass/partials/pages/_admin.scss
+++ b/assets/css/sass/partials/pages/_admin.scss
@@ -924,6 +924,12 @@
     }
 }
 
+// When editing a choice custom field,
+// hide the choice trash-can button on the sole remaining pre-existing choice.
+.udf-choices .choice-item:first-child:nth-last-child(2) [data-action="delete"] {
+    display: none;
+}
+
 // Requires all this specificity to override base style
 #management .admin-table tr[data-udf] {
     td {


### PR DESCRIPTION
Use css classes instead of hard-coded styles to hide and show errors
on the Custom Field management page.

Additionally, when editing a choice custom field, hide the choice trash-can button on the sole remaining
pre-existing choice.

--

Connects to OpenTreeMap/otm-addons#1483