### PR TITLE
Fix password rest done routing error

### DIFF
--- a/opentreemap/registration_backend/views.py
+++ b/opentreemap/registration_backend/views.py
@@ -11,6 +11,7 @@ from django.core.urlresolvers import reverse
 from django.contrib.sites.requests import RequestSite
 from django.contrib.auth.views import\
     PasswordResetView as DefaultPasswordResetView
+from django.urls import reverse_lazy
 
 from registration import signals
 from registration.forms import RegistrationFormUniqueEmail\
@@ -191,6 +192,10 @@ class ActivationView(DefaultActivationView):
 
 
 class PasswordResetView(DefaultPasswordResetView):
+    # Override the value of `password_reset_done` set in the default
+    # PasswordResetView
+    success_url = reverse_lazy('auth_password_reset_done')
+
     def post(self, request, *args, **kwargs):
         form = self.get_form()
 


### PR DESCRIPTION
The reverse name of the URL to be loaded after a successful password reset request is `auth_password_reset_done`. The base `PasswordResetView` from `django.contrib.auth` hard codes the reverse name `password_reset_done` that we must override.

--- 

##### Testing

After submitting a password reset request you should be successfully redirected to `/accounts/password/reset/done/`

---

Connects to #3178