### PR TITLE
Management pages in "General" category

### DIFF
--- a/opentreemap/manage_treemap/js/src/basicInfo.js
+++ b/opentreemap/manage_treemap/js/src/basicInfo.js
@@ -1,0 +1,13 @@
+"use strict";
+
+var adminPage = require('manage_treemap/lib/adminPage.js'),
+    inlineEditForm = require('treemap/lib/inlineEditForm.js'),
+    alerts = require('treemap/lib/alerts.js'),
+    reverse = require('reverse'),
+    config = require('treemap/lib/config.js');
+
+adminPage.init();
+inlineEditForm.init({
+    updateUrl: reverse.site_config(config.instance.url_name),
+    section: '#basic-info',
+});

--- a/opentreemap/manage_treemap/js/src/branding.js
+++ b/opentreemap/manage_treemap/js/src/branding.js
@@ -1,0 +1,72 @@
+"use strict";
+
+var $ = require('jquery'),
+    _ = require('lodash'),
+    uploadPanel = require('treemap/lib/uploadPanel.js'),
+    inlineEditForm = require('treemap/lib/inlineEditForm.js'),
+    url = require('url'),
+    adminPage = require('manage_treemap/lib/adminPage.js'),
+    alerts = require('treemap/lib/alerts.js'),
+    config = require('treemap/lib/config.js'),
+    reverse = require('reverse');
+
+require('jscolor');
+
+var dom = {
+    colorInput: {
+        primary: 'input[name="instance.config.scss_variables.primary-color"]',
+        secondary: 'input[name="instance.config.scss_variables.secondary-color"]'
+    },
+    colorDisplay: {
+        primary: '[data-field="instance.config.scss_variables.primary-color"][data-class="display"]',
+        secondary: '[data-field="instance.config.scss_variables.secondary-color"][data-class="display"]',
+    },
+    useDefaultColors: '.js-use-default-colors',
+    linkSelector: '#application-css',
+    uploadPanel: {
+        imageElement: '#site-logo'
+    }
+};
+
+adminPage.init();
+
+var cssUrl = reverse.scss() + '?' + config.instance.scssQuery,
+    form = inlineEditForm.init({
+        updateUrl: reverse.branding(config.instance.url_name),
+        section: '#branding',
+        errorCallback: alerts.errorCallback
+    });
+
+uploadPanel.init(dom.uploadPanel);
+
+$(dom.useDefaultColors).click(function () {
+    setColor(dom.colorInput.primary, '8BAA3D');
+    setColor(dom.colorInput.secondary, '56ABB2');
+});
+
+form.cancelStream.onValue(function () {
+    setColor(dom.colorInput.primary, $(dom.colorDisplay.primary).attr('data-value'));
+    setColor(dom.colorInput.secondary, $(dom.colorDisplay.secondary).attr('data-value'));
+});
+
+function setColor(selector, value) {
+    $(selector)[0].color.fromString(value);
+}
+
+// On save update the CSS url to use the new colors
+form.saveOkStream
+    .map('.formData')
+    .map(function (fieldDictionary) {
+        var cssUrlObject = url.parse(cssUrl, true),
+            query = _.reduce(fieldDictionary, function (query, value, name) {
+                var field = name.split(".").pop();
+                if (value) {
+                    query[field] = value;
+                }
+                return query;
+            }, cssUrlObject.query);
+        cssUrlObject.search = null;  // Force url.format to parse query object
+        cssUrl = url.format(cssUrlObject);
+        return cssUrl;
+    })
+    .onValue($(dom.linkSelector), 'attr', 'href');

--- a/opentreemap/manage_treemap/js/src/embed.js
+++ b/opentreemap/manage_treemap/js/src/embed.js
@@ -1,0 +1,138 @@
+"use strict";
+
+var $ = require('jquery'),
+    _ = require('lodash'),
+    adminPage = require('manage_treemap/lib/adminPage.js'),
+    config = require('treemap/lib/config.js'),
+    reverse = require('reverse'),
+    format = require('util').format,
+    Bacon = require('baconjs');
+
+adminPage.init();
+
+// constants
+var $iframeSizeCustom = $('#frame-size-custom'),
+    $iframeWidth = $('#iframe-width'),
+    $iframeHeight = $('#iframe-height'),
+    $previewButton = $('#preview'),
+    $snippet = $('#snippet'),
+    $iframeContainer = $('#iframe-container'),
+    $sizeChoiceRadio = $('input[name="frame-size"]'),
+    $alerts = $('.alert'),
+    $messages = $('.message');
+
+// mutable state
+var errors = [],
+    isCustom = false,
+    curSnippet = $snippet.val();
+
+// utility functions
+var focusSelectSnippet = function () {
+    if (!_.isEmpty($snippet.val())) {
+        $snippet.focus().select();
+    }
+};
+
+var validateCustom = function () {
+    var errors = [],
+        w = $iframeWidth.val(),
+        h = $iframeHeight.val();
+
+    if (_.isEmpty(w) && _.isEmpty(h)) {
+        errors.push('both-required');
+    } else if (_.isEmpty(w)) {
+        errors.push('width-required');
+    } else if (_.isEmpty(h)) {
+        errors.push('height-required');
+    }
+
+    var wOutOfRange = false,
+        hOutOfRange = false;
+
+    if (!_.isEmpty(w)) {
+        w = parseInt(w, 10);
+        wOutOfRange = w < 768 || 10000 < w;
+    }
+    if (!_.isEmpty(h)) {
+        h = parseInt(h, 10);
+        hOutOfRange = h < 450 || 10000 < h;
+    }
+
+    if (wOutOfRange && hOutOfRange) {
+        errors.push('both-range-error');
+    } else if (wOutOfRange) {
+        errors.push('width-range-error');
+    } else if (hOutOfRange) {
+        errors.push('height-range-error');
+    }
+
+    return errors;
+};
+
+var validate = function ($target) {
+    return isCustom ? validateCustom() : [];
+};
+
+var formatCustomSnippet = function () {
+    return format($iframeSizeCustom.val(),
+                  $iframeWidth.val(), $iframeHeight.val());
+};
+
+var fetchSnippet = function ($target) {
+    if (!isCustom) {
+        return $target.val();
+    } else if (_.isEmpty(errors)) {
+        return formatCustomSnippet();
+    } else {
+        return '';
+    }
+};
+
+var hideMessages = function () {
+    $messages.addClass('hidden');
+    $alerts.addClass('hidden');
+};
+
+var showMessages = function (errorIds) {
+    if (!_.isEmpty(errorIds)) {
+        var selectors = _.map(errorIds, function (id) {
+            return '#' + id;
+        }).join(',');
+        $(selectors).removeClass('hidden');
+        $alerts.removeClass('hidden');
+    }
+};
+
+var updateDisplay = function () {
+    hideMessages();
+    $snippet.val(curSnippet);
+    focusSelectSnippet();
+    $iframeContainer.empty();
+    if (!isCustom) {
+        $iframeContainer.html(curSnippet);
+    }
+};
+
+var handleChoice = function (ev) {
+    isCustom = $iframeSizeCustom.get(0) === ev.target;
+    var $target = $(ev.target);
+
+    errors = validate($target);
+    curSnippet = fetchSnippet($target);
+    updateDisplay();
+};
+
+$sizeChoiceRadio.on('change', handleChoice);
+
+var doPreview = function (ev) {
+    ev.preventDefault();
+    errors = validateCustom();
+    curSnippet = fetchSnippet($iframeSizeCustom);
+    updateDisplay();
+    $iframeContainer.html(curSnippet);
+    showMessages(errors);
+};
+
+$previewButton.on('click', doPreview);
+
+focusSelectSnippet();

--- a/opentreemap/manage_treemap/js/src/greenInfrastructure.js
+++ b/opentreemap/manage_treemap/js/src/greenInfrastructure.js
@@ -1,0 +1,21 @@
+"use strict";
+
+var inlineEditForm = require('treemap/lib/inlineEditForm.js'),
+    adminPage = require('manage_treemap/lib/adminPage.js'),
+    alerts = require('treemap/lib/alerts.js'),
+    config = require('treemap/lib/config.js'),
+    reverse = require('reverse'),
+    $ = require('jquery');
+
+
+adminPage.init();
+
+var form = inlineEditForm.init({
+    updateUrl: reverse.green_infrastructure(config.instance.url_name),
+    section: '#gsi',
+    errorCallback: alerts.errorCallback
+});
+form.saveOkStream.onValue(function () {
+    location.reload(false);
+});
+$('[data-toggle="tooltip"]').tooltip();

--- a/opentreemap/manage_treemap/js/src/link.js
+++ b/opentreemap/manage_treemap/js/src/link.js
@@ -1,0 +1,12 @@
+"use strict";
+
+var adminPage = require('manage_treemap/lib/adminPage.js'),
+    inlineEditForm = require('treemap/lib/inlineEditForm.js'),
+    reverse = require('reverse'),
+    config = require('treemap/lib/config.js');
+
+adminPage.init();
+inlineEditForm.init({
+    updateUrl: reverse.external_link(config.instance.url_name),
+    section: '#external-links',
+});

--- a/opentreemap/manage_treemap/js/src/units.js
+++ b/opentreemap/manage_treemap/js/src/units.js
@@ -1,0 +1,14 @@
+"use strict";
+
+var inlineEditForm = require('treemap/lib/inlineEditForm.js'),
+    adminPage = require('manage_treemap/lib/adminPage.js'),
+    alerts = require('treemap/lib/alerts.js'),
+    config = require('treemap/lib/config.js'),
+    reverse = require('reverse');
+
+adminPage.init();
+inlineEditForm.init({
+    updateUrl: reverse.units_endpoint(config.instance.url_name),
+    section: '#units',
+    errorCallback: alerts.errorCallback
+});

--- a/opentreemap/manage_treemap/routes.py
+++ b/opentreemap/manage_treemap/routes.py
@@ -100,3 +100,9 @@ benefits = admin_route(
            views.benefits_convs),
     PUT=json_do(views.update_benefits)
 )
+
+units = admin_route(
+    GET=do(render_template('manage_treemap/units.html'), views.units),
+    PUT=json_do(update_instance_fields_with_validator,
+                views.units_validator)
+)

