### PR TITLE
Stewardship with date search fix

### DIFF
--- a/opentreemap/treemap/js/src/lib/search.js
+++ b/opentreemap/treemap/js/src/lib/search.js
@@ -164,7 +164,7 @@ function buildFilterObject () {
 
         if ($elem.is(':checked') || ($elem.is(':not(:checkbox)') && val && val.length > 0)) {
             if ($elem.is('[data-date-format]')) {
-                var date = moment($elem.datepicker('getDate'));
+                var date = moment($elem.datepicker('getDate') || $elem.val());
                 if (key_and_pred.pred === "MIN") {
                     date = date.startOf("day");
                 } else if (key_and_pred.pred === "MAX") {

--- a/opentreemap/treemap/search.py
+++ b/opentreemap/treemap/search.py
@@ -185,7 +185,7 @@ def _parse_query_dict(query_dict, mapping):
     #    'udf.plot:<udfd>.date': ...}
     # should match IFF a plot with a UserDefinedCollectionValue
     # matches both the action and the date parts.
-    # By correlary, it should NOT match a plot that has
+    # By corollary, it should NOT match a plot that has
     # one UserDefinedCollectionValue that matches the action,
     # and another that matches the date, neither of which matches both.
     by_type = _parse_by_is_collection_udf(query_dict, mapping)


### PR DESCRIPTION
Changes
------------
Searches that include multiple queries on a single collection UserDefinedFieldDefinition need to be grouped together into a single subquery.

The previous search created a separate subquery for each one, and so incorrectly matched entities that had one UserDefinedCollectionValue that matched the action, another that matched the date, but none that matched both.

This fix necessitated test changes.

Now also includes a JS fix that threw, and prevented the frontend from submitting a search.

Testing Notes
------------------
Note that the fix does not cause the search cache to be flushed, so you will see the same wrong results if you execute the exact same query.

Anonymous boundary search is an easy way to game the cache. Just change the boundary a little each time.

I tried disabling the search cache in settings, but it resulted in an exception that prevented search from completing. I did not investigate the exception because it appeared to be out of scope.

--

Connects to #3029