### PR TITLE
Handle null multichoice value

### DIFF
--- a/opentreemap/treemap/udf.py
+++ b/opentreemap/treemap/udf.py
@@ -974,6 +974,8 @@ class UserDefinedFieldDefinition(models.Model):
                     raise complaint(
                         '%(fieldname)s must be valid JSON',
                         fieldname=self.name)
+                if values is None:
+                    return None
                 if isinstance(values, basestring):
                     # A single string is valid JSON. Wrap as a list for
                     # consistency


### PR DESCRIPTION
There is some data in the production database where the value of a multichoice field audit is the string "null". Adding a None check to the `clean_value` function prevents an exception where code further down in the function expects the value to be iterable.

---

##### Testing

`/greenprintmaps/features/2081911/`

The production data has an audit that looks like this

```
otm=# select field, previous_value, current_value  from treemap_audit where model = 'Tree' and model_id = 1814485 and previous_value = 'null' order by created;
        field         | previous_value | current_value
----------------------+----------------+---------------
 udf:Name of Project: | null           | null
```

On the `develop` branch, loading the detail page for this plot crashes. On the PR branch, it loads properly.

---

Connects to #1526