### PR TITLE
Update or remove python dependencies to ensure Django 1.11 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ on the old OTM1 code, and so we have left it up for archival purposes.
  - [Javascript module conventions](doc/js.md)
  - [Python mixins](doc/mixins.md)
 
+
+## Acknowledgements
+
+This application includes code based on [django-url-tools](https://bitbucket.org/monwara/django-url-tools), Copyright (c) 2013 Monwara LLC.
+
 USDA Grant
 ---------------
 Portions of OpenTreeMap are based upon work supported by the National Institute of Food and Agriculture, U.S. Department of Agriculture, under Agreement No. 2010-33610-20937, 2011-33610-30511, 2011-33610-30862 and 2012-33610-19997 of the Small Business Innovation Research Grants Program. Any opinions, findings, and conclusions, or recommendations expressed on the OpenTreeMap website are those of Azavea and do not necessarily reflect the view of the U.S. Department of Agriculture.

--- a/opentreemap/opentreemap/celery.py
+++ b/opentreemap/opentreemap/celery.py
@@ -20,11 +20,12 @@ app = Celery('opentreemap')
 app.config_from_object('django.conf:settings')
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 
-if getattr(settings, 'STATSD_CELERY_SIGNALS', False):
-    # Import here to prevent error on Celery launch
-    # that settings module is not defined
-    from django_statsd.celery import register_celery_events
-    register_celery_events()
+# TODO: Enable when django-statsd is compatible with Django > 1.8
+# if getattr(settings, 'STATSD_CELERY_SIGNALS', False):
+#     # Import here to prevent error on Celery launch
+#     # that settings module is not defined
+#     from django_statsd.celery import register_celery_events
+#     register_celery_events()
 
 rollbar_settings = getattr(settings, 'ROLLBAR', {})
 access_token = rollbar_settings.get('access_token')

--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -221,10 +221,11 @@ if ROLLBAR_ACCESS_TOKEN is not None:
         'rollbar.contrib.django.middleware.RollbarNotifierMiddleware',)
 
 # Settings for StatsD metrics aggregation
-STATSD_CLIENT = 'django_statsd.clients.normal'
-STATSD_PREFIX = '{}.django'.format(STACK_TYPE.lower())
-STATSD_HOST = os.environ.get('OTM_STATSD_HOST', 'localhost')
-STATSD_CELERY_SIGNALS = True
+# TODO: Enable when django-statsd is compatible with Django > 1.8
+# STATSD_CLIENT = 'django_statsd.clients.normal'
+# STATSD_PREFIX = '{}.django'.format(STACK_TYPE.lower())
+# STATSD_HOST = os.environ.get('OTM_STATSD_HOST', 'localhost')
+# STATSD_CELERY_SIGNALS = True
 
 STACK_COLOR = os.environ.get('OTM_STACK_COLOR', 'Black')
 CELERY_DEFAULT_QUEUE = STACK_COLOR

--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -294,7 +294,6 @@ UNMANAGED_APPS = (
     'django.contrib.humanize',
     'django.contrib.postgres',
     'djcelery',
-    'url_tools',
     'django_js_reverse',
     'webpack_loader',
 )

--- a/opentreemap/treemap/templates/treemap/partials/paging_controls.html
+++ b/opentreemap/treemap/templates/treemap/partials/paging_controls.html
@@ -1,5 +1,5 @@
 {% load l10n %}