--- a/opentreemap/manage_treemap/routes.py
+++ b/opentreemap/manage_treemap/routes.py
@@ -10,8 +10,10 @@ from django_tinsel.utils import decorate as do
 
 import manage_treemap.views.management as views
 import manage_treemap.views.photo as photo_views
+import manage_treemap.views.green_infrastructure as green_infrastructure_views
 
 from importer.views import list_imports
+from manage_treemap.views import update_instance_fields_with_validator
 from otm_comments.views import comment_moderation
 from treemap.decorators import (require_http_method, admin_instance_request,
                                 return_400_if_validation_errors)
@@ -26,6 +28,44 @@ management = do(
 
 admin_counts = admin_route(
     GET=do(json_api_call, views.admin_counts)
+)
+
+site_config = admin_route(
+    GET=do(render_template('manage_treemap/basic.html'),
+           views.site_config_basic_info),
+    PUT=json_do(update_instance_fields_with_validator,
+                views.site_config_validator)
+)
+
+external_link = admin_route(
+    GET=do(render_template('manage_treemap/link.html'),
+           views.external_link),
+    PUT=json_do(views.update_external_link)
+)
+
+branding = admin_route(
+    GET=do(render_template('manage_treemap/branding.html'),
+           views.branding),
+    PUT=json_do(update_instance_fields_with_validator,
+                views.branding_validator)
+)
+
+embed = admin_route(
+    GET=do(render_template('manage_treemap/embed.html'),
+           views.embed)
+)
+
+update_logo = do(
+    require_http_method("POST"),
+    admin_instance_request,
+    json_api_call,
+    return_400_if_validation_errors,
+    views.update_logo)
+
+green_infrastructure = admin_route(
+    GET=do(render_template('manage_treemap/green_infrastructure.html'),
+           green_infrastructure_views.site_config_green_infrastructure),
+    PUT=json_do(green_infrastructure_views.green_infrastructure),
 )
 
 comment_moderation = admin_route(

--- a/opentreemap/manage_treemap/templates/manage_treemap/basic.html
+++ b/opentreemap/manage_treemap/templates/manage_treemap/basic.html
@@ -6,44 +6,44 @@
 {% block admin_title %}{% trans "Basic Information" %}{% endblock %}
 
 {% block tab_content %}
-<div id="basic-info">
-    <div class="page-header">
-        <div class="page-header-toggles">
-            <i class="icon-menu" id="toggle-sidebar"></i>
+    <div id="basic-info">
+        <div class="page-header">
+            <div class="page-header-toggles">
+                <i class="icon-menu" id="toggle-sidebar"></i>
+            </div>
+            <div class="page-header-title">
+                <h1>{% trans "Basic Information" %}</h1>
+            </div>
+            {% include "treemap/partials/form_buttons.html" %}
         </div>
-        <div class="page-header-title">
-            <h1>{% trans "Basic Information" %}</h1>
-        </div>
-        {% include "treemap/partials/form_buttons.html" %}
-    </div>
-    <div class="content">
-        {% block messages %}
-        {% endblock %}
-        <form>
-            <fieldset>
-                <label>{% trans "URL" %}</label>
-                <div class="field-view">{{site_config.url}}</div>
-                {% for label, identifier in site_config.fields %}
-                    {% field label from identifier in request.instance withtemplate "treemap/field/div.html" %}
-                {% endfor %}
-                <label>{% trans "i-Tree Regions" %}</label>
-                <div class="field-view">
-                {% with itree_regions=request.instance.itree_regions %}
-                {% if itree_regions %}
-                    {% for itree_region in itree_regions %}
-                        {{ itree_region }}{% if not forloop.last %},&nbsp;{% endif %}
+        <div class="content">
+            {% block messages %}
+            {% endblock %}
+            <form>
+                <fieldset>
+                    <label>{% trans "URL" %}</label>
+                    <div class="field-view">{{site_config.url}}</div>
+                    {% for label, identifier in site_config.fields %}
+                        {% field label from identifier in request.instance withtemplate "treemap/field/div.html" %}
                     {% endfor %}
-                {% else %}
-                    {% trans "None" %}
-                {% endif %}
-                {% endwith %}
-                </div>
-            </fieldset>
-        </form>
+                    <label>{% trans "i-Tree Regions" %}</label>
+                    <div class="field-view">
+                        {% with itree_regions=request.instance.itree_regions %}
+                            {% if itree_regions %}
+                                {% for itree_region in itree_regions %}
+                                    {{ itree_region }}{% if not forloop.last %},&nbsp;{% endif %}
+                                {% endfor %}
+                            {% else %}
+                                {% trans "None" %}
+                            {% endif %}
+                        {% endwith %}
+                    </div>
+                </fieldset>
+            </form>
+        </div>
     </div>
-</div>
 {% endblock tab_content %}
 
 {% block scripts %}
-{% render_bundle 'js/manage_treemap/basicInfo' %}
+    {% render_bundle 'js/manage_treemap/basicInfo' %}
 {% endblock scripts %}

--- a/opentreemap/manage_treemap/templates/manage_treemap/basic.html
+++ b/opentreemap/manage_treemap/templates/manage_treemap/basic.html
@@ -1,0 +1,49 @@
+{% extends "manage_treemap/management_base.html" %}
+{% load render_bundle from webpack_loader %}
+{% load i18n %}
+{% load form_extras %}
+
+{% block admin_title %}{% trans "Basic Information" %}{% endblock %}
+
+{% block tab_content %}
+<div id="basic-info">
+    <div class="page-header">
+        <div class="page-header-toggles">
+            <i class="icon-menu" id="toggle-sidebar"></i>
+        </div>
+        <div class="page-header-title">
+            <h1>{% trans "Basic Information" %}</h1>
+        </div>
+        {% include "treemap/partials/form_buttons.html" %}
+    </div>
+    <div class="content">
+        {% block messages %}
+        {% endblock %}
+        <form>
+            <fieldset>
+                <label>{% trans "URL" %}</label>
+                <div class="field-view">{{site_config.url}}</div>
+                {% for label, identifier in site_config.fields %}
+                    {% field label from identifier in request.instance withtemplate "treemap/field/div.html" %}
+                {% endfor %}
+                <label>{% trans "i-Tree Regions" %}</label>
+                <div class="field-view">
+                {% with itree_regions=request.instance.itree_regions %}
+                {% if itree_regions %}
+                    {% for itree_region in itree_regions %}
+                        {{ itree_region }}{% if not forloop.last %},&nbsp;{% endif %}
+                    {% endfor %}
+                {% else %}
+                    {% trans "None" %}
+                {% endif %}
+                {% endwith %}
+                </div>
+            </fieldset>
+        </form>
+    </div>
+</div>
+{% endblock tab_content %}
+
+{% block scripts %}
+{% render_bundle 'js/manage_treemap/basicInfo' %}
+{% endblock scripts %}

--- a/opentreemap/manage_treemap/templates/manage_treemap/branding.html
+++ b/opentreemap/manage_treemap/templates/manage_treemap/branding.html
@@ -1,0 +1,53 @@
+{% extends "manage_treemap/management_base.html" %}
+{% load render_bundle from webpack_loader %}
+{% load i18n %}
+{% load form_extras %}
+{% load instance_config %}
+
+{% block admin_title %}{% trans "Branding" %}{% endblock %}
+
+{% block tab_content %}
+    <div id="branding">
+        <div class="page-header">
+            <div class="page-header-toggles">
+                <i class="icon-menu" id="toggle-sidebar"></i>
+            </div>
+            <div class="page-header-title">
+                <h1>{% trans "Branding" %}</h1>
+            </div>
+            {% if request.instance|feature_enabled:"custom_colors" or request.instance|feature_enabled:"custom_logo" %}
+                {% include "treemap/partials/form_buttons.html" %}
+            {% endif %}
+        </div>
+
+        <div class="content">
+            <form>
+                <fieldset>
+                    {% if request.instance|feature_enabled:"custom_colors" %}
+                        {% for label, identifier in branding.color_fields %}
+                            {% with class="color {pickerPosition:\'right\'}" %}
+                                {% field label from identifier withtemplate "treemap/field/div.html" %}
+                            {% endwith %}
+                        {% endfor %}
+                    {% endif %}
+                </fieldset>
+            </form>
+            {% if request.instance|feature_enabled:"custom_logo" %}
+                <a data-toggle="modal" data-target="#upload-panel" data-class="display" class="btn">{% trans "Upload Logo" %}</a>
+            {% endif %}
+            <a data-class="edit" class="btn js-use-default-colors" style="display: none;">
+                {% trans "Use Default Colors" %}
+            </a>
+        </div>
+
+    </div>
+{% endblock tab_content %}
+
+{% block endbody %}
+    {% trans "Upload Logo" as upload_title %}
+    {% include "treemap/partials/upload_file.html" with title=upload_title upload_url=logo_endpoint %}
+{% endblock endbody %}
+
+{% block scripts %}
+    {% render_bundle 'js/manage_treemap/branding' %}
+{% endblock scripts %}

--- a/opentreemap/manage_treemap/templates/manage_treemap/embed.html
+++ b/opentreemap/manage_treemap/templates/manage_treemap/embed.html
@@ -7,39 +7,39 @@
 {% block admin_title %}{% trans "Embed" %}{% endblock %}
 
 {% block tab_content %}
-<div id="embed">
-    <div class="page-header">
-        <div class="page-header-toggles">
-            <i class="icon-menu" id="toggle-sidebar"></i>
+    <div id="embed">
+        <div class="page-header">
+            <div class="page-header-toggles">
+                <i class="icon-menu" id="toggle-sidebar"></i>
+            </div>
+            <div class="page-header-title">
+                <h1>{% trans "Embed" %}</h1>
+            </div>
         </div>
-        <div class="page-header-title">
-            <h1>{% trans "Embed" %}</h1>
-        </div>
-    </div>
 
-    <div class="content">
-        <h3>{% trans "Embed this tree map on another site" %}</h3>
-        <p>Use the HTML snippet below to include this tree map on another website you administer.</p>
-        <form>
-            <fieldset>
-                <ul class="frame-size-choice list-inline container-fluid">
-                    <li class="pull-left">
-                        <label class="checkbox">
-                            <input type="radio" name="frame-size" id="frame-size-standard" value="{{ iframe_standard }}" checked="checked">
-                            <span>{% trans "Standard" %}</span> <span class="reduced">{{ iframe_standard_width }}x{{ iframe_standard_height }}</span>
-                        </label>
-                    </li>
-                    <li class="pull-left">
-                        <label class="checkbox">
-                            <input type="radio" name="frame-size" id="frame-size-wide" value="{{ iframe_wide }}">
-                            <span>{% trans "Wide" %}</span> <span class="reduced">{{ iframe_wide_width }}x{{ iframe_wide_height }}</span>
-                        </label>
-                    </li>
-                    <li class="pull-left">
-                        <label class="checkbox">
-                            <input type="radio" name="frame-size" id="frame-size-custom" value="{{ iframe_custom }}">
-                            <span>{% trans "Custom " %}</span>
-                            <span class="width-height-group">
+        <div class="content">
+            <h3>{% trans "Embed this tree map on another site" %}</h3>
+            <p>Use the HTML snippet below to include this tree map on another website you administer.</p>
+            <form>
+                <fieldset>
+                    <ul class="frame-size-choice list-inline container-fluid">
+                        <li class="pull-left">
+                            <label class="checkbox">
+                                <input type="radio" name="frame-size" id="frame-size-standard" value="{{ iframe_standard }}" checked="checked">
+                                <span>{% trans "Standard" %}</span> <span class="reduced">{{ iframe_standard_width }}x{{ iframe_standard_height }}</span>
+                            </label>
+                        </li>
+                        <li class="pull-left">
+                            <label class="checkbox">
+                                <input type="radio" name="frame-size" id="frame-size-wide" value="{{ iframe_wide }}">
+                                <span>{% trans "Wide" %}</span> <span class="reduced">{{ iframe_wide_width }}x{{ iframe_wide_height }}</span>
+                            </label>
+                        </li>
+                        <li class="pull-left">
+                            <label class="checkbox">
+                                <input type="radio" name="frame-size" id="frame-size-custom" value="{{ iframe_custom }}">
+                                <span>{% trans "Custom " %}</span>
+                                <span class="width-height-group">
                                 <input id="iframe-width" class="input-sm" type="number"
                                        placeholder="{% trans "width" %}" min="{{ iframe_custom_min_width }}" step="10" max="10000">
                                 &times;
@@ -47,43 +47,43 @@
                                        placeholder="{% trans "height" %}" min="{{ iframe_custom_min_height }}" step="10" max="10000">
                                 <button id="preview" class="btn-link">{% trans "Preview " %}</button>
                             </span>
-                        </label>
-                    </li>
-                </ul>
-                <div class="hidden alert alert-danger">
-                    <div id="width-required" class="message hidden">
-                        {% trans "The width is required for a preview." %}
+                            </label>
+                        </li>
+                    </ul>
+                    <div class="hidden alert alert-danger">
+                        <div id="width-required" class="message hidden">
+                            {% trans "The width is required for a preview." %}
+                        </div>
+                        <div id="height-required" class="message hidden">
+                            {% trans "The height is required for a preview." %}
+                        </div>
+                        <div id="both-required" class="message hidden">
+                            {% trans "The width and height are required for a preview." %}
+                        </div>
+                        <div id="width-range-error" class="message hidden">
+                            {% trans "The width must be between" %} {{ iframe_custom_min_width }} {% trans "and" %} 10,000.
+                        </div>
+                        <div id="height-range-error" class="message hidden">
+                            {% trans "The height must be between" %} {{ iframe_custom_min_height }} {% trans "and" %} 10,000.
+                        </div>
+                        <div id="both-range-error" class="message hidden">
+                            {% trans "The width must be between" %} {{ iframe_custom_min_width }} {% trans "and" %} 10,000,
+                            {% trans "and the height must be between" %} {{ iframe_custom_min_height }} {% trans "and" %} 10,000.
+                        </div>
                     </div>
-                    <div id="height-required" class="message hidden">
-                        {% trans "The height is required for a preview." %}
-                    </div>
-                    <div id="both-required" class="message hidden">
-                        {% trans "The width and height are required for a preview." %}
-                    </div>
-                    <div id="width-range-error" class="message hidden">
-                        {% trans "The width must be between" %} {{ iframe_custom_min_width }} {% trans "and" %} 10,000.
-                    </div>
-                    <div id="height-range-error" class="message hidden">
-                        {% trans "The height must be between" %} {{ iframe_custom_min_height }} {% trans "and" %} 10,000.
-                    </div>
-                    <div id="both-range-error" class="message hidden">
-                        {% trans "The width must be between" %} {{ iframe_custom_min_width }} {% trans "and" %} 10,000,
-                        {% trans "and the height must be between" %} {{ iframe_custom_min_height }} {% trans "and" %} 10,000.
-                    </div>
-                </div>
-                <input id="snippet" type="text" readonly="readonly" value="{{ iframe_standard }}">
-            </fieldset>
-        </form>
-        <div id="iframe-container">
-            {{ iframe_standard|safe }}
+                    <input id="snippet" type="text" readonly="readonly" value="{{ iframe_standard }}">
+                </fieldset>
+            </form>
+            <div id="iframe-container">
+                {{ iframe_standard|safe }}
+            </div>
         </div>
     </div>
-</div>
 {% endblock tab_content %}
 
 {% block endbody %}
 {% endblock endbody %}
 
 {% block scripts %}
-{% render_bundle 'js/manage_treemap/embed' %}
+    {% render_bundle 'js/manage_treemap/embed' %}
 {% endblock scripts %}

--- a/opentreemap/manage_treemap/templates/manage_treemap/embed.html
+++ b/opentreemap/manage_treemap/templates/manage_treemap/embed.html
@@ -1,0 +1,89 @@
+{% extends "manage_treemap/management_base.html" %}
+{% load render_bundle from webpack_loader %}
+{% load i18n %}
+{% load form_extras %}
+{% load instance_config %}
+
+{% block admin_title %}{% trans "Embed" %}{% endblock %}
+
+{% block tab_content %}
+<div id="embed">
+    <div class="page-header">
+        <div class="page-header-toggles">
+            <i class="icon-menu" id="toggle-sidebar"></i>
+        </div>
+        <div class="page-header-title">
+            <h1>{% trans "Embed" %}</h1>
+        </div>
+    </div>
+
+    <div class="content">
+        <h3>{% trans "Embed this tree map on another site" %}</h3>
+        <p>Use the HTML snippet below to include this tree map on another website you administer.</p>
+        <form>
+            <fieldset>
+                <ul class="frame-size-choice list-inline container-fluid">
+                    <li class="pull-left">
+                        <label class="checkbox">
+                            <input type="radio" name="frame-size" id="frame-size-standard" value="{{ iframe_standard }}" checked="checked">
+                            <span>{% trans "Standard" %}</span> <span class="reduced">{{ iframe_standard_width }}x{{ iframe_standard_height }}</span>
+                        </label>
+                    </li>
+                    <li class="pull-left">
+                        <label class="checkbox">
+                            <input type="radio" name="frame-size" id="frame-size-wide" value="{{ iframe_wide }}">
+                            <span>{% trans "Wide" %}</span> <span class="reduced">{{ iframe_wide_width }}x{{ iframe_wide_height }}</span>
+                        </label>
+                    </li>
+                    <li class="pull-left">
+                        <label class="checkbox">
+                            <input type="radio" name="frame-size" id="frame-size-custom" value="{{ iframe_custom }}">
+                            <span>{% trans "Custom " %}</span>
+                            <span class="width-height-group">
+                                <input id="iframe-width" class="input-sm" type="number"
+                                       placeholder="{% trans "width" %}" min="{{ iframe_custom_min_width }}" step="10" max="10000">
+                                &times;
+                                <input id="iframe-height" class="input-sm" type="number"
+                                       placeholder="{% trans "height" %}" min="{{ iframe_custom_min_height }}" step="10" max="10000">
+                                <button id="preview" class="btn-link">{% trans "Preview " %}</button>
+                            </span>
+                        </label>
+                    </li>
+                </ul>
+                <div class="hidden alert alert-danger">
+                    <div id="width-required" class="message hidden">
+                        {% trans "The width is required for a preview." %}
+                    </div>
+                    <div id="height-required" class="message hidden">
+                        {% trans "The height is required for a preview." %}
+                    </div>
+                    <div id="both-required" class="message hidden">
+                        {% trans "The width and height are required for a preview." %}
+                    </div>
+                    <div id="width-range-error" class="message hidden">
+                        {% trans "The width must be between" %} {{ iframe_custom_min_width }} {% trans "and" %} 10,000.
+                    </div>
+                    <div id="height-range-error" class="message hidden">
+                        {% trans "The height must be between" %} {{ iframe_custom_min_height }} {% trans "and" %} 10,000.
+                    </div>
+                    <div id="both-range-error" class="message hidden">
+                        {% trans "The width must be between" %} {{ iframe_custom_min_width }} {% trans "and" %} 10,000,
+                        {% trans "and the height must be between" %} {{ iframe_custom_min_height }} {% trans "and" %} 10,000.
+                    </div>
+                </div>
+                <input id="snippet" type="text" readonly="readonly" value="{{ iframe_standard }}">
+            </fieldset>
+        </form>
+        <div id="iframe-container">
+            {{ iframe_standard|safe }}
+        </div>
+    </div>
+</div>
+{% endblock tab_content %}
+
+{% block endbody %}
+{% endblock endbody %}
+
+{% block scripts %}
+{% render_bundle 'js/manage_treemap/embed' %}
+{% endblock scripts %}

--- a/opentreemap/manage_treemap/templates/manage_treemap/green_infrastructure.html
+++ b/opentreemap/manage_treemap/templates/manage_treemap/green_infrastructure.html
@@ -1,0 +1,141 @@
+{% extends "manage_treemap/management_base.html" %}
+{% load render_bundle from webpack_loader %}
+{% load i18n %}
+{% load form_extras %}
+{% load instance_config %}
+{% load util %}
+
+{% block admin_title %}{% trans "Green Infrastructure" %}{% endblock %}
+
+{% block tab_content %}
+    <div id="gsi">
+        <div class="page-header">
+            <div class="page-header-toggles">
+                <i class="icon-menu" id="toggle-sidebar"></i>
+            </div>
+            <div class="page-header-title">
+                <h1>{% trans "Green Infrastructure" %}</h1>
+            </div>
+            {% include "treemap/partials/form_buttons.html" %}
+        </div>
+
+        <div class="content">
+
+            <form>
+                {% if request.instance|feature_enabled:"green_infrastructure" %}
+                    <p class="alert alert-info" data-class="edit" style="display:none">
+                        {% blocktrans %}
+                            If a green infrastructure resource is deactivated, those resources will be hidden from your map but the data will not be deleted. Please check the box to reactivate that resource.
+                        {% endblocktrans %}
+                    </p>
+                    <h3 class="management-header">{% trans "Green Infrastructure Resources" %}</h3>
+                    <table class="table admin-table">
+                        <thead>
+                        <tr>
+                            <th>{% trans "Active" %}</th>
+                            <th>{% trans "Resource" %}</th>
+                            <th>{% trans "Singular" %}</th>
+                            <th>{% trans "Plural" %}</th>
+                            <th>
+                                {% trans "Show Ecobenefits" %}
+                                <i class="icon-info-circled"
+                                   title="{% trans 'Display the ecobenefits publicly on the map' %}"
+                                   data-toggle="tooltip"
+                                   data-container="body"
+                                   data-placement="top"></i>
+                            </th>
+                            <th>
+                                {% trans "Runoff Coefficient" %}
+                                {% captureas helptext %}
+                                    {% blocktrans with resource=term.Resource.singular %}
+                                        Fraction of runoff that reaches the {{resource}} due to slope and material.
+                                        Between 0 and 1.
+                                    {% endblocktrans %}
+                                {% endcaptureas %}
+                                <i class="icon-info-circled"
+                                   title="{{ helptext }}"
+                                   data-toggle="tooltip"
+                                   data-container="body"
+                                   data-placement="top"></i>
+                            </th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {% for setting in gsi_model_fields %}
+                            <tr>
+                                <td>{% include "manage_treemap/partials/map_feature_type_checkbox.html" %}</td>
+                                <td>{{ setting.label }}</td>
+                                {% for field in setting.fields %}
+                                    {% include "treemap/field/td.html" %}
+                                {% endfor %}
+                                <td>{% include "manage_treemap/partials/should_show_eco.html"%}</td>
+                                <td>{% include "manage_treemap/partials/diversion_rate.html"%}</td>
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                {% endif %}
+                <h3 class="management-header">{% trans "Terminology" %}</h3>
+                <p>
+                    {% blocktrans %}
+                        Enter the text you would like to use to refer to green infrastructure features. The default is "Resource", which appears in "Add a Resource" and other places on your tree map.
+                    {% endblocktrans %}
+                </p>
+                <table class="table admin-table">
+                    <thead>
+                    <tr>
+                        <th>{% trans "Term" %}</th>
+                        <th>{% trans "Singular" %}</th>
+                        <th>{% trans "Plural" %}</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for label, fields in terminology_fields.items %}
+                        <tr>
+                            <td>{{ label }}</td>
+                            {% for field in fields %}
+                                {% include "treemap/field/td.html" %}
+                            {% endfor %}
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+                <h3 class="management-header">{% trans "Annual Rainfall" %}</h3>
+                <p>
+                    {% blocktrans %}
+                        Enter the total you would like to use to refer to annual rainfall.
+                    {% endblocktrans %}
+                </p>
+                <table class="table admin-table">
+                    <thead>
+                    <tr>
+                        <th>{% trans "Term" %}</th>
+                        <th>{% trans "Amount" %}</th>
+                        <th>
+                            {% trans "Unit" %}
+                            <i class="icon-info-circled"
+                               title="{% trans 'The Unit can be changed on the Units admin screen' %}"
+                               data-toggle="tooltip"
+                               data-container="body"
+                               data-placement="top"></i>
+                        </th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for label, field, units in annual_rainfall_fields %}
+                        <tr>
+                            <td>{{ label }}</td>
+                            {% include "treemap/field/td.html" %}
+                            <td>{{ units }}</td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </form>
+        </div>
+    </div>
+{% endblock %}
+
+{% block scripts %}
+    {% render_bundle 'js/manage_treemap/greenInfrastructure' %}
+{% endblock scripts %}

