### PR TITLE
Skip tree creation if tree UDF values are empty

### DIFF
--- a/opentreemap/treemap/tests/test_views.py
+++ b/opentreemap/treemap/tests/test_views.py
@@ -597,13 +597,21 @@ class PlotUpdateTest(OTMTestCase):
         set_write_permissions(self.instance, self.user,
                               'Plot', ['udf:Test choice', 'udf:Test col'])
         set_write_permissions(self.instance, self.user,
-                              'Tree', ['udf:Test col'])
+                              'Tree', ['udf:Test choice', 'udf:Test col'])
 
         self.choice_field = UserDefinedFieldDefinition.objects.create(
             instance=self.instance,
             model_type='Plot',
             datatype=json.dumps({'type': 'choice',
                                  'choices': ['a', 'b', 'c']}),
+            iscollection=False,
+            name='Test choice')
+
+        self.tree_choice_field = UserDefinedFieldDefinition.objects.create(
+            instance=self.instance,
+            model_type='Tree',
+            datatype=json.dumps({'type': 'choice',
+                                 'choices': ['foo', 'bar', 'baz']}),
             iscollection=False,
             name='Test choice')
 
@@ -681,6 +689,46 @@ class PlotUpdateTest(OTMTestCase):
         self.assertIsNone(created_plot_update.current_tree())
 
         created_plot_update.delete_with_user(self.user)
+
+    def test_does_create_tree_when_one_tree_field_is_non_empty(self):
+        plot = Plot(instance=self.instance)
+
+        update = {'plot.geom': {'x': 4, 'y': 9},
+                  'plot.readonly': False,
+                  'tree.udf:Test choice': '',
+                  'tree.diameter': 7}
+
+        created_plot, updated_tree = update_map_feature(update, self.user,
+                                                        plot)
+
+        created_plot_update = Plot.objects.get(pk=created_plot.pk)
+        self.assertIsNotNone(created_plot_update.current_tree())
+        self.assertEqual(None, updated_tree.udfs['Test choice'])
+        self.assertEqual(7, updated_tree.diameter)
+
+        created_plot_update.current_tree().delete_with_user(self.user)
+        created_plot_update.delete_with_user(self.user)
+
+    def test_does_clear_field_if_tree_already_exists(self):
+        tree = Tree(plot=self.plot, instance=self.instance)
+        tree.udfs['Test choice'] = 'bar'
+        tree.save_with_user(self.user)
+
+        tree.refresh_from_db()
+        self.assertEqual('bar', tree.udfs['Test choice'])
+
+        update = {'plot.geom': {'x': 4, 'y': 9},
+                  'plot.readonly': False,
+                  'tree.udf:Test choice': None}
+
+        updated_plot, created_tree = update_map_feature(update, self.user,
+                                                        self.plot)
+
+        self.assertIsNotNone(created_tree)
+        self.assertEqual(None, created_tree.udfs['Test choice'])
+
+        updated_plot.current_tree().delete_with_user(self.user)
+        updated_plot.delete_with_user(self.user)
 
     def test_invalid_udf_name_fails(self):
         update = {'plot.udf:INVaLiD UTF': 'z'}

--- a/opentreemap/treemap/tests/test_views.py
+++ b/opentreemap/treemap/tests/test_views.py
@@ -668,6 +668,20 @@ class PlotUpdateTest(OTMTestCase):
         created_plot_update.current_tree().delete_with_user(self.user)
         created_plot_update.delete_with_user(self.user)
 
+    def test_does_not_create_tree_if_tree_field_value_is_an_empty_string(self):
+        plot = Plot(instance=self.instance)
+
+        update = {'plot.geom': {'x': 4, 'y': 9},
+                  'plot.readonly': False,
+                  'tree.udf:Test choice': ''}
+
+        created_plot, __ = update_map_feature(update, self.user, plot)
+
+        created_plot_update = Plot.objects.get(pk=created_plot.pk)
+        self.assertIsNone(created_plot_update.current_tree())
+
+        created_plot_update.delete_with_user(self.user)
+
     def test_invalid_udf_name_fails(self):
         update = {'plot.udf:INVaLiD UTF': 'z'}
 

--- a/opentreemap/treemap/views/map_feature.py
+++ b/opentreemap/treemap/views/map_feature.py
@@ -303,15 +303,9 @@ def update_map_feature(request_dict, user, feature):
         if (object_name not in feature_object_names + ['tree']):
             raise ValueError(split_template % identifier)
 
-        tree_udfc_names = [fdef.canonical_name
-                           for fdef in udf_defs(feature.instance, 'Tree')
-                           if fdef.iscollection]
-
-        if ((field in tree_udfc_names and
-             feature.safe_get_current_tree() is None and
-             value == [])):
-            continue
-        elif object_name == 'tree' and skip_setting_value_on_tree(value, tree):
+        if (object_name == 'tree'
+            and skip_setting_value_on_tree(
+                value, feature.safe_get_current_tree())):
             continue
         elif object_name in feature_object_names:
             model = feature

--- a/opentreemap/treemap/views/map_feature.py
+++ b/opentreemap/treemap/views/map_feature.py
@@ -284,6 +284,13 @@ def update_map_feature(request_dict, user, feature):
         except ValidationError as e:
             return package_field_errors(thing._model_name, e)
 
+    def skip_setting_value_on_tree(value, tree):
+        # If the tree is not None, we always set a value.  If the tree
+        # is None (meaning that we would be creating a new Tree
+        # object) then we only want to set a value if the value is
+        # non-empty.
+        return (tree is None) and (value in ([], '[]', '', None))
+
     tree = None
     errors = {}
 
@@ -303,6 +310,8 @@ def update_map_feature(request_dict, user, feature):
         if ((field in tree_udfc_names and
              feature.safe_get_current_tree() is None and
              value == [])):
+            continue
+        elif object_name == 'tree' and skip_setting_value_on_tree(value, tree):
             continue
         elif object_name in feature_object_names:
             model = feature


### PR DESCRIPTION
We previously added code to protect against the iOS app always sending values for all UDF fields. While this protective code does skip over the values, it only runs after the presence of a `tree:` field in the request triggers the instantiation of a `Tree`, which then gets saved.

In this commit I have added a check to skip field value processing entirely and bypass the creation of a new `Tree` in the situation where the `Tree` does not already exist and the field value is empty.

---

##### Testing

The new unit test will fail if run with the `develop` branch and passes on this branch.

On an instance that has a choice custom field on Tree, adding an empty planting site via the iOS app works correctly.

---

Connects to https://github.com/OpenTreeMap/otm-clients/issues/382