### PR TITLE
Force CSRF cookie to be sent on Map Page

### DIFF
--- a/opentreemap/treemap/routes.py
+++ b/opentreemap/treemap/routes.py
@@ -8,6 +8,7 @@ from functools import partial
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import etag
+from django.views.decorators.csrf import ensure_csrf_cookie
 
 from django_tinsel.utils import decorate as do
 from django_tinsel.decorators import (route, json_api_call, render_template,
@@ -48,6 +49,7 @@ index_page = instance_request(misc_views.index)
 
 map_page = do(
     instance_request,
+    ensure_csrf_cookie,
     render_template('treemap/map.html'),
     misc_views.get_map_view_context)
 


### PR DESCRIPTION
Normally this cookie would already be present from other actions / pages, which have forms that use the `{% csrf_token %}` template tag, but if the Map page is the first page visited in a session it would not be set.

This wasn't noticed before because until polygonal search was added, there were no actions on the map page that required a CSRF token but did not first require login (which would set the cookie).

Adding this decorator to the route forces the cookie to be set, fixing the issue.

Connects to #3093