--- a/opentreemap/manage_treemap/templates/manage_treemap/link.html
+++ b/opentreemap/manage_treemap/templates/manage_treemap/link.html
@@ -1,0 +1,42 @@
+{% extends "manage_treemap/management_base.html" %}
+{% load render_bundle from webpack_loader %}
+{% load i18n %}
+{% load form_extras %}
+
+{% block admin_title %}{% trans "Basic Information" %}{% endblock %}
+
+{% block tab_content %}
+    <div id="external-links">
+        <div class="page-header">
+            <div class="page-header-toggles">
+                <i class="icon-menu" id="toggle-sidebar"></i>
+            </div>
+            <div class="page-header-title">
+                <h1>{% trans "External Links" %}</h1>
+            </div>
+            {% include "treemap/partials/form_buttons.html" %}
+        </div>
+        <div class="content">
+            Specify an external link to be placed at the top of the tree detail page.
+            <form>
+                <fieldset>
+                    {% trans "See this tree on SomeOtherSite.org" as placeholder %}
+                    {% with extra='placeholder="'|add:placeholder|add:'"' %}
+                        {% field _("Link Text") from "instance.config.externalLink.text" in request.instance withtemplate "treemap/field/div.html" %}
+                    {% endwith %}
+                    {% trans "https://www.SomeOtherTreeSite.org/tree/#{tree.id}" as placeholder %}
+                    {% with extra='placeholder="'|add:placeholder|add:'"' %}
+                        {% field _("Link URL") from "instance.config.externalLink.url" in request.instance withtemplate "treemap/field/div.html" %}
+                    {% endwith %}
+                    {% blocktrans with tokens=tokens|safe %}
+                        <h5 data-class="edit" style="display: none;">Type {{ tokens }} where that id field should appear in the URL.</h5>
+                    {% endblocktrans %}
+                </fieldset>
+            </form>
+        </div>
+    </div>
+{% endblock tab_content %}
+
+{% block scripts %}
+    {% render_bundle 'js/manage_treemap/link' %}
+{% endblock scripts %}

