### PR TITLE
Default static pages

### DIFF
--- a/assets/css/sass/partials/pages/_content.scss
+++ b/assets/css/sass/partials/pages/_content.scss
@@ -23,7 +23,7 @@
       &.title {
         list-style: none;
         margin-top: 10px;
-        
+
         a {
           font-weight: 700;
         }
@@ -34,5 +34,13 @@
         font-size: 1.3rem;
       }
     }
+  }
+  dt {
+    float: left;
+    margin-right: 20px;
+    font-weight: bold;
+  }
+  dd {
+    margin: 0 0 20px 30px;
   }
 }

--- a/opentreemap/treemap/templates/treemap/partials/About.html
+++ b/opentreemap/treemap/templates/treemap/partials/About.html
@@ -1,0 +1,11 @@
+<h2>About</h2>
+<p>This tree map enables the general public and local tree organizations to collaboratively create an accurate and informative inventory of the trees in the community. Search for trees by location, species, and other criteria and click on a dot on the map to view more information and photos.</p>
+<p>The tree map can also be accessed via the OpenTreeMap apps for Android and iOS devices.</p>
+
+<a href="https://itunes.apple.com/us/app/opentreemap/id898428451">
+    <img src="https://s3.amazonaws.com/origin.static.opentreemap.org/app-store-badge.png" alt="OpenTreeMap iOS App" style="width: 200px;"/>
+</a>
+
+<a href="https://play.google.com/store/apps/details?id=org.azavea.otm2.prod&amp;hl=en">
+    <img src="https://s3.amazonaws.com/origin.static.opentreemap.org/google-play-badge.png" alt="OpenTreeMap Android App" style="width: 200px;"/>
+</a>

--- a/opentreemap/treemap/templates/treemap/partials/FAQ.html
+++ b/opentreemap/treemap/templates/treemap/partials/FAQ.html
@@ -1,0 +1,74 @@
+<h2>FAQ</h2>
+<h3 class="P10">How do I use the tree map?</h3>
+
+<p>There are several ways that you can explore and use the tree map.</p>
+
+<dl>
+    <dt>Find Trees:</dt>
+    <dd>Use the tree map to search for trees near a specific address or in a general neighborhood using the Search by Location search box located at the top of the page.
+    Type an address, city, and state or select a location by clicking the three lines in the search box.
+    Click the "Search" button to find trees near that location.
+    You can also search by a tree's species using the Search by Species box.
+    Discover which trees are near your home!
+    </dd>
+    <dt>Add Trees:</dt>
+    <dd>Do you know of a tree that isn't in the map?
+    If the organization that manages the map is working to create a full inventory of the urban forest,
+    you may be able to add trees after <a href="https://www.opentreemap.org/accounts/register/">creating a free OpenTreeMap account</a>.
+    Once you've logged in, click the "Add a Tree" button to enter information about your tree.
+    Fill out the requested information in the three simple steps and then click "Done."
+    We recommend first searching the map to confirm that the tree you want to add is not already on the map.
+	<p>Adding trees may be limited to user accounts with certain privileges.
+	If you are unsure whether you should have the ability to add trees,
+	contact the map owner by clicking the “Contact” button in the bar at the bottom of the map.
+	</p>
+    </dd>
+    <dt>View Tree Details:</dt>
+    <dd> After searching for a tree, click a dot on the map to view the tree’s species, diameter, and location.
+    You can click “More Details” to view other information and photographs for the tree.
+    </dd>
+    <dt>Edit Trees:</dt>
+    <dd>Many trees in the tree map may need to be updated with new information.
+    After viewing the existing information about the tree, you can click the "Edit” button on the tree’s detail page to add or edit information about the tree,
+    leave comments, or upload photos.
+	<p>Editing tree information may be limited to user accounts with certain privileges.
+	If you are unsure whether you should have the ability to edit tree details,
+	contact the map owner by clicking the “Contact” button in the bar at the bottom of the map.
+	</p>
+    </dd>
+</dl>
+
+<h3>How do I find out the species of my tree?</h3>
+
+<p>If you’re unsure about the species of a tree, click the Tree ID link in the bar at the bottom of the map.
+The <a href="https://www.arborday.org/trees/whattree/">What Tree Is That?</a> website is also a helpful resource for identifying a tree’s species.</p>
+
+<h3>What if the species of my tree is not available in the species list on the map?</h3>
+
+<p>If your tree’s species is not listed in the species list on the tree map, click the “Contact” button in the bar at the bottom of the map to contact the map organizers.</p>
+
+<h3>How do I measure the diameter of my tree’s trunk?</h3>
+
+<p>Entering the diameter of a tree is crucial for helping track that tree’s growth and environmental benefits.
+Measuring the diameter can be a bit tricky though.
+The following video from the people at <a href="http://www.urbanforestmap.org/"><span class="T19">UrbanForestMap.org</span></a> provides a quick tutorial on an easy way to measure your tree’s diameter.</p>
+
+<p><a href="https://vimeo.com/11119129">https://vimeo.com/11119129</a></p>
+
+<h3>My community has a lot of tree data. Is there a way to upload many trees at once?</h3>
+
+<p>If you have an existing tree inventory you would like to add to the tree map, please click the “Contact” button in the bar at the bottom of the map to contact the map organizers.</p>
+
+<h3>How do I report an issue with a tree or a hazardous or dead tree?</h3>
+
+<p>Tree maps generally do not include options for reporting hazardous or dead trees. Please contact your local government to determine the best way to report tree issues.</p>
+
+<h3>What is the source of the eco impact data?</h3>
+
+<p>
+We calculate the economic benefits and environmental impacts of the trees using protocols that are part of the <a href="http://www.itreetools.org/">i-Tree software</a> provided by the <a href="http://www.fs.fed.us/">USDA Forest Service</a>.
+This software provides options for calculating benefits by assigning a dollar value to the impact of trees in a number of ecological areas including electricity, natural gas, carbon dioxide, particulate matter, nitrogen dioxide, sulfur dioxide, volatile organic compounds, and stormwater interception.
+</p>
+<p>To complete the calculations, we need to have the species and diameter for each tree. You can help us more accurately calculate eco data by entering the species and diameter that are missing for trees in your neighborhood.</p>
+<p>Ecobenefit data is not available for most tree maps located outside the continental United States.
+</p>

