### PR TITLE
Defer choice delete until Save

### DIFF
--- a/opentreemap/manage_treemap/templates/manage_treemap/partials/fields/udf_choice_cell.html
+++ b/opentreemap/manage_treemap/templates/manage_treemap/partials/fields/udf_choice_cell.html
@@ -3,23 +3,24 @@
 
 {# Refer to treemap/field/td.html with field=udf.datatype_dict.choices #}
 {% with id=udf.id|unlocalize %}
-    <div data-class="display" data-field="{{ udf.pk|unlocalize }}">
-        <ul class="choice-udf-choices less">
-            {% for choice in choices %}
-                <li class="less-more" data-choice="{{ choice }}">{{ choice }}</li>
-            {% endfor %}
-            {# Keep link within ul to make it easy to hide when there are fewer than 4 .less-more items before it #}
-            <a class="show-all less" data-less-more href="javascript:void(0)">
-                <span class="less">{% trans 'Show All...' %}</span>
-                <span class="more">{% trans 'Show Less...' %}</span>
-            </a>
-        </ul>
-    </div>
-    {# Collection udfs only ever have one subfield, although in theory they could have more. #}
-    <div class="choice-container" data-class="edit" data-field="{{ udf.pk|unlocalize }}" data-item="choices-list"  data-subfield="{{ name }}" data-add-prefix="{{ udf.pk|unlocalize|add:'+' }}" style="display: none;">
+<div data-class="display" data-field="{{ udf.pk|unlocalize }}">
+    <ul class="choice-udf-choices less">
         {% for choice in choices %}
-            {% include "manage_treemap/partials/fields/udf_choice_existing.html" with data_field_id=udf.pk|unlocalize|add:':'|add:choice %}
+            <li class="less-more" data-choice="{{ choice }}">{{ choice }}</li>
         {% endfor %}
-        {% include "manage_treemap/partials/fields/udf_choice_add_another.html" %}
-    </div>
+        {# Keep link within ul to make it easy to hide when there are fewer than 4 .less-more items before it #}
+        <a class="show-all less" data-less-more href="javascript:void(0)">
+            <span class="less">{% trans 'Show All...' %}</span>
+            <span class="more">{% trans 'Show Less...' %}</span>
+        </a>
+    </ul>
+</div>
+{# Collection udfs only ever have one subfield, although in theory they could have more. #}
+<div class="choice-container" data-class="edit" data-field="{{ udf.pk|unlocalize }}" data-item="choices-list"  data-subfield="{{ name }}" data-add-prefix="{{ udf.pk|unlocalize|add:'+' }}" style="display: none;">
+    {% for choice in choices %}
+        {% include "manage_treemap/partials/fields/udf_choice_existing.html" with data_field_id=udf.pk|unlocalize|add:':'|add:choice %}
+    {% endfor %}
+    {% include "manage_treemap/partials/fields/udf_choice_add_another.html" %}
+</div>
+<div class="hidden" data-item="deleted-choices"></div>
 {% endwith %}

--- a/opentreemap/manage_treemap/templates/manage_treemap/partials/fields/udf_choice_existing.html
+++ b/opentreemap/manage_treemap/templates/manage_treemap/partials/fields/udf_choice_existing.html
@@ -3,4 +3,3 @@
 
 {% block choice_attrs %}data-udf-choice="{{ choice }}"{% endblock %}
 {% block input_attrs %}value="{{ choice }}"{% endblock %}
-{% block delete_attrs %}data-popup-target="#remove-udf-choice-panel"{% endblock %}

--- a/opentreemap/manage_treemap/templates/manage_treemap/partials/fields/udf_choice_item.html
+++ b/opentreemap/manage_treemap/templates/manage_treemap/partials/fields/udf_choice_item.html
@@ -10,7 +10,10 @@
     </button>
 
     {# Error classes within a .choice-item are styled to be hidden by default #}
-    <div class="error" data-class="error" data-field-id="{{ data_field_id|default:'<%= field %>' }}"></div>
+
+    <div class="error" data-item="empty">
+        <i class="icon-attention"></i>{% trans "You need at least one choice" %}
+    </div>
 
     <div class="error" data-item="duplicate">
         <i class="icon-attention"></i>{% trans "You cannot use the same name twice" %}

--- a/opentreemap/manage_treemap/templates/manage_treemap/search_fields.html
+++ b/opentreemap/manage_treemap/templates/manage_treemap/search_fields.html
@@ -20,13 +20,9 @@
         </div>
 
         <div class="content">
-            {% if request.instance|feature_enabled:"set_advanced_search" %}
-                <div id="search-config-container">
-                    {% include "manage_treemap/partials/fields/search_fields.html" %}
-                </div>
-            {% else %}
-                {% include "cloud_management/partials/upgrade.html" %}
-            {% endif %}
+            <div id="search-config-container">
+                {% include "manage_treemap/partials/fields/search_fields.html" %}
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/opentreemap/manage_treemap/templates/manage_treemap/udfs.html
+++ b/opentreemap/manage_treemap/templates/manage_treemap/udfs.html
@@ -7,156 +7,127 @@
 {% block admin_title %}{% trans "Custom Fields" %}{% endblock %}
 
 {% block tab_content %}
-    <div id="udfs">
-        <div class="page-header">
-            <div class="page-header-toggles">
-                <i class="icon-menu" id="toggle-sidebar"></i>
-            </div>
-            <div class="page-header-title">
-                <h1>{% trans "Custom Fields" %}</h1>
-            </div>
-            <div class="page-header-actions">
-                {% if request.instance|feature_enabled:"custom_fields" %}
-                    {% include "manage_treemap/partials/form_buttons_udfs.html" %}
-                {% endif %}
-            </div>
+<div id="udfs">
+    <div class="page-header">
+        <div class="page-header-toggles">
+            <i class="icon-menu" id="toggle-sidebar"></i>
         </div>
-
-        <div class="content">
-            <div class="alert alert-danger messages"></div>
+        <div class="page-header-title">
+            <h1>{% trans "Custom Fields" %}</h1>
+        </div>
+        <div class="page-header-actions">
             {% if request.instance|feature_enabled:"custom_fields" %}
-                <div id="udf-info">
-                    {% for model in udf_models %}
-                        {% include "manage_treemap/partials/fields/udfs_table.html" with spec=model %}
-                    {% endfor %}
-                </div>
+                {% include "manage_treemap/partials/form_buttons_udfs.html" %}
             {% endif %}
         </div>
     </div>
+
+    <div class="content">
+        <div class="alert alert-danger messages"></div>
+        <div id="udf-info">
+            {% for model in udf_models %}
+                {% include "manage_treemap/partials/fields/udfs_table.html" with spec=model %}
+            {% endfor %}
+        </div>
+    </div>
+</div>
 {% endblock %}
 
 {% block endbody %}
-    <div id="delete-udf-panel" class="modal fade"></div>
-    <div id="remove-udf-choice-panel" class="modal fade">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-                    <h2>{% trans "Remove field choice" %}</h2>
-                </div>
-                <div class="modal-body">
-                    <p>{% trans "Are you sure you want to remove this choice?" %}</p>
-                    <div class="alert alert-danger">
-                        {% trans "This change cannot be undone." %}
-                    </div>
-                </div>
-                <div class="modal-footer">
-                    <a href="javascript:void(0)" class="btn dismiss-cancel" data-dismiss="modal">
-                        {% trans "Cancel" %}
-                    </a>
-                    <a href="javascript:void(0)"
-                       class="btn btn-danger dismiss-ok"
-                       data-dismiss="modal"
-                       data-udf-action="delete">
-                        {% trans "Remove Choice" %}
-                    </a>
-                </div>
+<div id="delete-udf-panel" class="modal fade"></div>
+<div id="add-udf-panel" class="modal fade modal-primary">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+                <h3>{% trans "Create Custom Field" %}</h3>
             </div>
-        </div>
-    </div>
-    <div id="add-udf-panel" class="modal fade modal-primary">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-                    <h3>{% trans "Create Custom Field" %}</h3>
-                </div>
-                <div class="modal-body">
-                    <div id="udf-create" class="container-fluid">
-                        <form class="row" onsubmit="return false;">
-                            <div id="udf-create-errors" class="alert alert-danger"></div>
-                            <div class="col-xs-12" id="udf-create-fields">
-                                <div class="form-group">
-                                    <label class="control-label">{% trans "Field Name:" %}</label>
-                                    <input type="text" class="form-control" data-key="udf.name" tabindex="1">
-                                </div>
-                                <div class="form-group">
-                                    <label class="control-label">{% trans "Feature Type:" %}</label>
-                                    <select id="udf-model" data-key="udf.model" class="form-control" tabindex="2">
-                                        {% for model in udf_models %}
-                                            <option value="{{ model.name }}">{{ model.display_name }}</option>
-                                        {% endfor %}
-                                    </select>
-                                </div>
-                                <div class="form-group">
-                                    <label class="control-label">{% trans "Field Type:" %}</label>
-                                    <select id="udf-type" data-key="udf.type" class="form-control" tabindex="3">
-                                        <option value="float">{% trans "Decimal Number" %}</option>
-                                        <option value="int">{% trans "Integer Number" %}</option>
-                                        <option value="string">{% trans "Text" %}</option>
-                                        <option value="choice">{% trans "List of Choices" %}</option>
-                                        <option value="multichoice">{% trans "List of Choices (Select Multiple)" %}</option>
-                                        <option value="date">{% trans "Date" %}</option>
-                                    </select>
-                                </div>
+            <div class="modal-body">
+                <div id="udf-create" class="container-fluid">
+                    <form class="row" onsubmit="return false;">
+                        <div id="udf-create-errors" class="alert alert-danger"></div>
+                        <div class="col-xs-12" id="udf-create-fields">
+                            <div class="form-group">
+                                <label class="control-label">{% trans "Field Name:" %}</label>
+                                <input type="text" class="form-control" data-key="udf.name" tabindex="1">
                             </div>
-                            <div class="col-xs-0" id="udf-create-choices">
-                                <label class="control-label">{% trans "List of Choices" %}</label>
-                                <div class="choice-container" data-item="choices-list">
-                                </div>
+                            <div class="form-group">
+                                <label class="control-label">{% trans "Feature Type:" %}</label>
+                                <select id="udf-model" data-key="udf.model" class="form-control" tabindex="2">
+                                {% for model in udf_models %}
+                                    <option value="{{ model.name }}">{{ model.display_name }}</option>
+                                {% endfor %}
+                                </select>
                             </div>
-                        </form>
-                    </div>
+                            <div class="form-group">
+                                <label class="control-label">{% trans "Field Type:" %}</label>
+                                <select id="udf-type" data-key="udf.type" class="form-control" tabindex="3">
+                                    <option value="float">{% trans "Decimal Number" %}</option>
+                                    <option value="int">{% trans "Integer Number" %}</option>
+                                    <option value="string">{% trans "Text" %}</option>
+                                    <option value="choice">{% trans "List of Choices" %}</option>
+                                    <option value="multichoice">{% trans "List of Choices (Select Multiple)" %}</option>
+                                    <option value="date">{% trans "Date" %}</option>
+                                </select>
+                            </div>
+                        </div>
+                        <div class="col-xs-0" id="udf-create-choices">
+                            <label class="control-label">{% trans "List of Choices" %}</label>
+                            <div class="choice-container" data-item="choices-list">
+                            </div>
+                        </div>
+                    </form>
                 </div>
-                <div class="modal-footer">
-                    <button class="btn btn-primary pull-right" id="create-new-udf">{% trans "Finish" %}</button>
-                </div>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-primary pull-right" id="create-new-udf">{% trans "Finish" %}</button>
             </div>
         </div>
     </div>
-    <div id="save-udf-panel" class="modal fade">
-        <div class="modal-dialog">
-            <div class="modal-content management-container">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
-                    <h2>{% trans "Confirm changes" %}</h2>
+</div>
+<div id="save-udf-panel" class="modal fade">
+    <div class="modal-dialog">
+        <div class="modal-content management-container">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+                <h2>{% trans "Confirm changes" %}</h2>
+            </div>
+            <div class="modal-body">
+                <div class="rename-warning">
+                    <p>{% trans "Are you sure you want to rename choices?" %}</p>
+                    <div class="alert alert-danger">{% trans "This change will impact the data for any places where a renamed choice is currently being used. The change cannot be undone." %}</div>
                 </div>
-                <div class="modal-body">
-                    <div class="rename-warning">
-                        <p>{% trans "Are you sure you want to rename choices?" %}</p>
-                        <div class="alert alert-danger">{% trans "This change will impact the data for any places where a renamed choice is currently being used. The change cannot be undone." %}</div>
-                    </div>
-                    <div class="change-info"></div>
-                </div>
-                <div class="modal-footer">
-                    <a href="javascript:void(0)" class="btn dismiss-cancel" data-dismiss="modal">
-                        {% trans "Cancel" %}
-                    </a>
-                    <a href="javascript:void(0)"
-                       class="btn btn-danger dismiss-ok"
-                       data-dismiss="modal"
-                       data-action="save">
-                        {% trans "Confirm Changes" %}
-                    </a>
-                </div>
+                <div class="change-info"></div>
+            </div>
+            <div class="modal-footer">
+                <a href="javascript:void(0)" class="btn dismiss-cancel" data-dismiss="modal">
+                    {% trans "Cancel" %}
+                </a>
+                <a href="javascript:void(0)"
+                    class="btn btn-danger dismiss-ok"
+                    data-dismiss="modal"
+                    data-action="save">
+                    {% trans "Confirm Changes" %}
+                </a>
             </div>
         </div>
     </div>
-    <script type="text/underscore" id="choice-template">
+</div>
+<script type="text/underscore" id="choice-template">
     {% include "manage_treemap/partials/fields/udf_choice_item.html" %}
 </script>
-    <script type="text/underscore" id="display-choice-template">
+<script type="text/underscore" id="display-choice-template">
     <li class="less-more" data-choice="<%= choice %>"><%= choice %></li>
 </script>
-    <script type="text/underscore" id="confirmer-model-template">
+<script type="text/underscore" id="confirmer-model-template">
     <h3 class="management-header"><%= udfName %></h3>
     <ul><%= changes %></ul>
 </script>
-    <script type="text/underscore" id="confirmer-change-template">
+<script type="text/underscore" id="confirmer-change-template">
     <li><%= originalValue %> <i class="icon-left"></i> <em><%= newValue %></em></li>
 </script>
 {% endblock %}
 
 {% block scripts %}
-    {% render_bundle 'js/manage_treemap/udfs' %}
+{% render_bundle 'js/manage_treemap/udfs' %}
 {% endblock scripts %}

--- a/opentreemap/manage_treemap/views/udf.py
+++ b/opentreemap/manage_treemap/views/udf.py
@@ -36,6 +36,29 @@ def udf_update_choice(request, instance, udf_id):
 
 @transaction.atomic
 def udf_bulk_update(request, instance):
+    '''
+    udf_bulk_update(request, instance)
+
+    'instance': a treemap instance
+    'request': an HTTP request object whose body is a JSON representation
+               of a dict containing the key 'choice_changes'.
+
+    choice_changes is a list of directives per choice-type
+    UserDefinedFieldDefinition.  Each directive is a dict, defined as follows:
+    {
+        'id': id of a UserDefinedFieldDefinition,
+        'changes': a list of changes to make to the UserDefinedFieldDefinition
+                   with that id.
+    }
+
+    Each change is either a delete, rename, or add request pertaining to
+    one choice of the UserDefinedFieldDefinition.
+
+    There should be no more than one change per choice,
+    and the list should be ordered as deletes, then renames, then adds.
+    See the docstring for `_udf_update_choice` for the structure of each
+    choice change parameter.
+    '''
     params = json.loads(request.body)
     choice_changes = params.get('choice_changes', None)
 
@@ -60,6 +83,22 @@ def udf_bulk_update(request, instance):
 
 
 def _udf_update_choice(udf, instance, params):
+    '''
+    _udf_update_choice(udf, instance, params)
+
+    `udf`: a choice-type UserDefinedFieldDefinition
+    `instance`: a treemap Instance
+    `params`: a dict representing changes to make to the udf, as follows.
+    {
+        'action':         ('delete'|'rename'|'add')
+        'subfield':       empty string for a scalar udf, or
+                          the key of interest in a collection udf.
+        'original_value': the name of the choice on entry to this function,
+                          empty string if 'action' is 'add'.
+        'new_value':      the name of the choice on exit from this function,
+                          empty string if 'action is 'delete'.
+    }
+    '''
     editable_udf_model_names = {clz.__name__ for clz in
                                 instance.editable_udf_models()['all']}
 


### PR DESCRIPTION
Changes
-------
- Added docstrings in the endpoint explaining what data is expected
- Removed markup for the delete choice confirmer from the template
- Removed markup that cued the JavaScript to pop up the delete choice
 confirmer
- Added markup for a trash div to hold pending deletes
- Removed a JavaScript TODO for the Save Confirmer in favor of an issue,
 OpenTreeMap/otm-addons#1493
- Replaced JavaScript code dealing with the confirmer with code
 to stage deletions to a trash div
- Related JavaScript changes for the content of the Save Confirmer,
 and fixing the dom up after Save or Cancel

--

Connects to OpenTreeMap/otm-addons#1482