--- a/opentreemap/manage_treemap/templates/manage_treemap/management_base.html
+++ b/opentreemap/manage_treemap/templates/manage_treemap/management_base.html
@@ -101,6 +101,8 @@
                     {% include "manage_treemap/partials/admin_link.html" with view="importer" title=_("Bulk Uploader") icon="icon-tools" %}
 
                     {% include "manage_treemap/partials/admin_link.html" with view="benefits" title=_("Ecosystem Benefits") icon="icon-leaf" %}
+
+                    {% include "manage_treemap/partials/admin_link.html" with view="units_endpoint" title=_("Units") icon="icon-book" %}
                     </tbody>
                 </table>
             </div>

--- a/opentreemap/manage_treemap/templates/manage_treemap/management_base.html
+++ b/opentreemap/manage_treemap/templates/manage_treemap/management_base.html
@@ -42,6 +42,35 @@
                 </table>
                 <table class="nav nav-list">
                     <tbody>
+                    {% with is_active=request|is_current_view:"site_config green_infrastructure branding embed external_link" %}
+                        <tr {% if is_active %}class="active"{% endif %}>
+                            <td>
+                                {% include "manage_treemap/partials/admin_icon_link.html" with view="site_config" icon="icon-cog" %}
+                            </td>
+                            <td>
+                                <div class="full-section">
+                                    <a class="section-title" data-toggle="collapse" data-target="#nav-general">
+                                        {% trans "General" %}
+                                        {% if is_active %}
+                                            <i class="icon-down-open"></i>
+                                        {% else %}
+                                            <i class="icon-left-open"></i>
+                                        {% endif %}
+                                    </a>
+                                    <ul class="nav collapse {% if is_active %}in{% endif %}" id="nav-general">
+                                        {% include "manage_treemap/partials/nested_link.html" with view="site_config" title=_("Basic Information") %}
+                                        {% if request.instance|feature_enabled:"green_infrastructure" %}
+                                            {% include "manage_treemap/partials/nested_link.html" with view="green_infrastructure" title=_("Green Infrastructure") %}
+                                        {% endif %}
+                                        {% include "manage_treemap/partials/nested_link.html" with view="branding" title=_("Branding") %}
+                                        {% include "manage_treemap/partials/nested_link.html" with view="embed" title=_("Embed") %}
+                                        {% include "manage_treemap/partials/nested_link.html" with view="external_link" title=_("External Link") %}
+                                    </ul>
+                                </div>
+                            </td>
+                        </tr>
+                    {% endwith %}
+
                     {% block extra_menu_items %}
                     {% endblock extra_menu_items %}
 

--- a/opentreemap/manage_treemap/templates/manage_treemap/partials/diversion_rate.html
+++ b/opentreemap/manage_treemap/templates/manage_treemap/partials/diversion_rate.html
@@ -3,7 +3,7 @@
      data-class="display"
      data-value="{{ setting.diversion_rate }}"
      data-type="float">
-  {{ setting.diversion_rate }}
+    {{ setting.diversion_rate }}
 </div>
 <div class="field-edit"
      style="display: none;"
@@ -11,13 +11,13 @@
      data-class="edit"
      data-value="{{ setting.diversion_rate }}"
      data-type="float">
-  <input name="instance.config.map_feature_config.{{ setting.model_name }}.diversion_rate"
-         value="{{ setting.diversion_rate }}"
-         {% if not setting.diversion_rate_applies %}
-         disabled="disabled"
-         {% endif %}
-         type="text"
-         class="form-control">
+    <input name="instance.config.map_feature_config.{{ setting.model_name }}.diversion_rate"
+           value="{{ setting.diversion_rate }}"
+        {% if not setting.diversion_rate_applies %}
+           disabled="disabled"
+        {% endif %}
+           type="text"
+           class="form-control">
 </div>
 <div class="text-danger"
      style="display: none;"

