### PR TITLE
Fix geocode test to be compatible with python-omgeo 2.0.0

### DIFF
--- a/opentreemap/geocode/tests.py
+++ b/opentreemap/geocode/tests.py
@@ -65,9 +65,9 @@ class GeocodeTest(OTMTestCase):
                          'The response should not have an error property')
         self.assertIn('lat', res, 'The reponse should have a "lat" property')
         self.assertIn('lng', res, 'The reponse should have a "lng" property')
-        self.assertTrue(abs(res['lat'] - 39.958774) < .00001,
+        self.assertTrue(abs(res['lat'] - 39.958750) < .00001,
                         'Latitude not as expected')
-        self.assertTrue(abs(res['lng'] - (-75.158384)) < .00001,
+        self.assertTrue(abs(res['lng'] - (-75.158416)) < .00001,
                         'Longitude not as expected')
 
     def test_geocoding_without_magic_key_returns_404(self):


### PR DESCRIPTION
The updated ESRI World Geocoding Service returns a slightly different lat/lng for the old Azavea office address.

<img width="1436" alt="screen shot 2017-06-29 at 11 23 35 am" src="https://user-images.githubusercontent.com/17363/27703849-8c782d7a-5cbd-11e7-9937-f25179bc712d.png">

---

Connects to https://github.com/OpenTreeMap/otm-cloud/issues/384