### PR TITLE
Use ESRI credentials when geocoding stored points/addresses

### DIFF
--- a/opentreemap/geocode/tests.py
+++ b/opentreemap/geocode/tests.py
@@ -4,13 +4,16 @@ from __future__ import division
 
 import json
 import requests
+import os
 from urllib import urlencode
+from unittest import skipIf
+
+from django.http import HttpResponse
+from django.test.client import RequestFactory
 
 from treemap.tests.base import OTMTestCase
 
 from geocode.views import geocode
-from django.test.client import RequestFactory
-from django.http import HttpResponse
 
 
 class MockGeocodeRequest():
@@ -26,6 +29,9 @@ class GeocodeTest(OTMTestCase):
     def setUp(self):
         self.factory = RequestFactory()
 
+    @skipIf('ESRI_CLIENT_ID' not in os.environ
+            or 'ESRI_CLIENT_SECRET' not in os.environ,
+            'Set Esri Client ID & Secret to run authenticated geocode tests')
     def test_azavea_office_geocodes_correctly(self):
         extent = {
             'xmin': -8475485,

--- a/opentreemap/geocode/urls.py
+++ b/opentreemap/geocode/urls.py
@@ -3,8 +3,9 @@ from __future__ import unicode_literals
 from __future__ import division
 
 from django.conf.urls import url
-from geocode.views import geocode_view
+from geocode.views import geocode_view, get_esri_token_view
 
 urlpatterns = [
-    url(r'^geocode$', geocode_view, name='geocode')
+    url(r'^geocode$', geocode_view, name='geocode'),
+    url(r'^get-geocode-token$', get_esri_token_view, name='get_geocode_token')
 ]

--- a/opentreemap/geocode/views.py
+++ b/opentreemap/geocode/views.py
@@ -14,9 +14,11 @@ from django_tinsel.decorators import json_api_call
 
 from omgeo import Geocoder
 from omgeo.places import Viewbox, PlaceQuery
+from omgeo.services.esri import EsriWGS
 
 
 geocoder = Geocoder(sources=settings.OMGEO_SETTINGS)
+ESRI_WGS = EsriWGS(settings=settings.OMGEO_SETTINGS[0][1]['settings'])
 
 
 def _omgeo_candidate_to_dict(candidate, srid=3857):
@@ -86,10 +88,11 @@ def geocode(request):
     """
     key = request.GET.get('key')
     address = request.GET.get('address').encode('utf-8')
+    for_storage = 'forStorage' in request.GET
 
     if key:
         # See settings.OMGEO_SETTINGS for configuration
-        pq = PlaceQuery(query=address, key=key)
+        pq = PlaceQuery(query=address, key=key, for_storage=for_storage)
         geocode_result = geocoder.geocode(pq)
         candidates = geocode_result.get('candidates', None)
         if candidates:
@@ -105,4 +108,9 @@ def geocode(request):
     return _no_results_response(address)
 
 
+def get_esri_token(request):
+    return {'token': ESRI_WGS.get_token()}
+
+
 geocode_view = json_api_call(geocode)
+get_esri_token_view = json_api_call(get_esri_token)

--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -85,8 +85,11 @@ OMGEO_SETTINGS = [[
             ),
             postprocessors.GroupBy('match_addr'),
             postprocessors.GroupBy(('x', 'y')),
-            postprocessors.SnapPoints(distance=10)
-        ]
+            postprocessors.SnapPoints(distance=10)],
+        'settings': {
+            'client_id': os.environ.get('ESRI_CLIENT_ID'),
+            'client_secret': os.environ.get('ESRI_CLIENT_SECRET')
+        }
     }
 ]]
 

--- a/opentreemap/treemap/js/src/lib/geocoderUi.js
+++ b/opentreemap/treemap/js/src/lib/geocoderUi.js
@@ -30,7 +30,7 @@ module.exports = function (options) {
             .flatMap(getDatum)
             .filter(_.identity),  // ignore false values
         gcoder = geocoder(),
-        geocodedLocationStream = gcoder.geocodeStream(geocodeCandidateStream);
+        geocodedLocationStream = gcoder.geocodeStream(geocodeCandidateStream, options.forStorage);
 
     enterOrClickStream.onValue(function () {
         _.each(typeaheads, function (ta) {

--- a/opentreemap/treemap/js/src/mapPage/addMapFeature.js
+++ b/opentreemap/treemap/js/src/mapPage/addMapFeature.js
@@ -95,7 +95,8 @@ function init(options) {
         }),
         geocodedLocationStream = geocoderUi({
             locationTypeahead: addressTypeahead,
-            searchButton: '.geocode'
+            searchButton: '.geocode',
+            forStorage: true
         }).geocodedLocationStream;
 
     geocodedLocationStream.onValue(onLocationChosen);

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ pep8==1.4.6 # rq.filter: ==1.4.6
 Pillow==3.3.1
 psycopg2==2.6.2                          # http://initd.org/psycopg/docs/news.html
 python-dateutil==2.5.3                   # https://github.com/dateutil/dateutil/blob/master/NEWS
-git+https://github.com/maurizi/python-omgeo.git@authenticate-esri-wgs
+python-omgeo==3.0.0
 pytz==2016.6.1                           # https://launchpad.net/pytz/+announcements
 rollbar==0.13.12                         # https://github.com/rollbar/pyrollbar/blob/master/CHANGELOG.md
 statsd==3.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ pep8==1.4.6 # rq.filter: ==1.4.6
 Pillow==3.3.1
 psycopg2==2.6.2                          # http://initd.org/psycopg/docs/news.html
 python-dateutil==2.5.3                   # https://github.com/dateutil/dateutil/blob/master/NEWS
-python-omgeo==2.0.0
+git+https://github.com/maurizi/python-omgeo.git@authenticate-esri-wgs
 pytz==2016.6.1                           # https://launchpad.net/pytz/+announcements
 rollbar==0.13.12                         # https://github.com/rollbar/pyrollbar/blob/master/CHANGELOG.md
 statsd==3.2.1


### PR DESCRIPTION
This is required to be compliant with the ESRI terms of service.

Some of our uses of geocoding are "use and discard" and we don't need to pass the  `forStorage` flag, so I made it an option to `geocodeStream`. All uses of `reverseGeocodeStream` can be stored in a database, so I made it always pass `forStorage`

Required by https://github.com/OpenTreeMap/otm-addons/pull/1540
Depends on https://github.com/OpenTreeMap/otm-cloud/pull/401

Connects to OpenTreeMap/otm-cloud#309