-{% load urls %}  {# https://bitbucket.org/monwara/django-url-tools #}
+{% load urls %}
 
 {% load paging %}
 <div class="row center-block text-center">

--- a/opentreemap/treemap/templatetags/urls.py
+++ b/opentreemap/treemap/templatetags/urls.py
@@ -1,0 +1,40 @@
+import urlparse
+
+from django import template
+from django.http.request import QueryDict
+from django.utils.encoding import iri_to_uri
+
+register = template.Library()
+
+
+class UrlHelper(object):
+    def __init__(self, full_path):
+        url = urlparse.urlparse(full_path)
+        self.path = url.path
+        self.fragment = url.fragment
+        self.query_dict = QueryDict(url.query, mutable=True)
+
+    def update_query_data(self, **kwargs):
+        for key, val in kwargs.iteritems():
+            if hasattr(val, '__iter__'):
+                self.query_dict.setlist(key, val)
+            else:
+                self.query_dict[key] = val
+
+    def get_full_path(self, **kwargs):
+        query_string = self.get_query_string(**kwargs)
+        if query_string:
+            query_string = '?' + query_string
+        fragment = self.fragment and '#' + iri_to_uri(self.fragment) or ''
+
+        return iri_to_uri(self.path) + query_string + fragment
+
+    def get_query_string(self, **kwargs):
+        return self.query_dict.urlencode(**kwargs)
+
+
+@register.simple_tag
+def add_params(url, **kwargs):
+    url = UrlHelper(url)
+    url.update_query_data(**kwargs)
+    return url.get_full_path()

--- a/opentreemap/treemap/tests/test_templatetags.py
+++ b/opentreemap/treemap/tests/test_templatetags.py
@@ -22,6 +22,7 @@ from treemap.tests import (make_instance, make_observer_user,
                            make_conjurer_user, make_tweaker_user)
 from treemap.tests.base import OTMTestCase
 from treemap.templatetags.util import display_name
+from treemap.templatetags.urls import add_params
 
 
 class UserCanReadTagTest(OTMTestCase):
@@ -673,3 +674,17 @@ class DisplayValueTagTest(OTMTestCase):
 
     def test_display_value_converts_model_name(self):
         self.assertEqual('Tree', display_name(Tree()))
+
+
+class AddParamsTest(OTMTestCase):
+    def test_add_first_param(self):
+        self.assertEqual(
+            add_params('/a/b#hash', foo=1),
+            '/a/b?foo=1#hash'
+        )
+
+    def test_add_params_to_existing_param(self):
+        self.assertEqual(
+            add_params('/a/b?baz=0#hash', foo=1, bar=2),
+            '/a/b?bar=2&foo=1&baz=0#hash'
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ django-apptemplates==1.2
 # but it has not yet been released.
 celery>=3.1.15,<4.0
 django-celery-with-redis==3.0
-django-contrib-comments==1.7.3
+django-contrib-comments==1.8.0
 django-hstore==1.4.2
 django-js-reverse==0.7.2
 django-queryset-csv==0.3.3               # https://github.com/azavea/django-queryset-csv/commits/master
@@ -18,7 +18,7 @@ django-redis==4.4.4
 django-registration-redux==1.4
 django-statsd-mozilla==0.3.16
 django-storages==1.5.1
-django-threadedcomments==1.0.1
+django-threadedcomments==1.1
 django-tinsel==0.1.1
 django-url-tools==0.0.8
 django-webpack-loader==0.3.3             # https://github.com/owais/django-webpack-loader/releases

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ django-contrib-comments==1.8.0
 django-hstore==1.4.2
 django-js-reverse==0.7.2
 django-queryset-csv==0.3.3               # https://github.com/azavea/django-queryset-csv/commits/master
-django-redis==4.4.4
+django-redis==4.8.0
 django-registration-redux==1.4
 django-statsd-mozilla==0.3.16
 django-storages==1.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ django-celery-with-redis==3.0
 django-contrib-comments==1.8.0
 django-hstore==1.4.2
 django-js-reverse==0.7.3
-django-queryset-csv==0.3.3               # https://github.com/azavea/django-queryset-csv/commits/master
+django-queryset-csv==1.0.0               # https://github.com/azavea/django-queryset-csv/commits/master
 django-redis==4.8.0
 django-registration-redux==1.4
 django-statsd-mozilla==0.3.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ django-storages==1.6.3
 django-threadedcomments==1.1
 django-tinsel==0.1.1
 django-url-tools==0.0.8
-django-webpack-loader==0.3.3             # https://github.com/owais/django-webpack-loader/releases
+django-webpack-loader==0.5.0             # https://github.com/owais/django-webpack-loader/releases
 flake8==2.0 # rq.filter: ==2.0
 gunicorn==19.6.0                         # http://docs.gunicorn.org/en/stable/news.html
 hiredis==0.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ django-queryset-csv==1.0.0               # https://github.com/azavea/django-quer
 django-redis==4.8.0
 django-registration-redux==1.6
 django-statsd-mozilla==0.3.16
-django-storages==1.5.1
+django-storages==1.6.3
 django-threadedcomments==1.1
 django-tinsel==0.1.1
 django-url-tools==0.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ django-js-reverse==0.7.3
 django-queryset-csv==1.0.0               # https://github.com/azavea/django-queryset-csv/commits/master
 django-redis==4.8.0
 django-registration-redux==1.6
-django-statsd-mozilla==0.3.16
+# django-statsd-mozilla==0.3.16  # TODO: enable when compatible with Django > 1.8 https://github.com/django-statsd/django-statsd/issues/97
 django-storages==1.6.3
 django-threadedcomments==1.1
 django-tinsel==0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,6 @@ psycopg2==2.6.2                          # http://initd.org/psycopg/docs/news.ht
 python-dateutil==2.5.3                   # https://github.com/dateutil/dateutil/blob/master/NEWS
 python-omgeo==2.0.0
 pytz==2016.6.1                           # https://launchpad.net/pytz/+announcements
-rollbar==0.13.8                          # https://github.com/rollbar/pyrollbar/blob/master/CHANGELOG.md
+rollbar==0.13.12                         # https://github.com/rollbar/pyrollbar/blob/master/CHANGELOG.md
 statsd==3.2.1
 wsgiref==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ django-hstore==1.4.2
 django-js-reverse==0.7.3
 django-queryset-csv==1.0.0               # https://github.com/azavea/django-queryset-csv/commits/master
 django-redis==4.8.0
-django-registration-redux==1.4
+django-registration-redux==1.6
 django-statsd-mozilla==0.3.16
 django-storages==1.5.1
 django-threadedcomments==1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ django-registration-redux==1.6
 # django-statsd-mozilla==0.3.16  # TODO: enable when compatible with Django > 1.8 https://github.com/django-statsd/django-statsd/issues/97
 django-storages==1.6.3
 django-threadedcomments==1.1
-django-tinsel==0.1.1
+django-tinsel==1.0.0
 django-webpack-loader==0.5.0             # https://github.com/owais/django-webpack-loader/releases
 flake8==2.0 # rq.filter: ==2.0
 gunicorn==19.6.0                         # http://docs.gunicorn.org/en/stable/news.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,6 @@ django-statsd-mozilla==0.3.16
 django-storages==1.6.3
 django-threadedcomments==1.1
 django-tinsel==0.1.1
-django-url-tools==0.0.8
 django-webpack-loader==0.5.0             # https://github.com/owais/django-webpack-loader/releases
 flake8==2.0 # rq.filter: ==2.0
 gunicorn==19.6.0                         # http://docs.gunicorn.org/en/stable/news.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ celery>=3.1.15,<4.0
 django-celery-with-redis==3.0
 django-contrib-comments==1.8.0
 django-hstore==1.4.2
-django-js-reverse==0.7.2
+django-js-reverse==0.7.3
 django-queryset-csv==0.3.3               # https://github.com/azavea/django-queryset-csv/commits/master
 django-redis==4.8.0
 django-registration-redux==1.4


### PR DESCRIPTION
See the description of #3156 for a detailed checklist of updates.

---

##### Testing

- django-contrib-comments and django-threadedcomments
  - Commenting works on the tree detail page.
  - Comment moderation works on the mangement page.
- django-redis
  - Ran `redis-cli -d 1 monitor`on the services VM and:
    - Verified that eco benefits are written to and read from the cache.
    - Verified the addons health check cache test.
- django-js-reverse
  - Adding a tree and choosing "continue editing" works. (This action depends on reversing a URL in the client https://github.com/OpenTreeMap/otm-core/blob/28cd298dd5a72c7e4039c86a8275fdb62a51ea49/opentreemap/treemap/js/src/mapPage/addMapFeature.js#L275)
- django-queryset-csv
  - Can export from the map page.
  - Can export from the users management page.
  - Can export from the bulk import management page.
- django-registration-redux
  - Can register and confirm and accout.
  - Can add a user to an instance that has already registered an account.
  - Can add a user to an instance that has not already registered an account.
  - Can reset a password.
  - Can get a username reminder.
- django-storages
  - Create a testing S3 bucket, uncomment the `AWS_*` items in `default_settings.py`, add the `AWS_S3_FILE_OVERWRITE = False` setting and then verify that these actions write to S3 without error:
    - Can export a search. Multiple exports have unique names.
    - Can upload a photo to a tree.
    - Can upload a user profile photo.
    - Can export species from the bulk uploader management page.
- django-webpack-loader
  - Works as before. Pages load bundled asses.
- rollbar
  - Raise and exception from a Python view and make sure it appears in Rollbar.
- django-apptemplates
  - When deployed along with private code, ensure that template extensions are working by verifying that "By clicking Create Account you are agreeing..." is displayed on the account registration form.
- django-url-tools (replaced with core code)
  - Verify that paging works on management pages that import the `paging_controls.html` partial
    - Bulk Import
    - Photo Review
    - Comment Moderation
    - User Roles
- django-tinsel
  - All of our routes go though tinsel, so just using the app is a verification that it is working.

---

Connects to #3156