### PR TITLE
Update to python-omgeo 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ pep8==1.4.6 # rq.filter: ==1.4.6
 Pillow==3.3.1
 psycopg2==2.6.2                          # http://initd.org/psycopg/docs/news.html
 python-dateutil==2.5.3                   # https://github.com/dateutil/dateutil/blob/master/NEWS
-python-omgeo==1.9.0
+python-omgeo==2.0.0
 pytz==2016.6.1                           # https://launchpad.net/pytz/+announcements
 rollbar==0.13.8                          # https://github.com/rollbar/pyrollbar/blob/master/CHANGELOG.md
 statsd==3.2.1


### PR DESCRIPTION
This release includes a required fix to the ESRI geocoder integration.

---

Connects to https://github.com/OpenTreeMap/otm-cloud/issues/384