### PR TITLE
Cancel importer proximity check within same csv

### DIFF
--- a/opentreemap/importer/tests.py
+++ b/opentreemap/importer/tests.py
@@ -36,7 +36,7 @@ from importer import errors, fields
 from importer.tasks import _create_rows_for_event
 from importer.models.trees import TreeImportEvent, TreeImportRow
 from importer.models.species import SpeciesImportEvent, SpeciesImportRow
-from importer.views import (process_csv, process_status,
+from importer.views import (process_status,
                             commit, merge_species, start_import)
 
 
@@ -147,9 +147,9 @@ class TreeValidationTestBase(ValidationTest):
                                   instance=self.instance)
         self.ie.save()
 
-    def mkrow(self, data):
+    def mkrow(self, data, idx=1):
         return TreeImportRow.objects.create(
-            data=json.dumps(data), import_event=self.ie, idx=1)
+            data=json.dumps(data), import_event=self.ie, idx=idx)
 
 
 class TreeValidationTest(TreeValidationTestBase):
@@ -244,6 +244,52 @@ class TreeValidationTest(TreeValidationTestBase):
         i.validate_row()
 
         self.assertNotHasError(i, errors.NEARBY_TREES)
+
+    def test_update_proximity_ok(self):
+        p1 = mkPlot(self.instance, self.user,
+                    geom=Point(25.0000001, 25.0000001, srid=4326))
+
+        r1 = self.mkrow({'point x': '25.00000025',
+                         'point y': '25.00000025',
+                         'planting site id': p1.id})
+        r1.validate_row()
+
+        self.assertNotHasError(r1, errors.NEARBY_TREES)
+
+    def test_proximity_same_csv_ok(self):
+        initial_plot_count = Plot.objects\
+            .filter(instance=self.instance)\
+            .count()
+
+        self.assertEqual(initial_plot_count, 0)
+
+        r1 = self.mkrow({'point x': '25.0000001',
+                         'point y': '25.0000001'}, idx=1)
+        r1.validate_row()
+
+        self.assertNotHasError(r1, errors.NEARBY_TREES)
+
+        r2 = self.mkrow({'point x': '25.0000001',
+                         'point y': '25.0000001'}, idx=2)
+        r2.validate_row()
+
+        # Trust the csv
+        self.assertNotHasError(r2, errors.DUPLICATE_TREE)
+        self.assertNotHasError(r2, errors.NEARBY_TREES)
+
+        r1.commit_row()
+        after_r1_count = Plot.objects\
+            .filter(instance=self.instance)\
+            .count()
+        self.assertEqual(after_r1_count, 1)
+
+        r2.commit_row()
+        after_r2_count = Plot.objects\
+            .filter(instance=self.instance)\
+            .count()
+        self.assertNotHasError(r2, errors.DUPLICATE_TREE)
+        self.assertNotHasError(r2, errors.NEARBY_TREES)
+        self.assertEqual(after_r2_count, 2)
 
     def test_species_id(self):
         s1_gsc = Species(instance=self.instance, genus='g1', species='s1',


### PR DESCRIPTION
When `row._validate_proximity` gets called during the commit phase,
exclude previously committed plots in the same csv from
the proximity check.

--

Connects to OpenTreeMap/otm-addons#1519