### PR TITLE
Add link from modeling scenarios to prioritization demo

### DIFF
--- a/assets/css/sass/partials/pages/_modeling.scss
+++ b/assets/css/sass/partials/pages/_modeling.scss
@@ -153,7 +153,8 @@
             position: absolute;
             z-index: 998;
             top: 0;
-            right: 0;
+            left: 0;
+            border-right: 1px solid #ddd;
 
             > .btn {
                 padding: 9px 13px;
@@ -170,7 +171,7 @@
         }
 
         .scenario-button-container {
-            padding-left: 10px;
+            padding-left: 50px;
             position: relative;
             white-space: nowrap;
             margin-top: -2px;

--- a/opentreemap/modeling/js/src/modeling.js
+++ b/opentreemap/modeling/js/src/modeling.js
@@ -3,6 +3,7 @@
 var $ = require('jquery'),
     _ = require('lodash'),
     Bacon = require('baconjs'),
+    L = require('leaflet'),
     U = require('treemap/lib/utility.js'),
     toastr = require('toastr'),
     MapPage = require('treemap/lib/mapPage.js'),
@@ -117,9 +118,9 @@ function init() {
 }
 
 function appendCenterToPrioritizationLink() {
-    var center = L.Projection.SphericalMercator.unproject(
-        L.point(otm.settings.instance.center.x,
-                otm.settings.instance.center.y)),
+    var instanceCenter = window.otm.settings.instance.center,
+        center = L.Projection.SphericalMercator.unproject(
+            L.point(instanceCenter.x, instanceCenter.y)),
         prioritizationHref = $(dom.scenarioPrioritizationLink).attr('href');
     $(dom.scenarioPrioritizationLink).attr('href', prioritizationHref + '?center=' + center.lat + ',' + center.lng);
 }

--- a/opentreemap/modeling/js/src/modeling.js
+++ b/opentreemap/modeling/js/src/modeling.js
@@ -30,7 +30,8 @@ var dom = {
     modelVisibility: '#model-visibility',
     modelVisibilityText: '#model-visibility-text',
     autosaveMessage: '#autosave-message',
-    noRegionModal: '#noRegion'
+    noRegionModal: '#noRegion',
+    scenarioPrioritizationLink: '#scenario-prioritization-link'
 };
 
 var _strings = window.modelingOptions.strings,
@@ -112,6 +113,15 @@ function init() {
 
     urlState.init();  // must happen after URL state handlers are set up
     showPlanListIfNoPlanChosen();
+    appendCenterToPrioritizationLink();
+}
+
+function appendCenterToPrioritizationLink() {
+    var center = L.Projection.SphericalMercator.unproject(
+        L.point(otm.settings.instance.center.x,
+                otm.settings.instance.center.y)),
+        prioritizationHref = $(dom.scenarioPrioritizationLink).attr('href');
+    $(dom.scenarioPrioritizationLink).attr('href', prioritizationHref + '?center=' + center.lat + ',' + center.lng);
 }
 
 function showPlanListIfNoPlanChosen() {

--- a/opentreemap/modeling/templates/modeling/modeling.html
+++ b/opentreemap/modeling/templates/modeling/modeling.html
@@ -52,7 +52,7 @@
 
 {% block content %}
 <div id="view-switcher">
-    <div id="scenario-dropdown" class="btn-group pull-right">
+    <div id="scenario-dropdown" class="btn-group pull-left">
         <button type="button" class="btn dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <i class="icon-menu"></i>
         </button>
@@ -63,6 +63,10 @@
             {% trans "+ Add scenario" %}
         </button>
         <div id="scenario-buttons"></div>
+
+        <div class="pull-right">
+            <a id="scenario-prioritization-link" class="btn" href="https://treeprioritization.geotrellis.io">{% trans "Prioritize plantings" %}</a>
+        </div>
     </div>
 </div>
 <div class="content map">


### PR DESCRIPTION
We extracted the modeling prioritization functionality into a separate demo application. In this commit we link to that application, passing the instance center coordinate so that prioritization starts in the same location as the instance.

After some design iteration we decided to move the scenario burger button to the far left of the toolbar to make room for the new prioritization link.

---

##### Testing

- Create an instance and go to the "Plan" page.
- Create a new plan, then click the "Prioritize plantings" link. You should be taken to treeprioritization.geotrellis.io with the map centered on the same location as the instance

---

Connects to https://github.com/OpenTreeMap/otm-addons/issues/1535