--- a/opentreemap/treemap/templates/treemap/partials/Resources.html
+++ b/opentreemap/treemap/templates/treemap/partials/Resources.html
@@ -1,0 +1,21 @@
+<h2>Resources</h2>
+    <h3>Want to find out more about trees and urban forestry?</h3>
+    <p>Visit the sites below for more information.</p>
+    <h4>Species Identification</h4>
+    <ul>
+        <li><a href="https://www.arborday.org/trees/whatTree/">Arbor Day Foundation's What Tree is That?</a></li>
+        <li><a href="http://www.mobot.org/gardeninghelp/plantfinder/Alpha.asp">Missouri Botanical Garden PlantFinder</a></li>
+        <li><a href="http://plants.usda.gov/java/">USDA PLANTS Database</a></li>
+    </ul>
+
+    <h4>Environmental Benefits</h4>
+    <ul>
+        <li><a href="http://www.treebenefits.com/calculator/">National Tree Benefit Calculator</a></li>
+        <li><a href="http://www.itreetools.org/">i-Tree</a> from the <a href="http://www.fs.fed.us/">US Forest Service</a></li>
+    </ul>
+
+    <h4>Forestry</h4>
+    <ul>
+        <li><a href="https://www.fs.fed.us/managing-land/urban-forests/ucf">Urban and Community Forestry Program at the U.S. Forest Service</a></li>
+        <li><a href="http://dendro.cnre.vt.edu/dendrology/factsheets.cfm">VTree Dendrology from Virginia Tech</a></li>
+    </ul>

--- a/opentreemap/treemap/tests/test_views.py
+++ b/opentreemap/treemap/tests/test_views.py
@@ -106,6 +106,8 @@ class StaticPageViewTest(ViewTestCase):
 
         self.assertIsNotNone(rslt['content'])
         self.assertIsNotNone(rslt['title'])
+        self.assertEqual(len(rslt['content']),
+                         len(StaticPage.DEFAULT_CONTENT['about']))
 
 
 class BoundaryViewTest(ViewTestCase):
@@ -1000,11 +1002,11 @@ class PlotViewProgressTest(PlotViewTestCase):
         wo_tree_context = self.get_plot_context(self.plot_wo_tree)
         w_tree_context = self.get_plot_context(self.plot_w_tree)
 
-        self.assertTrue(len(wo_tree_context['progress_messages'])
-                        > len(w_tree_context['progress_messages']))
+        self.assertTrue(len(wo_tree_context['progress_messages']) >
+                        len(w_tree_context['progress_messages']))
         # Adding a tree without and details does not add progress
-        self.assertTrue(wo_tree_context['progress_percent']
-                        == w_tree_context['progress_percent'])
+        self.assertTrue(wo_tree_context['progress_percent'] ==
+                        w_tree_context['progress_percent'])
 
     def test_progress_increases_when_diameter_is_added(self):
         tree = self.plot_w_tree.current_tree()


### PR DESCRIPTION
Changes
-------
- Data migration to add default Resources, About, and FAQ pages
  to instances that don't have them
- Styling for the `<dl>` in the About page

Testing Notes
-------------
Before running the migration, find both instances that do and
that do not have static pages with these names defined.

After running the migration, make sure that
- instances that did not have these pages now do
- the three pages have the right content
- the three pages are formatted nicely
- instances that already had custom versions of these pages
  still have their custom pages

--

Connects to #1386