### PR TITLE
Add template tag to sequence comments in thread order

### DIFF
--- a/opentreemap/treemap/templates/treemap/partials/map_feature_detail_base.html
+++ b/opentreemap/treemap/templates/treemap/partials/map_feature_detail_base.html
@@ -5,6 +5,7 @@
 {% load util %}
 {% load staticfiles %}
 {% load auth_extras %}
+{% load comment_sequence %}
 
 <div class="detail-header">
     {% if request.instance.is_public %}
@@ -103,7 +104,7 @@
     <h3>{% trans "Comments" %}</h3>
     <div id="comments-container">
         {% get_comment_list for feature as comments %}
-        {% for comment in comments|fill_tree|annotate_tree %}
+        {% for comment in comments|in_thread_order|fill_tree|annotate_tree %}
             {% ifchanged comment.parent_id %}{% else %}</li>{% endifchanged %}
             {% if not comment.open and not comment.close %}</li>{% endif %}
             {% if comment.open %}<ul>{% endif %}

--- a/opentreemap/treemap/templatetags/comment_sequence.py
+++ b/opentreemap/treemap/templatetags/comment_sequence.py
@@ -1,0 +1,36 @@
+from django.template import Library
+
+register = Library()
+
+
+@register.filter
+def in_thread_order(comments):
+    '''Convert a list of comments in chronological order into a list of
+    comments in tree order, where the children of a comment appear
+    directly after the comment in the list.'''
+    roots = []
+    children_of = {}
+    for c in comments:
+        if c.parent:
+            if c.parent.id not in children_of:
+                children_of[c.parent.id] = []
+            children_of[c.parent.id].append(c)
+        else:
+            roots.append(c)
+
+    def order_children_for(parent):
+        if parent.id in children_of:
+            children = []
+            for child in children_of[parent.id]:
+                children.append(child)
+                children.extend(order_children_for(child))
+            return children
+        else:
+            return []
+
+    sequenced = []
+    for root in roots:
+        sequenced.append(root)
+        sequenced.extend(order_children_for(root))
+
+    return sequenced

--- a/opentreemap/treemap/tests/test_templatetags.py
+++ b/opentreemap/treemap/tests/test_templatetags.py
@@ -24,6 +24,7 @@ from treemap.tests import (make_instance, make_observer_user,
                            make_conjurer_user, make_tweaker_user)
 from treemap.tests.base import OTMTestCase
 from treemap.templatetags.util import display_name
+from treemap.templatetags.comment_sequence import in_thread_order
 from treemap.templatetags.urls import add_params
 
 
@@ -701,3 +702,22 @@ class AddParamsTest(OTMTestCase):
             add_params('/a/b?baz=0#hash', foo=1, bar=2),
             '/a/b?bar=2&foo=1&baz=0#hash'
         )
+
+
+class MockComment:
+    def __init__(self, id, parent):
+        self.id = id
+        self.parent = parent
+
+
+class InThreadOrderTest(OTMTestCase):
+    def test_in_thread_order(self):
+        root1 = MockComment(1, None)
+        root2 = MockComment(2, None)
+        nested1 = MockComment(3, root1)
+        nested12 = MockComment(4, nested1)
+        nested11 = MockComment(5, root1)
+        comments = [root1, root2, nested1, nested12, nested11]
+        self.assertEqual([c.id for c in [root1, nested1, nested12, nested11,
+                                         root2]],
+                         [c.id for c in in_thread_order(comments)])


### PR DESCRIPTION
In my analysis of the template tags in both `django-contrib-comments` and `django-threadedcomments` (the older versions we use and also the latest code in Github) I did not see any code that put comments in a parent-then-children sequence.

---

##### Testing

The test procedure in #3084 should produce correct results.

---

Connects to #3084 