--- a/opentreemap/manage_treemap/templates/manage_treemap/partials/diversion_rate.html
+++ b/opentreemap/manage_treemap/templates/manage_treemap/partials/diversion_rate.html
@@ -1,0 +1,28 @@
+<div class="field-view"
+     data-field="instance.config.map_feature_config.{{ setting.model_name }}.diversion_rate"
+     data-class="display"
+     data-value="{{ setting.diversion_rate }}"
+     data-type="float">
+  {{ setting.diversion_rate }}
+</div>
+<div class="field-edit"
+     style="display: none;"
+     data-field="instance.config.map_feature_config.{{ setting.model_name }}.diversion_rate"
+     data-class="edit"
+     data-value="{{ setting.diversion_rate }}"
+     data-type="float">
+  <input name="instance.config.map_feature_config.{{ setting.model_name }}.diversion_rate"
+         value="{{ setting.diversion_rate }}"
+         {% if not setting.diversion_rate_applies %}
+         disabled="disabled"
+         {% endif %}
+         type="text"
+         class="form-control">
+</div>
+<div class="text-danger"
+     style="display: none;"
+     data-class="error"
+     data-field="instance.config.map_feature_config.{{ setting.model_name }}.diversion_rate"
+     data-value="{{ setting.diversion_rate }}"
+     data-type="float">
+</div>

--- a/opentreemap/manage_treemap/templates/manage_treemap/partials/map_feature_type_checkbox.html
+++ b/opentreemap/manage_treemap/templates/manage_treemap/partials/map_feature_type_checkbox.html
@@ -1,0 +1,25 @@
+<span class="field-view"
+      data-bool-true-text="Yes"
+      data-bool-false-text="No"
+      data-field="instance.config.map_feature_types.{{ setting.model_name }}"
+      data-class="display"
+      data-value="{{ setting.checked }}"
+      data-type="bool">
+      {% if setting.checked %}Yes{% else %}No{% endif %}
+</span>
+<span class="field-edit"
+      style="display: none;"
+      data-field="instance.config.map_feature_types.{{ setting.model_name }}"
+      data-class="edit"
+      data-type="bool">
+  <input name="instance.config.map_feature_types.{{ setting.model_name }}"
+         {% if setting.is_la_model %}
+         disabled="disabled"
+         {% endif %}
+         {% if setting.checked %}
+         checked="checked"
+         {% endif %}
+         type="checkbox"
+         class="edit"
+         />
+</span>

--- a/opentreemap/manage_treemap/templates/manage_treemap/partials/should_show_eco.html
+++ b/opentreemap/manage_treemap/templates/manage_treemap/partials/should_show_eco.html
@@ -1,0 +1,47 @@
+<div class="field-view"
+     data-bool-true-text="Yes"
+     {% if setting.should_show_eco_applies %}
+     data-bool-false-text="No"
+     {% else %}
+     data-bool-false-text="{{ setting.should_show_eco_indicator }}"
+     {% endif %}
+     data-field="instance.config.map_feature_config.{{ setting.model_name }}.should_show_eco"
+     data-class="display"
+     data-value="{{ setting.should_show_eco }}"
+     data-type="bool">
+     {% if not setting.should_show_eco_applies %}
+        {{ setting.should_show_eco_indicator }}
+     {% elif setting.should_show_eco %}
+        Yes
+     {% else %}
+        No
+     {% endif %}
+</div>
+<div class="field-edit"
+     style="display: none;"
+     data-field="instance.config.map_feature_config.{{ setting.model_name }}.should_show_eco"
+     data-class="edit"
+     data-type="bool">
+  <input name="instance.config.map_feature_config.{{ setting.model_name }}.should_show_eco"
+         {% if setting.is_la_model or not setting.should_show_eco_applies %}
+         disabled="disabled"
+         {% endif %}
+         {% if setting.should_show_eco_applies and setting.should_show_eco %}
+         checked="checked"
+         {% endif %}
+         type="checkbox"
+         class="edit"
+         />
+  {% if not setting.should_show_eco_applies %}
+  <label for="instance.config.map_feature_config.{{ setting.model_name }}.should_show_eco">
+    {{ setting.should_show_eco_indicator }}
+  </label>
+  {% endif %}
+</div>
+<div class="text-danger"
+     style="display: none;"
+     data-class="error"
+     data-field="instance.config.map_feature_config.{{ setting.model_name }}.should_show_eco"
+     data-value="{{ setting.should_show_eco }}"
+     data-type="float">
+</div>

--- a/opentreemap/manage_treemap/templates/manage_treemap/partials/units_table.html
+++ b/opentreemap/manage_treemap/templates/manage_treemap/partials/units_table.html
@@ -1,0 +1,19 @@
+<h3 class="management-header">{{ spec.title }}</h3>
+<table class="units table table-hover admin-table">
+  <thead>
+    <tr>
+      <th style="width:40%;">Field</th>
+      <th style="width:40%;">Units</th>
+      <th style="width:20%;">Decimal Digits</th>
+    </tr>
+  </thead>
+  <tbody>
+  {% for value_spec in spec.items %}
+    <tr>
+      <td>{{ value_spec.label }}</td>
+      {% include "treemap/field/td.html" with field=value_spec.units %}
+      {% include "treemap/field/td.html" with field=value_spec.digits %}
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>

--- a/opentreemap/manage_treemap/templates/manage_treemap/units.html
+++ b/opentreemap/manage_treemap/templates/manage_treemap/units.html
@@ -1,0 +1,31 @@
+{% extends "manage_treemap/management_base.html" %}
+{% load render_bundle from webpack_loader %}
+{% load i18n %}
+
+{% block admin_title %}{% trans "Units" %}{% endblock %}
+
+{% block tab_content %}
+<div id="units">
+    <div class="page-header">
+        <div class="page-header-toggles">
+            <i class="icon-menu" id="toggle-sidebar"></i>
+        </div>
+        <div class="page-header-title">
+            <h1>{% trans "Units" %}</h1>
+        </div>
+        {% include "treemap/partials/form_buttons.html" %}
+    </div>
+
+    <div class="content">
+        <form onsubmit="return false;">
+          {% for spec in value_specs %}
+            {% include "manage_treemap/partials/units_table.html" %}
+          {% endfor %}
+        </form>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{% render_bundle 'js/manage_treemap/units' %}
+{% endblock scripts %}

--- a/opentreemap/manage_treemap/tests/test_general.py
+++ b/opentreemap/manage_treemap/tests/test_general.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import json
+
+from django.core.exceptions import ValidationError
+from django.test.utils import override_settings
+
+from manage_treemap.views.management import update_logo, update_external_link
+from treemap.tests import (make_instance, make_commander_user, make_request,
+                           media_dir, LocalMediaTestCase)
+from treemap.tests.base import OTMTestCase
+
+
+class LogoUpdateTest(LocalMediaTestCase):
+    def update_logo(self, filename):
+        self.instance = make_instance()
+        file = self.load_resource(filename)
+        return update_logo(make_request(file=file), self.instance)
+
+    @media_dir
+    def test_update_logo(self):
+        self.update_logo('tree1.gif')
+        path = self.instance.logo.path
+        self.assertPathExists(path)
+
+        self.update_logo('tree2.jpg')
+        self.assertPathExists(self.instance.logo.path)
+
+    @media_dir
+    def test_non_image(self):
+        with self.assertRaises(ValidationError):
+            self.update_logo('nonImage.jpg')
+
+    @media_dir
+    @override_settings(MAXIMUM_IMAGE_SIZE=10)
+    def test_rejects_large_files(self):
+        with self.assertRaises(ValidationError):
+            self.update_logo('tree2.jpg')
+
+
+class ExternalLinkUpdateTest(OTMTestCase):
+    def setUp(self):
+        self.instance = make_instance()
+        self.commander = make_commander_user(self.instance)
+
+    def update_links(self, updates):
+        json_updates = json.dumps(updates)
+        request = make_request(method='PUT',
+                               body=json_updates,
+                               user=self.commander)
+
+        update_external_link(request, self.instance)
+
+    def test_update_some_values(self):
+        self.update_links({
+            'instance.config.externalLink.text': 'A link',
+            'instance.config.externalLink.url': 'http://opentreemap.org/'
+        })
+
+        self.assertEqual(self.instance.config['externalLink.text'], 'A link')
+        self.assertEqual(self.instance.config['externalLink.url'],
+                         'http://opentreemap.org/')
+
+        self.update_links({
+            'instance.config.externalLink.text': 'Different text',
+        })
+
+        self.assertEqual(self.instance.config['externalLink.text'],
+                         'Different text')
+        self.assertEqual(self.instance.config['externalLink.url'],
+                         'http://opentreemap.org/')
+
+        self.update_links({
+            'instance.config.externalLink.url': 'http://example.com/',
+        })
+
+        self.assertEqual(self.instance.config['externalLink.text'],
+                         'Different text')
+        self.assertEqual(self.instance.config['externalLink.url'],
+                         'http://example.com/')
+
+        self.update_links({
+            'instance.config.externalLink.text': '',
+            'instance.config.externalLink.url': ''
+        })
+
+        self.assertEqual(self.instance.config['externalLink.text'], '')
+        self.assertEqual(self.instance.config['externalLink.url'], '')
+
+    def test_error_on_blank(self):
+        self.assertIsNone(self.instance.config.get('externalLink'))
+
+        with self.assertRaises(ValidationError):
+            self.update_links({
+                # omitted text is the same as blank text before configuration
+                'instance.config.externalLink.url': 'http://opentremap.org/'
+            })
+
+        with self.assertRaises(ValidationError):
+            self.update_links({
+                'instance.config.externalLink.text': 'A link'
+                # omitted url is the same as a blank url before configuration
+            })
+
+        with self.assertRaises(ValidationError):
+            self.update_links({
+                'instance.config.externalLink.text': '',
+                'instance.config.externalLink.url': 'http://opentreemap.org/'
+            })
+
+        with self.assertRaises(ValidationError):
+            self.update_links({
+                'instance.config.externalLink.text': None,
+                'instance.config.externalLink.url': 'http://opentreemap.org/'
+            })
+
+        with self.assertRaises(ValidationError):
+            self.update_links({
+                'instance.config.externalLink.text': 'A link',
+                'instance.config.externalLink.url': ''
+            })
+
+        with self.assertRaises(ValidationError):
+            self.update_links({
+                'instance.config.externalLink.text': 'A link',
+                'instance.config.externalLink.url': None
+            })
+
+    def test_error_on_tokens(self):
+        # No errors
+        self.update_links({
+            'instance.config.externalLink.text': 'A link',
+            'instance.config.externalLink.url': 'http://opentreemap.org/plot/#{planting_site.id}'  # NOQA
+        })
+
+        with self.assertRaises(ValidationError):
+            self.update_links({
+                'instance.config.externalLink.text': 'A link',
+                'instance.config.externalLink.url': 'http://opentreemap.org/plot/#{planting_site.width}'  # NOQA
+            })
+
+        with self.assertRaises(ValidationError):
+            self.update_links({
+                'instance.config.externalLink.text': 'A link',
+                'instance.config.externalLink.url': 'http://opentreemap.org/plot/#{bioswale.id}'  # NOQA
+            })
+
+        with self.assertRaises(ValidationError):
+            self.update_links({
+                'instance.config.externalLink.text': 'A link',
+                'instance.config.externalLink.url': 'http://opentreemap.org/plot/#{id}'  # NOQA
+            })
+
+        with self.assertRaises(ValidationError):
+            self.update_links({
+                'instance.config.externalLink.text': 'A link',
+                'instance.config.externalLink.url': 'http://opentreemap.org/plot/#{}'  # NOQA
+            })
+
+    def test_error_with_omitted_field(self):
+        # No errors
+        self.update_links({
+            'instance.config.externalLink.text': 'A link',
+            'instance.config.externalLink.url': 'http://opentreemap.org/plot/#{planting_site.id}'  # NOQA
+        })
+
+        # text is required while url is still in effect
+        with self.assertRaises(ValidationError):
+            self.update_links({
+                'instance.config.externalLink.text': '',
+            })
+
+        # url is required while text is still in effect
+        with self.assertRaises(ValidationError):
+            self.update_links({
+                'instance.config.externalLink.url': ''
+            })

