### PR TITLE
Use cached plot count in public instances GeoJSON view

### DIFF
--- a/opentreemap/treemap/tests/test_views.py
+++ b/opentreemap/treemap/tests/test_views.py
@@ -2017,7 +2017,6 @@ class InstanceListTest(OTMTestCase):
         self.assertIn('properties', instance_dict)
 
         self.assertEqual(self.i1.name, instance_dict['properties']['name'])
-        self.assertEqual(1, instance_dict['properties']['tree_count'])
         self.assertEqual(2, instance_dict['properties']['plot_count'])
 
     def test_instance_list_only_public(self):

--- a/opentreemap/treemap/views/misc.py
+++ b/opentreemap/treemap/views/misc.py
@@ -231,27 +231,13 @@ def public_instances_geojson(request):
                 'url': reverse(
                     'instance_index_view',
                     kwargs={'instance_url_name': instance.url_name}),
-                'tree_count': instance.tree_count,
-                'plot_count': instance.plot_count
+                'plot_count': instance.plot_count()
             }
         }
 
-    tree_query = "SELECT COUNT(*) FROM treemap_tree WHERE "\
-        "treemap_tree.instance_id = treemap_instance.id"
-
-    plot_query = "SELECT COUNT(*) FROM treemap_mapfeature"\
-        " WHERE treemap_mapfeature.instance_id = treemap_instance.id"\
-        " AND treemap_mapfeature.feature_type = 'Plot'"
-
-    # You might think you can do .annotate(tree_count=Count('tree'))
-    # But it is horribly slow due to too many group bys
     instances = (Instance.objects
                  .filter(is_public=True)
-                 .filter(get_viewable_instances_filter())
-                 .extra(select={
-                     'tree_count': tree_query,
-                     'plot_count': plot_query
-                 }))
+                 .filter(get_viewable_instances_filter()))
 
     return [instance_geojson(instance) for instance in instances]
 


### PR DESCRIPTION
Fetching every map's tree/plot count was too slow for use in the new marketing site (taking 2-10 seconds).

Since we already cache plot count, I switched to getting the `plot_count` from the cache, and entirely removed the `tree_count`.

Required by https://github.com/OpenTreeMap/otm-website/pull/178

Connects to OpenTreeMap/otm-website#176