### PR TITLE
Update Django to 1.11

### DIFF
--- a/opentreemap/appevents/models.py
+++ b/opentreemap/appevents/models.py
@@ -6,11 +6,12 @@ from __future__ import division
 from django.db import models
 
 from treemap.json_field import JSONField
+from treemap.DotDict import DotDict
 
 
 class AppEvent(models.Model):
     event_type = models.CharField(max_length=255)
-    data = JSONField(blank=True)
+    data = JSONField(blank=True, default=DotDict)
     triggered_at = models.DateTimeField(auto_now_add=True)
     handler_assigned_at = models.DateTimeField(null=True)
     handled_by = models.CharField(max_length=255, blank=True)

--- a/opentreemap/manage_treemap/tests/test_instance_invitations.py
+++ b/opentreemap/manage_treemap/tests/test_instance_invitations.py
@@ -45,8 +45,8 @@ class InstanceInvitationTest(UrlTestCase):
 
     def _make_request(self):
         request = HttpRequest()
-        request.META = {'SERVER_NAME': 'blah',
-                        'SERVER_PORT': '44'}
+        request.META = {'SERVER_NAME': 'localhost',
+                        'SERVER_PORT': '80'}
         request.session = self.MockSession()
         return request
 

--- a/opentreemap/modeling/tests.py
+++ b/opentreemap/modeling/tests.py
@@ -152,7 +152,7 @@ class TestPlansList(OTMTestCase):
         self.assertEqual(plans, [self.plan_a2, self.plan_a1])
 
 
-class TestGrowthModel(SimpleTestCase):
+class TestGrowthModel(OTMTestCase):
     def setUp(self):
         self.instance = make_instance()
         self.instance.itree_region_default = 'GulfCoCHS'

--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -60,6 +60,7 @@ NEARBY_TREE_DISTANCE = 6.096  # 20ft
 DEBUG = True
 AUTH_USER_MODEL = 'treemap.User'
 INTERNAL_IPS = ['127.0.0.1']
