### PR TITLE
ecobenefits totals

### DIFF
--- a/opentreemap/treemap/ecobenefits.py
+++ b/opentreemap/treemap/ecobenefits.py
@@ -30,6 +30,14 @@ class BenefitCategory(object):
 
     GROUPS = (ENERGY, STORMWATER, AIRQUALITY, CO2, CO2STORAGE)
 
+    is_annual_table = {
+        ENERGY: True,
+        STORMWATER: True,
+        AIRQUALITY: True,
+        CO2: True,
+        CO2STORAGE: False
+    }
+
 
 class BenefitCalculator(object):
     """

--- a/opentreemap/treemap/lib/__init__.py
+++ b/opentreemap/treemap/lib/__init__.py
@@ -6,6 +6,7 @@ from __future__ import division
 import re
 
 from django.db import connection
+from django.utils.translation import ugettext as _
 from django.utils.formats import number_format
 
 from treemap.units import get_units, get_display_value
@@ -14,6 +15,9 @@ COLOR_RE = re.compile(r'^(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$')
 
 
 def format_benefits(instance, benefits, basis, digits=None):
+    # keep the top level module dependencies small
+    from treemap.ecobenefits import BenefitCategory
+
     currency_symbol = ''
     if instance.eco_benefits_conversion:
         currency_symbol = instance.eco_benefits_conversion.currency_symbol
@@ -26,7 +30,8 @@ def format_benefits(instance, benefits, basis, digits=None):
                 # TODO: Use i18n/l10n to format currency
                 benefit['currency_saved'] = currency_symbol + number_format(
                     benefit['currency'], decimal_pos=0)
-                total_currency += benefit['currency']
+                if BenefitCategory.is_annual_table.get(key, False):
+                    total_currency += benefit['currency']
 
             unit_key = benefit.get('unit-name')
 
@@ -37,6 +42,13 @@ def format_benefits(instance, benefits, basis, digits=None):
                 benefit['name'] = key
                 benefit['value'] = value
                 benefit['unit'] = get_units(instance, unit_key, key)
+
+    benefits['all'] = {'totals': {
+        'value': None,
+        'label': _('Total annual benefits'),
+        'currency': total_currency,
+        'currency_saved': currency_symbol + number_format(
+            total_currency, decimal_pos=0)}}
 
     # Add total and percent to basis
     rslt = {'benefits': benefits,

--- a/opentreemap/treemap/lib/__init__.py
+++ b/opentreemap/treemap/lib/__init__.py
@@ -30,7 +30,7 @@ def format_benefits(instance, benefits, basis, digits=None):
                 # TODO: Use i18n/l10n to format currency
                 benefit['currency_saved'] = currency_symbol + number_format(
                     benefit['currency'], decimal_pos=0)
-                if BenefitCategory.is_annual_table.get(key, False):
+                if BenefitCategory.is_annual_table.get(key, True):
                     total_currency += benefit['currency']
 
             unit_key = benefit.get('unit-name')

--- a/opentreemap/treemap/templates/treemap/partials/eco_benefits.html
+++ b/opentreemap/treemap/templates/treemap/partials/eco_benefits.html
@@ -8,8 +8,10 @@
             <i class="icon-right-open"></i>
             <i class="icon-cancel"></i>
         </a>
+        {% with all_benefits=benefits.all %}
+            {% include "treemap/partials/benefit_value_row.html" with benefit=all_benefits.totals total=True %}
+        {% endwith %}
         {% with plot_benefits=benefits.plot %}
-            {% include "treemap/partials/benefit_value_row.html" with benefit=plot_benefits.totals total=True %}
             {% if not hide_summary and plot_benefits %}
                 <div class="benefit-value-title">{% trans "Tree Benefits"%}</div>
             {% endif %}

--- a/opentreemap/treemap/tests/test_map_feature.py
+++ b/opentreemap/treemap/tests/test_map_feature.py
@@ -6,14 +6,18 @@ from __future__ import division
 from contextlib import contextmanager
 from unittest.case import skip
 
-from django.contrib.gis.geos import Point
+from django.contrib.gis.geos import Point, MultiPolygon, Polygon
 from django.test.utils import override_settings
 
-from treemap.models import (Tree, Plot, MapFeature, Species, TreePhoto)
+from treemap.models import Tree, Plot, MapFeature, Species, TreePhoto
 from treemap.instance import Instance
+from treemap.search import Filter
+from treemap.lib import format_benefits
+from treemap.ecobenefits import get_benefits_for_filter, BenefitCategory
 from treemap.tests import (make_instance, make_commander_user,
                            LocalMediaTestCase)
 from treemap.tests.base import OTMTestCase
+from treemap.tests.test_ecobenefits import EcoTestCase
 from treemap.views.map_feature import update_map_feature
 
 from stormwater.models import Bioswale
@@ -189,6 +193,105 @@ class PlotHashTestCase(OTMTestCase):
         self.assertEqual(self.final_plot_hash,
                          self.final_map_feature_hash,
                          same_hash_msg)
+
+
+# this decorator is necessary in order to `add_map_feature_types(['Bioswale'])`
+# in `setUp`.
+@override_settings(FEATURE_BACKEND_FUNCTION=None)
+class ResourceEcoBenefitsTest(EcoTestCase):
+    def setUp(self):
+        # sets up self.instance, self.user, self.species
+        super(ResourceEcoBenefitsTest, self).setUp()
+        self.instance.add_map_feature_types(['Bioswale'])
+        diversion_rate = .85
+        Bioswale.set_config_property(self.instance, 'diversion_rate',
+                                     diversion_rate)
+        Bioswale.set_config_property(self.instance, 'should_show_eco', True)
+        self.instance.annual_rainfall_inches = 8.0
+
+    def _center_as_3857(self):
+        p = self.instance.center
+        if p.srid != 3857:
+            p.transform(3857)
+        return p
+
+    def _box_around_point(self, pt, edge=1.0):
+        half_edge = 0.5 * edge
+        x_min = pt.x - half_edge
+        y_min = pt.y - half_edge
+        x_max = pt.x + half_edge
+        y_max = pt.y + half_edge
+        poly = Polygon(((x_min, y_min),
+                        (x_min, y_max),
+                        (x_max, y_max),
+                        (x_max, y_min),
+                        (x_min, y_min)))
+        return MultiPolygon((poly, ))
+
+    def test_resource_ecobenefits(self):
+        p = self._center_as_3857()
+        box = self._box_around_point(p)
+        bioswale = Bioswale(instance=self.instance,
+                            geom=p,
+                            polygon=box,
+                            feature_type='Bioswale',
+                            drainage_area=100.0)
+        bioswale.save_with_user(self.user)
+        filter = Filter('', '', self.instance)
+        benefits, __ = get_benefits_for_filter(filter)
+
+        self.assertIn('resource', benefits)
+        resource_benefits = benefits['resource']
+        self.assertIn(BenefitCategory.STORMWATER, resource_benefits)
+        stormwater = resource_benefits[BenefitCategory.STORMWATER]
+        self.assertTrue(isinstance(stormwater['value'], float))
+        self.assertGreater(stormwater['value'], 0.0)
+        self.assertTrue(isinstance(stormwater['currency'], float))
+        self.assertEqual(stormwater['value'], stormwater['currency'])
+
+    def test_all_ecobenefits(self):
+        p = self._center_as_3857()
+        plot = Plot(geom=p, instance=self.instance)
+        plot.save_with_user(self.user)
+
+        tree = Tree(plot=plot,
+                    instance=self.instance,
+                    readonly=False,
+                    species=self.species,
+                    diameter=1630)
+
+        tree.save_with_user(self.user)
+
+        p.x += 1.1
+        p.y += 1.1
+        box = self._box_around_point(p)
+        bioswale = Bioswale(instance=self.instance,
+                            geom=p,
+                            polygon=box,
+                            feature_type='Bioswale',
+                            drainage_area=100.0)
+        bioswale.save_with_user(self.user)
+        filter = Filter('', '', self.instance)
+        benefits, basis = get_benefits_for_filter(filter)
+
+        self.assertIn('plot', benefits)
+        plot_benefits = benefits['plot']
+        plot_categories = set(plot_benefits.keys())
+        self.assertSetEqual(plot_categories, set(BenefitCategory.GROUPS))
+
+        plot_currencies = {
+            cat: benefit.get('currency', None)
+            for cat, benefit in plot_benefits.items()}
+        self.assertIsNotNone(min(plot_currencies.values()))
+
+        expected_total_currency = sum(
+            [benefit['currency'] for benefit in plot_benefits.values()]) - \
+            plot_benefits[BenefitCategory.CO2STORAGE]['currency'] + \
+            benefits['resource'][BenefitCategory.STORMWATER]['currency']
+
+        formatted = format_benefits(self.instance, benefits, basis, digits=0)
+        self.assertAlmostEqual(formatted['benefits_total_currency'],
+                               expected_total_currency, 3)
 
 
 class UpdatedFieldsTest(LocalMediaTestCase):

--- a/opentreemap/treemap/views/tree.py
+++ b/opentreemap/treemap/views/tree.py
@@ -7,7 +7,7 @@ import hashlib
 
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
-from django.utils.translation import ugettext as _, ungettext
+from django.utils.translation import ungettext
 from django.shortcuts import get_object_or_404
 from django.db import transaction
 from django.http import HttpResponseRedirect
@@ -15,7 +15,6 @@ from django.http import HttpResponseRedirect
 from treemap.search import Filter
 from treemap.models import Tree, Plot
 from treemap.ecobenefits import get_benefits_for_filter
-from treemap.ecobenefits import BenefitCategory
 from treemap.ecocache import get_cached_plot_count
 from treemap.lib import format_benefits
 from treemap.lib.tree import add_tree_photo_helper
@@ -69,24 +68,6 @@ def search_tree_benefits(request, instance):
 
     # Inject the plot count as a basis for tree benefit calcs
     basis.get('plot', {})['n_plots'] = total_plots
-
-    # We also want to inject the total currency amount saved
-    # for plot-based items except CO2 stored
-    total_currency_saved = 0
-
-    for benefit_name, benefit in benefits.get('plot', {}).iteritems():
-        if benefit_name != BenefitCategory.CO2STORAGE:
-            currency = benefit.get('currency', 0.0)
-            if currency:
-                total_currency_saved += currency
-
-    # save it as if it were a normal benefit so we get formatting
-    # and currency conversion
-    benefits.get('plot', {})['totals'] = {
-        'value': None,
-        'currency': total_currency_saved,
-        'label': _('Total annual benefits')
-    }
 
     formatted = format_benefits(instance, benefits, basis, digits=0)
 


### PR DESCRIPTION
`treemap.lib.format_benefits` now calculates `'benefits_total_currency'`
correctly, and also adds its formatted results to
`rslt['benefits']['all']['totals']`.

>`format_benefits` now omits non-annual currency from total currency based on a `dict` in `BenefitCategory`. I hope that the code and variable names make this self-explanatory, but if they do not, it's fair to ask for a comment in the code.

`treemap/partials/eco_benefits.html` adjusted accordingly.

Total currency calculation no longer needed in `treemap.views.tree`.

Added a very basic resource ecobenefits test,
and a test for total currency for both plots and resources,
which failed before correcting `format_benefits`.

--

Connects to OpenTreeMap/otm-addons#1394