### PR TITLE
Edit default static page

### DIFF
--- a/opentreemap/treemap/templates/treemap/field/attrs.html
+++ b/opentreemap/treemap/templates/treemap/field/attrs.html
@@ -1,7 +1,7 @@
 {% load l10n %}
 data-field="{{ field.identifier }}"
 data-class="{{ class }}"
-data-value="{{ field.value|default_if_none:""|unlocalize }}"
+data-value="{{ field.value|default_if_none:""|unlocalize|force_escape }}"
 data-type="{{ field.data_type }}"
 data-units="{{ field.units }}"
 data-digits="{{ field.digits }}"


### PR DESCRIPTION
Added `|force_escape` to `data-value` in `treemap/field/attrs.html`
in order to get the static page editor to send html escaped
tag attributes.

`|escape` had no effect.

`|force_escape` is not double-escaping.

Tested with advanced search, add a tree, tree quick edit,
the tree details page, the units management page, and the
custom fields management page.

--

Connects to OpenTreeMap/otm-addons#1506