--- a/opentreemap/manage_treemap/tests/test_gsi.py
+++ b/opentreemap/manage_treemap/tests/test_gsi.py
@@ -1,0 +1,254 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+import json
+
+from django.core.exceptions import ValidationError
+from django.test.utils import override_settings
+
+from manage_treemap.views.green_infrastructure import green_infrastructure
+from opentreemap.util import dotted_split
+from stormwater.models import Bioswale
+from treemap.audit import (FieldPermission)
+from treemap.instance import Instance
+from treemap.tests import (make_instance, make_commander_user, make_request,
+                           make_commander_role)
+from treemap.tests.base import OTMTestCase
+from treemap.units import get_value_display_attr
+
+
+@override_settings(FEATURE_BACKEND_FUNCTION=None)
+class AddMapFeatureTypeTest(OTMTestCase):
+    def setUp(self):
+        self.instance = make_instance()
+
+    def test_exception_adding_duplicate(self):
+        self.assertRaises(ValidationError, self.instance.add_map_feature_types,
+                          ['Plot'])
+
+    def test_exception_adding_nonexistent(self):
+        self.assertRaises(ValidationError, self.instance.add_map_feature_types,
+                          ['IDoNotExist'])
+
+    def test_type_and_permissions_are_added(self):
+        role = make_commander_role(self.instance)
+        current_map_feature_types = set(self.instance.map_feature_types)
+        self.instance.add_map_feature_types(['RainGarden'])
+        instance = Instance.objects.get(pk=self.instance.pk)
+        self.assertEqual(set(instance.map_feature_types),
+                         current_map_feature_types | {'RainGarden'})
+        qs = FieldPermission.objects.filter(
+            instance=instance, model_name='RainGarden',
+            field_name='drainage_area', role=role)
+        self.assertEqual(len(qs), 1)
+
+
+@override_settings(FEATURE_BACKEND_FUNCTION=None)
+class GreenInfrastructureUpdateTest(OTMTestCase):
+    def setUp(self):
+        self.instance = make_instance()
+        self.commander = make_commander_user(self.instance)
+
+    def tearDown(self):
+        self.instance.remove_map_feature_types(keep=['Plot'])
+
+    def _activate(self, mft):
+        already_activated = self.instance.map_feature_types
+        if mft not in already_activated:
+            self.instance.add_map_feature_types([mft])
+
+    def test_add_map_feature_types(self):
+        mft = 'Bioswale'
+        key = 'map_feature_types'
+        updates = {
+            'instance.config.{}.{}'.format(key, mft): True
+        }
+
+        json_updates = json.dumps(updates)
+        request = make_request(method='PUT',
+                               body=json_updates,
+                               user=self.commander)
+
+        green_infrastructure(request, self.instance)
+
+        map_feature_types = self.instance.config.get(key)
+        self.assertGreater(len(map_feature_types), 0)
+        self.assertIn(mft, map_feature_types)
+
+    def test_remove_map_feature_types(self):
+        mft = 'Bioswale'
+        key = 'map_feature_types'
+        request_key = 'instance.config.{}.{}'.format(key, mft)
+        updates = {request_key: True}
+
+        json_updates = json.dumps(updates)
+        request = make_request(method='PUT',
+                               body=json_updates,
+                               user=self.commander)
+
+        green_infrastructure(request, self.instance)
+
+        updates[request_key] = False
+
+        json_updates = json.dumps(updates)
+        request = make_request(method='PUT',
+                               body=json_updates,
+                               user=self.commander)
+
+        green_infrastructure(request, self.instance)
+        map_feature_types = self.instance.config.get(key)
+        self.assertNotIn(mft, map_feature_types)
+
+    def test_map_feature_applicable_constant_validation(self):
+        self._activate('Bioswale')
+
+        request_key = 'instance.config.map_feature_config.Bioswale'\
+                      '.diversion_rate'
+        updates = {request_key: 'x'}
+        json_updates = json.dumps(updates)
+        request = make_request(method='PUT',
+                               body=json_updates,
+                               user=self.commander)
+
+        with self.assertRaises(ValidationError):
+            green_infrastructure(request, self.instance)
+
+        updates = {request_key: -.166}
+        json_updates = json.dumps(updates)
+        request = make_request(method='PUT',
+                               body=json_updates,
+                               user=self.commander)
+
+        with self.assertRaises(ValidationError):
+            green_infrastructure(request, self.instance)
+
+        updates = {request_key: 1.66}
+        json_updates = json.dumps(updates)
+        request = make_request(method='PUT',
+                               body=json_updates,
+                               user=self.commander)
+
+        with self.assertRaises(ValidationError):
+            green_infrastructure(request, self.instance)
+
+        updates = {request_key: .166}
+        json_updates = json.dumps(updates)
+        request = make_request(method='PUT',
+                               body=json_updates,
+                               user=self.commander)
+
+        green_infrastructure(request, self.instance)
+
+        bioswale_config = Bioswale.get_config(self.instance)
+        self.assertEqual(bioswale_config.get('diversion_rate', None), 0.166)
+
+    def test_map_feature_inapplicable_config_validation(self):
+        self._activate('RainBarrel')
+        request_key = 'instance.config.map_feature_config.RainBarrel'\
+                      '.should_show_eco'
+        updates = {request_key: True}
+        json_updates = json.dumps(updates)
+        request = make_request(method='PUT',
+                               body=json_updates,
+                               user=self.commander)
+
+        with self.assertRaises(ValidationError):
+            green_infrastructure(request, self.instance)
+
+    def test_show_eco_without_rainfall(self):
+        self._activate('Bioswale')
+        self.assertIsNone(self.instance.annual_rainfall_inches)
+        Bioswale.set_config_property(self.instance, 'diversion_rate', .9)
+
+        request_key = 'instance.config.map_feature_config.Bioswale'\
+                      '.should_show_eco'
+        updates = {request_key: True}
+        json_updates = json.dumps(updates)
+        request = make_request(method='PUT',
+                               body=json_updates,
+                               user=self.commander)
+
+        with self.assertRaises(ValidationError):
+            green_infrastructure(request, self.instance)
+
+    def test_show_eco_without_constant(self):
+        self._activate('Bioswale')
+        self.instance.annual_rainfall_inches = 8.0
+        Bioswale.set_config_property(self.instance, 'diversion_rate', None)
+
+        request_key = 'instance.config.map_feature_config.Bioswale'\
+                      '.should_show_eco'
+        updates = {request_key: True}
+        json_updates = json.dumps(updates)
+        request = make_request(method='PUT',
+                               body=json_updates,
+                               user=self.commander)
+
+        with self.assertRaises(ValidationError):
+            green_infrastructure(request, self.instance)
+
+    def test_annual_rainfall_config_validation(self):
+        request_key = 'instance.config.annual_rainfall_inches'
+        updates = {request_key: 'x'}
+        json_updates = json.dumps(updates)
+        request = make_request(method='PUT',
+                               body=json_updates,
+                               user=self.commander)
+
+        with self.assertRaises(ValidationError):
+            green_infrastructure(request, self.instance)
+
+        updates[request_key] = '-10'
+        json_updates = json.dumps(updates)
+        request = make_request(method='PUT',
+                               body=json_updates,
+                               user=self.commander)
+
+        with self.assertRaises(ValidationError):
+            green_infrastructure(request, self.instance)
+
+        updates[request_key] = '10'
+        json_updates = json.dumps(updates)
+        request = make_request(method='PUT',
+                               body=json_updates,
+                               user=self.commander)
+
+        green_infrastructure(request, self.instance)
+
+        self.assertEqual(self.instance.annual_rainfall_inches, 10.0)
+
+    def test_annual_rainfall_unit_conversion(self):
+        rainfall_unit_key, rainfall_unit = get_value_display_attr(
+            self.instance, 'greenInfrastructure', 'rainfall', 'units')
+        self.assertEqual(rainfall_unit, 'in')
+        __, __, unit_key = dotted_split(rainfall_unit_key, 3, maxsplit=2)
+
+        self.assertEqual(rainfall_unit, 'in')
+
+        config_key = 'annual_rainfall_inches'
+        request_key = 'instance.config.annual_rainfall_inches'
+        updates = {request_key: 10}
+        json_updates = json.dumps(updates)
+        request = make_request(method='PUT',
+                               body=json_updates,
+                               user=self.commander)
+
+        green_infrastructure(request, self.instance)
+
+        self.assertEqual(self.instance.config[config_key], 10.0)
+
+        self.instance.config[unit_key] = 'cm'
+
+        config_key = 'annual_rainfall_inches'
+        request_key = 'instance.config.{}'.format(config_key)
+        updates = {request_key: 25.4}
+        json_updates = json.dumps(updates)
+        request = make_request(method='PUT',
+                               body=json_updates,
+                               user=self.commander)
+
+        green_infrastructure(request, self.instance)
+
+        self.assertEqual(self.instance.config[config_key], 10.0)

