### PR TITLE
Modify Treezilla species import to convert units

### DIFF
--- a/opentreemap/otm1_migrator/migration_rules/treezilla.py
+++ b/opentreemap/otm1_migrator/migration_rules/treezilla.py
@@ -55,6 +55,13 @@ MIGRATION_RULES['tree']['presave_actions'] = (MIGRATION_RULES['tree']
                                               .get('presave_actions', [])
                                               + [convert_tree_measurements])
 
+# The treezilla database stores species measurement maximums in meters
+MIGRATION_RULES['species']['value_transformers']['v_max_dbh'] = (
+    lambda x: x * METERS_TO_INCHES if x else 10000)
+
+MIGRATION_RULES['species']['value_transformers']['v_max_height'] = (
+    lambda x: x * METERS_TO_FEET if x else 10000)
+
 
 def create_override(species_obj, species_dict):
     itree_code = species_dict['fields'].get('itree_code', None)


### PR DESCRIPTION
The maximum diameter and height in the Treezilla species fixtures is in meters but the canonical units in OTM2 are feet for height and inches for diameter.

The `else` clause was copied from the default migration rules.

---

I tested this by following the migration steps in https://github.com/OpenTreeMap/otm-clients/blob/538bcbc730c386eab3dd6dea69ea3b7de9c84bd0/treezilla/migration/README.md up through "Run The Migration" with the following changes.

- I skipped deleting boundaries.
- I only copied the species fixture JSON file to my VM
- I used this `config.json`

```json
{
    "rule_module": "otm1_migrator.migration_rules.treezilla",
    "species_fixture": "local/fixtures/species.json"
}
```

On the `develop` branch, the migration produces rows in the species table with unconverted measurements:

```
SELECT genus, species, max_diameter, max_height
FROM treemap_species
WHERE instance_id = { the_instance_id_being_tested }
ORDER BY genus, species 
LIMIT 10;

 genus |    species    | max_diameter | max_height
-------+---------------+--------------+------------
 Abies |               |            6 |         70
 Abies | alba          |            6 |         70
 Abies | amabilis      |            6 |         70
 Abies | borisii-regis |            6 |         70
 Abies | bracteata     |            6 |         70
 Abies | cephalonica   |            6 |         70
 Abies | chayuensis    |            6 |         70
 Abies | cilicica      |            6 |         70
 Abies | cilicica      |            6 |         70
 Abies | concolor      |            6 |         70
```

On this branch, the measurements are converted

```
 genus |    species    | max_diameter | max_height
-------+---------------+--------------+------------
 Abies |               |          236 |        229
 Abies | alba          |          236 |        229
 Abies | amabilis      |          236 |        229
 Abies | borisii-regis |          236 |        229
 Abies | bracteata     |          236 |        229
 Abies | cephalonica   |          236 |        229
 Abies | chayuensis    |          236 |        229
 Abies | cilicica      |          236 |        229
 Abies | cilicica      |          236 |        229
 Abies | concolor      |          236 |        229
```

---

Connects to https://github.com/OpenTreeMap/otm-clients/issues/358