+ALLOWED_HOSTS = ['localhost']
 
 ADMINS = (
     # ('Your Name', 'your_email@example.com'),

--- a/opentreemap/otm_comments/__init__.py
+++ b/opentreemap/otm_comments/__init__.py
@@ -4,20 +4,15 @@ from __future__ import unicode_literals
 from __future__ import division
 
 
-from otm_comments.models import EnhancedThreadedComment
-from threadedcomments.forms import ThreadedCommentForm
-
-
-class EnhancedThreadedCommentForm(ThreadedCommentForm):
-    def get_comment_model(self, *args, **kwargs):
-        return EnhancedThreadedComment
-
-
 # The contrib.comments app will load whichever app is specified in the settings
 # by COMMENT_APP.  The two methods below will make it use our subclassed Model
 def get_model():
+    # Delayed import, Apps won't be loaded yet when this module is
+    from otm_comments.models import EnhancedThreadedComment
     return EnhancedThreadedComment
 
 
 def get_form():
+    # Delayed import, Apps won't be loaded yet when this module is
+    from otm_comments.forms import EnhancedThreadedCommentForm
     return EnhancedThreadedCommentForm

--- a/opentreemap/otm_comments/forms.py
+++ b/opentreemap/otm_comments/forms.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import division
+
+from threadedcomments.forms import ThreadedCommentForm
+
+from otm_comments.models import EnhancedThreadedComment
+
+
+class EnhancedThreadedCommentForm(ThreadedCommentForm):
+    def get_comment_model(self, *args, **kwargs):
+        return EnhancedThreadedComment

--- a/opentreemap/registration_backend/urls.py
+++ b/opentreemap/registration_backend/urls.py
@@ -8,7 +8,7 @@ from views import RegistrationView, ActivationView, LoginForm
 
 
 urlpatterns = [
-    url(r'^login/?$', login, {'authentication_form': LoginForm}),
+    url(r'^login/?$', login, {'authentication_form': LoginForm}, name='login'),
     url(r'^activation-complete/$',
         TemplateView.as_view(template_name='registration/activation_complete.html'),  # NOQA
         name='registration_activation_complete'),

--- a/opentreemap/registration_backend/views.py
+++ b/opentreemap/registration_backend/views.py
@@ -7,7 +7,7 @@ from django import forms
 from django.contrib.auth.forms import AuthenticationForm
 from django.utils.translation import ugettext_lazy as _
 from django.core.urlresolvers import reverse
-from django.contrib.sites.models import RequestSite
+from django.contrib.sites.requests import RequestSite
 
 from registration import signals
 from registration.forms import RegistrationFormUniqueEmail\

--- a/opentreemap/treemap/audit.py
+++ b/opentreemap/treemap/audit.py
@@ -757,7 +757,7 @@ class FieldPermission(models.Model):
     def clean(self):
         try:
             cls = get_authorizable_class(self.model_name)
-            cls._meta.get_field_by_name(self.field_name)
+            cls._meta.get_field(self.field_name)
             assert issubclass(cls, Authorizable)
         except KeyError:
             raise ValidationError(
@@ -1429,8 +1429,7 @@ class Audit(models.Model):
                     ' deleted! This audit should be deleted as well')
 
         cls = get_auditable_class(self.model)
-        field_query = cls._meta.get_field_by_name(self.field)
-        field_cls, __, __, __ = field_query
+        field_cls = cls._meta.get_field(self.field)
         field_modified_value = field_cls.to_python(value)
 
         # handle edge cases

--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -753,7 +753,10 @@ class Instance(models.Model):
         for field in scalar_fields:
             model_name, name = field.split('.', 1)  # maxsplit of 1
             Model = Plot if model_name == 'plot' else Tree
-            standard_fields = Model._meta.get_all_field_names()
+            standard_fields = [
+                f.name for f in Model._meta.get_fields()
+                if not (f.many_to_one and f.related_model is None)
+            ]
 
             if ((name not in standard_fields and field not in scalar_udfs)):
                 errors.add(INSTANCE_FIELD_ERRORS['missing_field'])

--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -32,6 +32,7 @@ from treemap.json_field import JSONField
 from treemap.lib.object_caches import udf_defs
 from treemap.species.codes import (species_codes_for_regions,
                                    all_species_codes, ITREE_REGION_CHOICES)
+from treemap.DotDict import DotDict
 
 URL_NAME_PATTERN = r'[a-zA-Z]+[a-zA-Z0-9\-]*'
 
@@ -268,7 +269,7 @@ class Instance(models.Model):
         instance.config = DotDict({})
         instance.config.fruit.apple.type = 'macoun'
     """
-    config = JSONField(blank=True)
+    config = JSONField(blank=True, default=DotDict)
 
     is_public = models.BooleanField(default=False)
 

--- a/opentreemap/treemap/json_field.py
+++ b/opentreemap/treemap/json_field.py
@@ -1,13 +1,12 @@
 from django.contrib.gis.db import models
-from django.utils.six import with_metaclass
 
 import json
 
 from opentreemap.util import dotted_split
-from DotDict import DotDict
+from treemap.DotDict import DotDict
 
 
-class JSONField(with_metaclass(models.SubfieldBase, models.TextField)):
+class JSONField(models.TextField):
     def to_python(self, value):
         if isinstance(value, basestring):
             obj = json.loads(value or "{}")
@@ -27,6 +26,9 @@ class JSONField(with_metaclass(models.SubfieldBase, models.TextField)):
     def value_to_string(self, obj):
         value = self._get_val_from_obj(obj)
         return self.get_prep_value(value)
+
+    def from_db_value(self, value, expression, connection, context):
+        return self.to_python(value)
 
 
 def is_json_field_reference(field_path):

--- a/opentreemap/treemap/migrations/0001_initial.py
+++ b/opentreemap/treemap/migrations/0001_initial.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from django.db import models, migrations
 import re
 import django.contrib.gis.db.models.fields
-import django_hstore.fields
+import django.contrib.postgres.fields.hstore
 import treemap.json_field
 import treemap.instance
 import django.contrib.auth.models
@@ -273,7 +273,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('model_id', models.IntegerField()),
-                ('data', django_hstore.fields.DictionaryField()),
+                ('data', django.contrib.postgres.fields.hstore.HStoreField()),
             ],
             bases=(treemap.audit.UserTrackable, models.Model),
         ),

--- a/opentreemap/treemap/migrations/0044_hstorefield.py
+++ b/opentreemap/treemap/migrations/0044_hstorefield.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 from django.db import migrations
-import django.contrib.postgres.fields.hstore
 import treemap.udf
 
 
@@ -26,10 +25,5 @@ class Migration(migrations.Migration):
             field=treemap.udf.UDFPostgresField(
                 default=treemap.udf.UDFDictionary,
                 db_index=True, db_column='udfs', blank=True),
-        ),
-        migrations.AlterField(
-            model_name='userdefinedcollectionvalue',
-            name='data',
-            field=django.contrib.postgres.fields.hstore.HStoreField(),
         ),
     ]

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -103,7 +103,8 @@ class StaticPage(models.Model):
                 raise Http404('Static page does not exist')
 
             if page_name.lower() in StaticPage.DEFAULT_CONTENT:
-                template = get_template(StaticPage.DEFAULT_CONTENT[page_name])
+                template = get_template(
+                    StaticPage.DEFAULT_CONTENT[page_name.lower()])
                 content = template.render()
             else:
                 content = 'There is no content for this page yet.'

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -75,9 +75,9 @@ class StaticPage(models.Model):
     content = models.TextField()
 
     DEFAULT_CONTENT = {
-        'resources': get_template('treemap/partials/Resources.html').render(),
-        'about': get_template('treemap/partials/About.html').render(),
-        'faq': get_template('treemap/partials/FAQ.html').render()
+        'resources': 'treemap/partials/Resources.html',
+        'about': 'treemap/partials/About.html',
+        'faq': 'treemap/partials/FAQ.html'
     }
 
     @staticmethod
@@ -102,11 +102,14 @@ class StaticPage(models.Model):
             elif only_create_built_ins:
                 raise Http404('Static page does not exist')
 
-            static_page = StaticPage(
-                instance=instance, name=page_name,
-                content=StaticPage.DEFAULT_CONTENT.get(
-                    page_name.lower(),
-                    ('There is no content for this page yet.')))
+            if page_name.lower() in StaticPage.DEFAULT_CONTENT:
+                template = get_template(StaticPage.DEFAULT_CONTENT[page_name])
+                content = template.render()
+            else:
+                content = 'There is no content for this page yet.'
+
+            static_page = StaticPage(instance=instance, name=page_name,
+                                     content=content)
         return static_page
 
     @staticmethod

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -1248,7 +1248,7 @@ class MapFeaturePhoto(models.Model, PendingAuditable, Convertible):
         if thing is None:
             return None
 
-        field, __, __, __ = MapFeaturePhoto._meta.get_field_by_name(field)
+        field = MapFeaturePhoto._meta.get_field(field)
 
         saved_rep = field.pre_save(self, thing)
         return str(saved_rep)

--- a/opentreemap/treemap/templates/treemap/settings.js
+++ b/opentreemap/treemap/templates/treemap/settings.js
@@ -27,7 +27,7 @@ otm.settings.urls = Object.freeze({
     otm.settings.loggedIn = false;
 {% endif %}
 
-otm.settings.loginUrl = "{% url 'django.contrib.auth.views.login' %}?next=";
+otm.settings.loginUrl = "{% url 'login' %}?next=";
 
 otm.settings.staticUrl = '{{ STATIC_URL }}';
 

--- a/opentreemap/treemap/templates/treemap/settings.js
+++ b/opentreemap/treemap/templates/treemap/settings.js
@@ -17,7 +17,7 @@ otm.settings.urls = Object.freeze({
     'displayQueryArgumentName': 'show'
 });
 
-{% if not settings.TILE_HOST = None %}
+{% if not settings.TILE_HOST == None %}
     otm.settings.tileHost = "{{ settings.TILE_HOST }}";
 {% endif %}
 

--- a/opentreemap/treemap/templates/treemap/user.html
+++ b/opentreemap/treemap/templates/treemap/user.html
@@ -65,7 +65,7 @@ ga('global.set', 'page', pathname);
             <button id="edit-user" data-class="display" class="btn btn-sm btn-info">{% trans "Edit Profile" %}</button>
             <button id="save-edit" data-class="edit" class="btn btn-sm btn-primary" style="display: none;">{% trans "Save" %}</button>
             <button id="cancel-edit" data-class="edit" class="btn btn-sm" style="display: none;">{% trans "Cancel" %}</button>
-            <a class="btn btn-sm" href="{% url 'django.contrib.auth.views.password_reset' %}">{% trans "Reset Password" %}</a>
+            <a class="btn btn-sm" href="{% url 'auth_password_reset' %}">{% trans "Reset Password" %}</a>
             {% endusercontent %}
             <form id="user-form">
                 {% for label, identifier, template in public_fields %}

--- a/opentreemap/treemap/templatetags/form_extras.py
+++ b/opentreemap/treemap/templatetags/form_extras.py
@@ -350,7 +350,7 @@ class AbstractNode(template.Node):
         def _field_value(model, field_name, data_type):
             udf_field_name = field_name.replace('udf:', '')
             val = None
-            if field_name in model._meta.get_all_field_names():
+            if field_name in [f.name for f in model._meta.get_fields()]:
                 try:
                     val = getattr(model, field_name)
                 except (ObjectDoesNotExist, AttributeError):

--- a/opentreemap/treemap/templatetags/form_extras.py
+++ b/opentreemap/treemap/templatetags/form_extras.py
@@ -331,7 +331,7 @@ class AbstractNode(template.Node):
         user = _resolve_variable(self.user, context)
         instance = _resolve_variable(self.instance, context)
         field_template = get_template(_resolve_variable(
-                                      self.field_template, context))
+                                      self.field_template, context)).template
 
         if not isinstance(identifier, basestring)\
            or not _identifier_regex.match(identifier):

--- a/opentreemap/treemap/templatetags/partial.py
+++ b/opentreemap/treemap/templatetags/partial.py
@@ -32,5 +32,5 @@ def partial(parser, token):
         {% partial myApp/partials/house.html house %}
     """
     tag, template_name, context_item = token.split_contents()
-    template = loader.get_template(template_name)
+    template = loader.get_template(template_name).template
     return PartialNode(template, context_item)

--- a/opentreemap/treemap/tests/test_json_field.py
+++ b/opentreemap/treemap/tests/test_json_field.py
@@ -12,7 +12,9 @@ from treemap.json_field import get_attr_from_json_field, set_attr_on_json_field
 class JsonFieldTests(OTMTestCase):
     def setUp(self):
         self.instance = make_instance()
-        self.instance.config = '{"a":"x", "b":{"c":"y"}}'
+        self.instance.config = {"a": "x", "b": {"c": "y"}}
+        self.instance.save()
+        self.instance.refresh_from_db()
 
     def _assert_get(self, model, field_name, value):
         val = get_attr_from_json_field(model, field_name)

--- a/opentreemap/treemap/tests/test_search.py
+++ b/opentreemap/treemap/tests/test_search.py
@@ -56,8 +56,8 @@ def destructure_query_set(node):
 
         return n
     elif isinstance(node, tuple):
-        # Lists are unhashable, so convert ValuesListQuerySets into tuples
-        # for easy comparison
+        # Lists are unhashable, so convert QuerySets into tuples for easy
+        # comparison
         return tuple(tuple(c) if isinstance(c, QuerySet) else c for c in node)
     else:
         return node

--- a/opentreemap/treemap/tests/test_search.py
+++ b/opentreemap/treemap/tests/test_search.py
@@ -10,8 +10,8 @@ from datetime import datetime
 from functools import partial
 
 from django.db.models import Q
-from django.db.models.query import ValuesListQuerySet
 from django.db import connection
+from django.db.models.query import QuerySet
 from django.utils.tree import Node
 
 from django.contrib.gis.geos import Point, MultiPolygon
@@ -58,8 +58,7 @@ def destructure_query_set(node):
     elif isinstance(node, tuple):
         # Lists are unhashable, so convert ValuesListQuerySets into tuples
         # for easy comparison
-        return tuple(tuple(c) if isinstance(c, ValuesListQuerySet) else c
-                     for c in node)
+        return tuple(tuple(c) if isinstance(c, QuerySet) else c for c in node)
     else:
         return node
 

--- a/opentreemap/treemap/tests/test_views.py
+++ b/opentreemap/treemap/tests/test_views.py
@@ -82,9 +82,7 @@ class StaticPageViewTest(ViewTestCase):
                                      instance=self.instance)
         self.staticPage.save()
 
-        p = Point(-8515941.0, 4953519.0)
-        self.otherInstance = Instance(name='i1', geo_rev=0, center=p)
-        self.otherInstance.seed_with_dummy_default_role()
+        self.otherInstance = make_instance()
 
     def test_can_get_page(self):
         # Note- case insensitive match

--- a/opentreemap/treemap/tests/test_views.py
+++ b/opentreemap/treemap/tests/test_views.py
@@ -14,6 +14,7 @@ from django.http import Http404, HttpResponse
 from django.core.exceptions import ValidationError
 from django.db import connection
 from django.core import mail
+from django.template.loader import get_template
 
 from django.contrib.auth.models import AnonymousUser, Permission
 from django.contrib.contenttypes.models import ContentType
@@ -103,11 +104,11 @@ class StaticPageViewTest(ViewTestCase):
     def test_can_get_pre_defined_page(self):
         # Note- case insensitive match
         rslt = static_page(None, self.instance, "AbOUt")
+        content = get_template(StaticPage.DEFAULT_CONTENT['about']).render()
 
         self.assertIsNotNone(rslt['content'])
         self.assertIsNotNone(rslt['title'])
-        self.assertEqual(len(rslt['content']),
-                         len(StaticPage.DEFAULT_CONTENT['about']))
+        self.assertEqual(len(rslt['content']), len(content))
 
 
 class BoundaryViewTest(ViewTestCase):

--- a/opentreemap/treemap/tests/ui/uitest_map.py
+++ b/opentreemap/treemap/tests/ui/uitest_map.py
@@ -204,9 +204,9 @@ class MapTest(TreemapUITestCase):
             self.assertEqual(tree.diameter, 32.0)
 
 
+# Use modified URL set (e.g. to mock out tiler requests)
+@override_settings(ROOT_URLCONF='treemap.tests.ui.ui_test_urls')
 class ModeChangeTest(TreemapUITestCase):
-    urls = 'treemap.tests.ui.ui_test_urls'
-
     def test_leave_page(self):
         self.login_and_go_to_map_page()
         self.browse_to_instance_url('edits/')

--- a/opentreemap/treemap/tests/unit_test_urls.py
+++ b/opentreemap/treemap/tests/unit_test_urls.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals
 from __future__ import division
 
 from django.conf.urls import include, url
-from django.template import Template
-from django.template.response import TemplateResponse
+from django.template import Template, RequestContext
+from django.template.response import HttpResponse
 
 from opentreemap import urls
 
@@ -14,7 +14,8 @@ def last_instance(request):
     """
     Returns the PK of the last instance saved in session
     """
-    return TemplateResponse(request, Template("{{ last_instance.pk }}"))
+    template = Template("{{ last_instance.pk }}")
+    return HttpResponse(template.render(RequestContext(request, {})))
 
 
 urlpatterns = [

--- a/opentreemap/treemap/udf.py
+++ b/opentreemap/treemap/udf.py
@@ -1118,21 +1118,20 @@ class UDFModelBase(ModelBase):
     def __new__(clazz, *args, **kwargs):
         new = super(UDFModelBase, clazz).__new__(clazz, *args, **kwargs)
 
-        orig = new._meta.get_field_by_name
+        orig = new._meta.get_field
 
-        def get_field_by_name(name):
+        def get_field(name):
             try:
                 return orig(name)
             except Exception:
                 if name.startswith('udf:'):
                     udfname = get_name_from_canonical_name(name)
-                    field, model, direct, m2m = orig('udfs')
                     field = _UDFProxy(udfname)
-                    return (field, model, direct, m2m)
+                    return field
                 else:
                     raise
 
-        setattr(new._meta, 'get_field_by_name', get_field_by_name)
+        setattr(new._meta, 'get_field', get_field)
         return new
 
 

--- a/opentreemap/treemap/units.py
+++ b/opentreemap/treemap/units.py
@@ -41,9 +41,9 @@ class Convertible(object):
         # for lowerCamelCase, but `._meta.object_name` is a django
         # internal that is represented as UpperCamelCase.
         model = to_object_name(self._meta.object_name)
-        for field in self._meta.get_all_field_names():
-            if self.instance and is_convertible(model, field):
-                value = getattr(self, field)
+        for field in self._meta.get_fields():
+            if self.instance and is_convertible(model, field.name):
+                value = getattr(self, field.name)
 
                 try:
                     value = float(value)
@@ -51,9 +51,9 @@ class Convertible(object):
                     # These will be caught later in the cleaning process
                     pass
 
-                converted_value = f(self.instance, model, field, value)
+                converted_value = f(self.instance, model, field.name, value)
 
-                setattr(self, field, converted_value)
+                setattr(self, field.name, converted_value)
 
     def convert_to_display_units(self):
         if self.unit_status != 'display':

--- a/opentreemap/treemap/urls.py
+++ b/opentreemap/treemap/urls.py
@@ -35,7 +35,7 @@ urlpatterns = [
         routes.edit_map_feature_detail, name='map_feature_detail_edit'),
     url(r'^features/(?P<feature_id>\d+)/popup$',
         routes.map_feature_popup, name='map_feature_popup'),
-    url(r'^/canopy-popup$', routes.canopy_popup, name='canopy_popup'),
+    url(r'^canopy-popup$', routes.canopy_popup, name='canopy_popup'),
     url(r'^features/(?P<feature_id>\d+)/trees/(?P<tree_id>\d+)/$',
         routes.delete_tree, name='delete_tree'),
     url(r'^features/(?P<feature_id>\d+)/sidebar$',

--- a/opentreemap/treemap/views/map_feature.py
+++ b/opentreemap/treemap/views/map_feature.py
@@ -242,7 +242,7 @@ def update_map_feature(request_dict, user, feature):
 
     def set_attr_on_model(model, attr, val):
         field_classname = \
-            model._meta.get_field_by_name(attr)[0].__class__.__name__
+            model._meta.get_field(attr).__class__.__name__
 
         if field_classname.endswith('PointField'):
             srid = val.get('srid', 3857)
@@ -328,7 +328,7 @@ def update_map_feature(request_dict, user, feature):
         if not value_is_redundant(model, field, value):
             set_attr_on_model(model, field, value)
 
-        field_class = model._meta.get_field_by_name(field)[0]
+        field_class = model._meta.get_field(field)
         if isinstance(field_class, GeometryField):
             rev_updates.append('geo_rev')
             rev_updates.append('eco_rev')

--- a/opentreemap/treemap/views/map_feature.py
+++ b/opentreemap/treemap/views/map_feature.py
@@ -8,7 +8,6 @@ import hashlib
 from functools import wraps
 
 from django.http import HttpResponse
-from django.template.loader import get_template
 from django.shortcuts import get_object_or_404, render
 from django.core.exceptions import ValidationError
 from django.conf import settings
@@ -180,7 +179,6 @@ def render_map_feature_add(request, instance, type):
         app = MapFeature.get_subclass(type).__module__.split('.')[0]
         try:
             template = '%s/%s_add.html' % (app, type)
-            get_template(template)
         except:
             template = 'treemap/resource_add.html'
         return render(request, template, {'object_name': to_object_name(type)})

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 
 boto==2.42.0                             # http://docs.pythonboto.org/en/latest/releasenotes/v2.39.0.html
 # https://docs.djangoproject.com/en/1.10/releases/#id2
-Django==1.8.14  # rq.filter: >=1.8,<1.9
+Django==1.11.3  # rq.filter: >=1.11,<1.12
 django-apptemplates==1.2
 # django-celery requires celery, but is incompatible with celery
 # 4.0. django-celery has added this restriction on the master branch,

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ django-apptemplates==1.2
 celery>=3.1.15,<4.0
 django-celery-with-redis==3.0
 django-contrib-comments==1.8.0
-django-hstore==1.4.2
 django-js-reverse==0.7.3
 django-queryset-csv==1.0.0               # https://github.com/azavea/django-queryset-csv/commits/master
 django-redis==4.8.0


### PR DESCRIPTION
Updates Django to 1.11 and fixes a number of issues related to / uncovered by / blocking the upgrade.

Required by https://github.com/OpenTreeMap/otm-addons/pull/1531

Connects to https://github.com/OpenTreeMap/otm-core/issues/3157