--- a/opentreemap/manage_treemap/tests/test_units.py
+++ b/opentreemap/manage_treemap/tests/test_units.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django.test.utils import override_settings
+
+from manage_treemap.views.management import units
+from treemap.tests import make_instance
+from treemap.tests.base import OTMTestCase
+from treemap.json_field import set_attr_on_json_field
+
+
+# Enable green infrastructure (by disabling feature checks)
+@override_settings(FEATURE_BACKEND_FUNCTION=None)
+class UnitsTest(OTMTestCase):
+    def setUp(self):
+        pass
+
+    def test_basic_specs(self):
+        instance = make_instance(url_name='basic')
+        specs = units(None, instance)
+
+        self.assertIn('value_specs', specs)
+        value_specs = specs['value_specs']
+        self.assertEqual(len(value_specs), 4)
+
+        s1, s2, s3, s4 = tuple(value_specs)
+
+        self.assertEqual(s1.get('title'), 'Planting Site Fields')
+        self.assertEqual(s2.get('title'), 'Tree Fields')
+        self.assertEqual(s3.get('title'), 'Eco Benefits')
+        self.assertEqual(s4.get('title'), 'Green Infrastructure')
+
+        i1, i2, i3, i4 = \
+            s1.get('items'), s2.get('items'), s3.get('items'), s4.get('items')
+
+        self.assertEqual(len(i1), 2)
+        self.assertEqual(len(i2), 3)
+        self.assertEqual(len(i3), 5)
+        self.assertEqual(len(i4), 2)
+
+        self.assertEqual(i1[0].get('label'), 'Planting Site Width')
+        self.assertEqual(i1[1].get('label'), 'Planting Site Length')
+
+        self.assertEqual(i2[0].get('label'), 'Tree Diameter')
+        self.assertEqual(i2[1].get('label'), 'Tree Height')
+        self.assertEqual(i2[2].get('label'), 'Canopy Height')
+
+        self.assertEqual(i3[0].get('label'), 'Energy conserved')
+        self.assertEqual(i3[1].get('label'), 'Stormwater filtered')
+        self.assertEqual(i3[2].get('label'), 'Air quality improved')
+        self.assertEqual(i3[3].get('label'), 'Carbon dioxide removed')
+        self.assertEqual(i3[4].get('label'), 'Carbon dioxide stored to date')
+
+        self.assertEqual(i4[0].get('label'), 'Annual Rainfall')
+        self.assertEqual(i4[1].get('label'), 'Area')
+
+    def test_rain_barrel_specs(self):
+        instance = make_instance(url_name='test-rainbarrel')
+        instance.add_map_feature_types(['RainBarrel'])
+        specs = units(None, instance)
+
+        value_specs = specs.get('value_specs')
+        self.assertEqual(len(value_specs), 5)
+
+        rain_barrel_spec = value_specs[3]
+
+        self.assertEqual(rain_barrel_spec.get('title'), 'Rain Barrel Fields')
+
+        rain_barrel_items = rain_barrel_spec.get('items')
+
+        self.assertEqual(len(rain_barrel_items), 1)
+        self.assertEqual(rain_barrel_items[0].get('label'), 'Capacity')
+
+    def test_water_barrel_specs(self):
+        """
+        Rename Rain Barrel to Water Barrel, and make sure that is
+        what units returns.
+        """
+        instance = make_instance(url_name='test-waterbarrel')
+        instance.add_map_feature_types(['RainBarrel'])
+        set_attr_on_json_field(instance,
+                               'config.terms.RainBarrel.singular',
+                               'Water Barrel')
+        specs = units(None, instance)
+
+        value_specs = specs.get('value_specs')
+        self.assertEqual(len(value_specs), 5)
+
+        rain_barrel_spec = value_specs[3]
+
+        self.assertEqual(rain_barrel_spec.get('title'), 'Water Barrel Fields')
+
+    def test_rain_garden_specs(self):
+        instance = make_instance(url_name='test-raingarden')
+        instance.add_map_feature_types(['RainGarden'])
+
+        specs = units(None, instance)
+
+        value_specs = specs.get('value_specs')
+        self.assertEqual(len(value_specs), 5)
+
+        rain_barrel_spec = value_specs[3]
+
+        self.assertEqual(rain_barrel_spec.get('title'), 'Rain Garden Fields')
+
+        rain_barrel_items = rain_barrel_spec.get('items')
+
+        self.assertEqual(len(rain_barrel_items), 1)
+        self.assertEqual(rain_barrel_items[0].get('label'),
+                         'Adjacent Drainage Area')

--- a/opentreemap/manage_treemap/tests/test_urls.py
+++ b/opentreemap/manage_treemap/tests/test_urls.py
@@ -22,12 +22,16 @@ class PagesLoadTestCase(UrlTestCase):
         return reverse(django_url_name,
                        kwargs={'instance_url_name': self.instance.url_name})
 
-    # TODO: test redirect once site_config page is moved
-    # def test_management_redirects(self):
-    #     self.assert_page_redirects('management', 'site_config')
+    def test_management_redirects(self):
+        self.assert_page_redirects('management', 'site_config')
 
     def test_pages_load(self):
-        self.assert_page_loads('benefits')
-        self.assert_page_loads('importer')
+        self.assert_page_loads('site_config')
+        self.assert_page_loads('green_infrastructure')
+        self.assert_page_loads('branding')
+        self.assert_page_loads('embed')
+        self.assert_page_loads('external_link')
         self.assert_page_loads('comment_moderation')
         self.assert_page_loads('photo_review_admin')
+        self.assert_page_loads('importer')
+        self.assert_page_loads('benefits')

--- a/opentreemap/manage_treemap/urls.py
+++ b/opentreemap/manage_treemap/urls.py
@@ -31,4 +31,5 @@ urlpatterns = patterns(
 
     url(r'^bulk-uploader/$', routes.importer, name='importer'),
     url(r'^benefits/$', routes.benefits, name='benefits'),
+    url(r'^units/$', routes.units, name='units_endpoint'),
 )

