### PR TITLE
Add checksum to URL for both static and dynamic SASS bundles

### DIFF
--- a/opentreemap/treemap/templates/instance_base.html
+++ b/opentreemap/treemap/templates/instance_base.html
@@ -7,10 +7,13 @@
 
 {% block application_css %}
 
+{% get_files 'js/treemap/base' 'css' as css_files %}
 {% if request.instance.scss_variables %}
-  <link id="application-css" href="{% url 'scss' %}?{{ request.instance.scss_query_string }}" rel="stylesheet">
+<!-- The Webpack bundle name is added as a query parameter for cache busting since
+     it includes a checksum of the bundle, letting us set far-future expires cache headers -->
+  <link id="application-css" rel="stylesheet"
+        href="{% url 'scss' %}?{{ request.instance.scss_query_string }}&url={{ css_files.0.name|urlencode }}">
 {% else %}
-  {% get_files 'js/treemap/base' 'css' as css_files %}
   <link id="application-css" href="{{ css_files.0.url }}" rel="stylesheet">
 {% endif %}
 

--- a/opentreemap/treemap/views/misc.py
+++ b/opentreemap/treemap/views/misc.py
@@ -209,6 +209,9 @@ def compile_scss(request):
     for key, value in request.GET.items():
         if _SCSS_VAR_NAME_RE.match(key) and COLOR_RE.match(value):
             scss += '$%s: #%s;\n' % (key, value)
+        elif key == 'url':
+            # Ignore the cache-buster query parameter
+            continue
         else:
             raise ValidationError("Invalid SCSS values %s: %s" % (key, value))
     scss += '@import "%s";' % settings.SCSS_ENTRY

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -100,7 +100,7 @@ module.exports = {
             // Chunks are moved to the common bundle if they are used in 2 or more entry bundles
             minChunks: 2,
         }),
-        new ExtractTextPlugin('css/main.css', {allChunks: true}),
+        new ExtractTextPlugin('css/main-[chunkhash].css', {allChunks: true}),
         new BundleTracker({path: d('static'), filename: 'webpack-stats.json'})
     ],
     postcss: function () {


### PR DESCRIPTION
We had mistakenly omitted using the `[chunkhash]` in the Webpack SASS bundle.
Adding it in allows us to use the bundle name as a cache-buster URL parameter for the dynamically computed SASS bundle.

Required by https://github.com/OpenTreeMap/otm-cloud/pull/382

Connects to #3143