--- a/opentreemap/manage_treemap/urls.py
+++ b/opentreemap/manage_treemap/urls.py
@@ -10,6 +10,15 @@ urlpatterns = patterns(
     '',
     url(r'^$', routes.management, name='management'),
     url(r'^notifications/$', routes.admin_counts, name='admin_counts'),
+
+    url(r'^site-config/$', routes.site_config, name='site_config'),
+    url(r'^external-link/$', routes.external_link, name='external_link'),
+    url(r'^branding/$', routes.branding, name='branding'),
+    url(r'^embed/$', routes.embed, name='embed'),
+    url(r'^logo/$', routes.update_logo, name='logo_endpoint'),
+    url(r'^green-infrastructure/$', routes.green_infrastructure,
+        name='green_infrastructure'),
+
     url(r'^comment-moderation/$', routes.comment_moderation,
         name='comment_moderation_admin'),
 

--- a/opentreemap/manage_treemap/views/__init__.py
+++ b/opentreemap/manage_treemap/views/__init__.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from django.core.exceptions import ValidationError
+
+from opentreemap.util import json_from_request, dotted_split
+from treemap.json_field import is_json_field_reference, set_attr_on_json_field
+from treemap.util import package_field_errors
+
+
+def update_instance_fields_with_validator(validation_fn):
+    def f(*args, **kwargs):
+        kwargs['validation_fn'] = validation_fn
+        return update_instance_fields(*args, **kwargs)
+
+    return f
+
+
+def update_instance_fields(request, instance, validation_fn=None):
+    json_data = json_from_request(request)
+    return _update_instance_fields(json_data, instance, validation_fn)
+
+
+def _update_instance_fields(json_data, instance, validation_fn=None):
+    error_dict = {}
+    for identifier, value in json_data.iteritems():
+        model, field_name = dotted_split(identifier, 2, maxsplit=1)
+
+        obj = instance
+
+        if validation_fn:
+            errors = validation_fn(field_name, value, model)
+            if errors is not None:
+                error_dict[field_name] = errors
+
+        if is_json_field_reference(field_name):
+            set_attr_on_json_field(obj, field_name, value)
+        else:
+            setattr(obj, field_name, value)
+
+    if error_dict:
+        validation_error = ValidationError(error_dict)
+    else:
+        try:
+            instance.save()
+            return {'ok': True}
+        except ValidationError, ve:
+            validation_error = ve
+
+    raise ValidationError(package_field_errors('instance', validation_error))

--- a/opentreemap/manage_treemap/views/green_infrastructure.py
+++ b/opentreemap/manage_treemap/views/green_infrastructure.py
@@ -272,7 +272,7 @@ def green_infrastructure(request, instance):
         model, field_name = dotted_split(identifier, 2, maxsplit=1)
         if field_name.startswith('config.map_feature_types') or \
            field_name.startswith('config.map_feature_config'):
-            if not instance.feature_enabled('green infrastructure'):
+            if not instance.feature_enabled('green_infrastructure'):
                 raise PermissionDenied("The Green Infrastructure module is "
                                        "not enabled for this tree map")
             increment_universal_rev = True

--- a/opentreemap/manage_treemap/views/green_infrastructure.py
+++ b/opentreemap/manage_treemap/views/green_infrastructure.py
@@ -1,0 +1,297 @@
+# -*- coding: utf-8 -*-
+from django.core.exceptions import ValidationError, PermissionDenied
+from django.db import transaction
+from django.utils.translation import ugettext as _
+
+from opentreemap.context_processors import REPLACEABLE_TERMS
+from opentreemap.util import json_from_request, dotted_split
+
+from treemap.json_field import (get_attr_from_json_field,
+                                set_attr_on_json_field)
+from treemap.models import Plot, MapFeature
+from treemap.util import package_field_errors, leaf_models_of_class
+from treemap.units import get_units, get_display_value, get_storage_value
+
+
+def _get_replaceable_models(instance):
+    all_classes = leaf_models_of_class(MapFeature) - {Plot}
+    root_classes = {Cls for Cls in all_classes
+                    if not Cls.__name__.endswith('LA')}
+    la_classes = {Cls for Cls in all_classes
+                  if Cls.__name__.endswith('LA')}
+    if instance.url_name == 'latreemap':
+        classes = la_classes | {Cls for Cls in root_classes
+                                if not
+                                {LACls for LACls in la_classes
+                                 if LACls.__name__.startswith(Cls.__name__)}}
+    else:
+        classes = root_classes
+
+    return sorted(classes, key=lambda Cls: Cls.terminology()['singular'])
+
+
+def site_config_green_infrastructure(request, instance):
+    def _get_form_fields(defaults, thing):
+        form_fields = []
+        for form in ('singular', 'plural'):
+            term_getter = 'terms.%s.%s' % (thing, form)
+            val = instance.config.get(term_getter, defaults.get(form))
+            form_fields.append({
+                'display_value': val,
+                'value': val,
+                'data_type': 'text',
+                'identifier': 'instance.config.%s' % term_getter,
+            })
+        return form_fields
+
+    terminology_fields = {thing: _get_form_fields(defaults, thing)
+                          for thing, defaults in REPLACEABLE_TERMS.items()}
+
+    __, annual_rainfall_display_value = get_display_value(
+        instance, 'greenInfrastructure', 'rainfall',
+        instance.annual_rainfall_inches)
+    annual_rainfall_fields = [(
+        _('Annual Rainfall'),
+        {
+            'identifier': 'instance.config.annual_rainfall_inches',
+            'data_type': 'float',
+            'display_value': annual_rainfall_display_value,
+            'value': annual_rainfall_display_value
+        },
+        get_units(instance, 'greenInfrastructure', 'rainfall'))]
+
+    customizable_models = _get_replaceable_models(instance)
+
+    gsi_model_fields = []
+    for Cls in customizable_models:
+        thing = Cls.__name__
+        defaults = Cls.terminology()
+        config = Cls.get_config(instance)
+
+        gsi_model = {'label': defaults.get('singular', thing),
+                     'model_name': thing,
+                     'checked': thing in instance.map_feature_types,
+                     'fields': _get_form_fields(defaults, thing),
+                     'is_la_model': thing.lower().endswith('la')}
+        gsi_model['diversion_rate'], gsi_model['diversion_rate_applies'] = \
+            _get_diversion_rate_for_display(config)
+        (gsi_model['should_show_eco'], gsi_model['should_show_eco_applies'],
+         gsi_model['should_show_eco_indicator']) = \
+            _get_should_show_eco(config)
+
+        gsi_model_fields.append(gsi_model)
+
+    return {
+        'instance': instance,
+        'terminology_fields': terminology_fields,
+        'annual_rainfall_fields': annual_rainfall_fields,
+        'gsi_model_fields': gsi_model_fields,
+    }
+
+
+def _get_diversion_rate_for_display(config):
+    diversion_rate = config.get('diversion_rate')
+    diversion_rate_applies = diversion_rate is not None
+    if not diversion_rate_applies:
+        diversion_rate = _('not applicable')
+    return diversion_rate, diversion_rate_applies
+
+
+def _get_should_show_eco(config):
+    should_show_eco = config.get('should_show_eco')
+    should_show_eco_applies = should_show_eco is not None
+    should_show_eco_indicator = ''
+    if not should_show_eco_applies:
+        should_show_eco_indicator = _('not applicable')
+    return should_show_eco, should_show_eco_applies, should_show_eco_indicator
+
+
+def _map_feature_config_validator(field_name, value, instance):
+    acceptable_terms = [
+        Cls.__name__ for Cls in _get_replaceable_models(instance)]
+
+    __, __, term, key = dotted_split(field_name, 4, maxsplit=3)
+    field_name_valid = (term in acceptable_terms and
+                        key in ('should_show_eco', 'diversion_rate'))
+    if not field_name_valid:
+        return [_("An invalid key was sent in the request")]
+
+    plural = get_attr_from_json_field(instance, 'config.terms.{}.plural'
+                                      .format(term))
+
+    if key == 'should_show_eco':
+        if term == 'RainBarrel':
+            return [_("Showing Ecobenefits is not applicable to {RainBarrels}")
+                    .format(RainBarrels=plural)]
+    elif key == 'diversion_rate':
+        if term == 'RainBarrel':
+            return [_(
+                "The runoff coefficient is not applicable to {RainBarrels}")
+                .format(RainBarrels=plural)]
+        error_message = ("Please enter a number between 0 and 1 "
+                         "for the runoff coefficient")
+
+        if value is None or value == '':
+            return [_(error_message)]
+
+        try:
+            float_value = float(value)
+        except ValueError:
+            return [_(error_message)]
+
+        if not 0.0 <= float_value <= 1.0:
+            return [_(error_message)]
+
+    return None
+
+
+def _map_feature_cross_validator(field_name, value, instance):
+    __, __, model_name, setting = dotted_split(field_name, 4, maxsplit=3)
+    Classes = _get_replaceable_models(instance)
+    Cls = next(Cls for Cls in Classes if Cls.__name__ == model_name)
+    config = Cls.get_config(instance)
+
+    if setting == 'should_show_eco':
+        value = config.get(setting)
+        if value:
+            rainfall_inches = instance.annual_rainfall_inches
+            if rainfall_inches is None or rainfall_inches == '':
+                return [_("Ecobenefits cannot be calculated unless "
+                          "annual rainfall is given")]
+            diversion_rate = config.get('diversion_rate')
+            if diversion_rate is None or diversion_rate == '':
+                return [_("Ecobenefits cannot be calculated unless "
+                          "a runoff coefficient is given")]
+
+
+def _terminology_validator(field_name, value, instance):
+    acceptable_terms = REPLACEABLE_TERMS.keys() + [
+        Cls.__name__ for Cls in _get_replaceable_models(instance)]
+
+    __, terms, term, form = dotted_split(field_name, 4, maxsplit=3)
+    field_name_valid = (terms == 'terms' and
+                        term in acceptable_terms and
+                        form in ('singular', 'plural'))
+    if not field_name_valid:
+        return [_("An invalid key was sent in the request")]
+
+    if term == 'Resource' and len(value) > 20:
+        return [_('Please limit replacement text to 20 characters.')]
+
+    return None
+
+
+def _annual_rainfall_validator(value):
+    INVALID_RAINFALL_MESSAGE = _(
+        "Please enter a positive number for annual rainfall")
+    if value is None or value == "":
+        return [INVALID_RAINFALL_MESSAGE]
+
+    try:
+        rainfall_inches = float(value)
+    except ValueError:
+        return [INVALID_RAINFALL_MESSAGE]
+
+    if rainfall_inches < 0.0:
+        return [INVALID_RAINFALL_MESSAGE]
+
+    return None
+
+
+def _set_annual_rainfall(value, instance):
+    value = get_storage_value(instance, 'greenInfrastructure', 'rainfall',
+                              float(value))
+    instance.annual_rainfall_inches = value
+
+
+def _set_map_feature_config(field_name, value, instance):
+    __, __, model_name, setting = dotted_split(field_name, 4, maxsplit=3)
+    Classes = _get_replaceable_models(instance)
+    Cls = next(Cls for Cls in Classes if Cls.__name__ == model_name)
+    if setting == 'diversion_rate':
+        value = float(value)
+    elif setting == 'should_show_eco':
+        value = bool(value)
+    Cls.set_config_property(instance, setting, value, save=False)
+
+
+# mutates error_dict
+def _validate_and_set_individual_values(json_data, instance, error_dict):
+    errors = None
+    INVALID_KEY_MESSAGE = _("An invalid key was sent in the request")
+    for identifier, value in json_data.iteritems():
+        if not '.' in identifier:
+            error_dict[identifier] = [INVALID_KEY_MESSAGE]
+        __, field_name = dotted_split(identifier, 2, maxsplit=1)
+
+        if not identifier.startswith('instance.config.'):
+            error_dict[field_name] = [INVALID_KEY_MESSAGE]
+            continue
+
+        if field_name == 'config.annual_rainfall_inches':
+            errors = _annual_rainfall_validator(value)
+            if errors is None:
+                _set_annual_rainfall(value, instance)
+        elif field_name.startswith('config.map_feature_config'):
+            errors = _map_feature_config_validator(field_name, value,
+                                                   instance)
+            if errors is None:
+                _set_map_feature_config(field_name, value, instance)
+        elif field_name.startswith('config.terms'):
+            errors = _terminology_validator(field_name, value, instance)
+            if errors is None:
+                set_attr_on_json_field(instance, field_name, value)
+        else:
+            errors = [INVALID_KEY_MESSAGE]
+
+        if errors is not None:
+            error_dict[field_name] = errors
+
+
+# mutates error_dict
+def _cross_validate_values(json_data, instance, error_dict):
+    errors = None
+    for identifier, value in json_data.iteritems():
+        __, field_name = dotted_split(identifier, 2, maxsplit=1)
+        if field_name in error_dict:
+            continue
+
+        if field_name.startswith('config.map_feature_config'):
+            errors = _map_feature_cross_validator(field_name, value, instance)
+
+        if errors is not None:
+            error_dict[field_name] = errors
+
+
+@transaction.atomic
+def green_infrastructure(request, instance):
+    json_data = json_from_request(request)
+    new_data = {}
+    increment_universal_rev = False
+    for identifier, value in json_data.iteritems():
+        model, field_name = dotted_split(identifier, 2, maxsplit=1)
+        if field_name.startswith('config.map_feature_types') or \
+           field_name.startswith('config.map_feature_config'):
+            if not instance.feature_enabled('green infrastructure'):
+                raise PermissionDenied("The Green Infrastructure module is "
+                                       "not enabled for this tree map")
+            increment_universal_rev = True
+        if field_name.startswith('config.map_feature_types'):
+            __, __, mft_name = dotted_split(field_name, 3, maxsplit=2)
+            if value:
+                instance.add_map_feature_types([mft_name])
+            else:
+                instance.remove_map_feature_types([mft_name])
+        else:
+            new_data[identifier] = value
+
+    error_dict = {}
+    _validate_and_set_individual_values(new_data, instance, error_dict)
+    _cross_validate_values(new_data, instance, error_dict)
+    if error_dict:
+        raise ValidationError(package_field_errors('instance',
+                              ValidationError(error_dict)))
+    if increment_universal_rev:
+        instance.update_universal_rev()
+    instance.save()
+    return {'ok': True}


### PR DESCRIPTION
* Restore test of `/management` URL now that `site_config` is present

Also add "Units" page.

Only the final two commits are relevant.

Required by OpenTreeMap/otm-addons#1488