### PR TITLE
Update requirements.txt

### DIFF
--- a/opentreemap/appevents/tasks.py
+++ b/opentreemap/appevents/tasks.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 
-from celery import task
+from celery import shared_task
 from django.db import transaction
 from django.utils.timezone import now
 from django.conf import settings
@@ -44,13 +44,13 @@ def _get_handler_path_for_event(event):
                                  DEFAULT_HANDLER_PATH)
 
 
-@task
+@shared_task
 def queue_events_to_be_handled():
     for event in AppEvent.objects.filter(handler_assigned_at=None):
         handle_event.delay(event.pk)
 
 
-@task
+@shared_task
 def handle_event(event_id):
     event = _lookup_and_assign_handler(event_id)
     if event is None:

--- a/opentreemap/exporter/tasks.py
+++ b/opentreemap/exporter/tasks.py
@@ -9,7 +9,7 @@ import logging
 from contextlib import contextmanager
 from functools import wraps
 from collections import OrderedDict
-from celery import task
+from celery import shared_task
 from tempfile import TemporaryFile
 
 from django.core.files import File
@@ -114,7 +114,7 @@ def _values_for_model(
     return prefixed_names
 
 
-@task
+@shared_task
 @_job_transaction
 def async_users_export(job, data_format):
     instance = job.instance
@@ -130,7 +130,7 @@ def async_users_export(job, data_format):
     job.save()
 
 
-@task
+@shared_task
 @_job_transaction
 def async_csv_export(job, model, query, display_filters):
     instance = job.instance
@@ -269,7 +269,7 @@ def _csv_field_header_map(field_names):
     return map
 
 
-@task
+@shared_task
 @_job_transaction
 def simple_async_csv(job, qs):
     file_obj = TemporaryFile()
@@ -278,7 +278,7 @@ def simple_async_csv(job, qs):
     job.save()
 
 
-@task
+@shared_task
 def custom_async_csv(csv_rows, job_pk, filename, fields):
     with _job_transaction_manager(job_pk) as job:
         csv_obj = TemporaryFile()

--- a/opentreemap/importer/tests.py
+++ b/opentreemap/importer/tests.py
@@ -15,7 +15,6 @@ from unittest.case import skip, skipIf
 
 from django.conf import settings
 from django.db import connection
-from django.test import TestCase
 from django.test.utils import override_settings
 from django.http import HttpRequest, HttpResponseBadRequest
 from django.contrib.gis.geos import Point, Polygon, MultiPolygon
@@ -30,6 +29,7 @@ from treemap.models import (Species, Plot, Tree, ITreeCodeOverride,
 from treemap.plugin import get_tree_limit
 from treemap.tests import (make_admin_user, make_instance, login,
                            ecoservice_not_running, make_request)
+from treemap.tests.base import OTMTestCase
 from treemap.udf import UserDefinedFieldDefinition
 
 from importer import errors, fields
@@ -40,7 +40,7 @@ from importer.views import (process_status,
                             commit, merge_species, start_import)
 
 
-class MergeTest(TestCase):
+class MergeTest(OTMTestCase):
     def setUp(self):
         self.instance = setupTreemapEnv()
 
@@ -98,7 +98,7 @@ class MergeTest(TestCase):
         self.assertEqual(t2r.species.pk, self.s2.pk)
 
 
-class ValidationTest(TestCase):
+class ValidationTest(OTMTestCase):
 
     def assertHasError(self, thing, error, data=None, df=None):
         local_errors = ''
@@ -962,7 +962,7 @@ class FileLevelTreeValidationTest(ValidationTest):
 
 
 @override_settings(TREE_LIMIT_FUNCTION=None)
-class IntegrationTests(TestCase):
+class IntegrationTests(OTMTestCase):
     def setUp(self):
         self.instance = setupTreemapEnv()
 
@@ -1078,7 +1078,7 @@ class SpeciesIntegrationTests(IntegrationTests):
         self.assertEqual(species.max_height, int(100 * m_to_ft))
 
 
-class SpeciesExportTests(TestCase):
+class SpeciesExportTests(OTMTestCase):
     def setUp(self):
         instance = make_instance()
         user = make_admin_user(instance)

--- a/opentreemap/opentreemap/__init__.py
+++ b/opentreemap/opentreemap/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
+from .celery import app as celery_app  # NOQA
+
+__all__ = ['celery_app']

--- a/opentreemap/opentreemap/celery.py
+++ b/opentreemap/opentreemap/celery.py
@@ -2,12 +2,9 @@ from __future__ import absolute_import
 
 import os
 
-import rollbar
-
 from celery import Celery
 from celery.signals import task_failure
 
-from django.conf import settings
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault('DJANGO_SETTINGS_MODULE',
@@ -17,8 +14,8 @@ app = Celery('opentreemap')
 
 # Using a string here means the worker will not have to
 # pickle the object when using Windows.
-app.config_from_object('django.conf:settings')
-app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
+app.config_from_object('django.conf:settings', namespace='CELERY')
+app.autodiscover_tasks()
 
 # TODO: Enable when django-statsd is compatible with Django > 1.8
 # if getattr(settings, 'STATSD_CELERY_SIGNALS', False):
@@ -27,13 +24,23 @@ app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 #     from django_statsd.celery import register_celery_events
 #     register_celery_events()
 
-rollbar_settings = getattr(settings, 'ROLLBAR', {})
-access_token = rollbar_settings.get('access_token')
-if access_token:
-    rollbar.init(access_token, rollbar_settings['environment'])
+
+rollbar_setup = False
 
 
 @task_failure.connect
 def handle_task_failure(**kw):
+    # Rollbar initialization has to be done lazily, or the server segfaults
+    # when starting :(
+    from django.conf import settings
+    import rollbar
+    global rollbar_setup
+
+    rollbar_settings = getattr(settings, 'ROLLBAR', {})
+    access_token = rollbar_settings.get('access_token')
+    if access_token and not rollbar_setup:
+        rollbar.init(access_token, rollbar_settings['environment'])
+        rollbar_setup = True
+
     if access_token:
         rollbar.report_exc_info(extra_data=kw)

--- a/opentreemap/opentreemap/settings/__init__.py
+++ b/opentreemap/opentreemap/settings/__init__.py
@@ -41,9 +41,3 @@ RESERVED_INSTANCE_URL_NAMES += EXTRA_RESERVED_INSTANCE_URL_NAMES
 
 DISPLAY_DEFAULTS.update(EXTRA_DISPLAY_DEFAULTS)
 STORAGE_UNITS.update(EXTRA_STORAGE_UNITS)
-
-# CELERY
-# NOTE: BROKER_URL and CELERY_RESULT_BACKEND must be set
-#       to a valid redis URL in local_settings.py
-import djcelery
-djcelery.setup_loader()

--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -258,7 +258,7 @@ STACK_COLOR = os.environ.get('OTM_STACK_COLOR', 'Black')
 CELERY_TASK_DEFAULT_QUEUE = STACK_COLOR
 CELERY_TASK_DEFAULT_ROUTING_KEY = "task.%s" % STACK_COLOR
 CELERY_TASK_SERIALIZER = 'pickle'
-CELERY_ACCEPT_CONTENT = ['pickle']
+CELERY_ACCEPT_CONTENT = ['pickle', 'application/json']
 
 ROOT_URLCONF = 'opentreemap.urls'
 

--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -254,8 +254,11 @@ if ROLLBAR_SERVER_ACCESS_TOKEN is not None:
 # STATSD_CELERY_SIGNALS = True
 
 STACK_COLOR = os.environ.get('OTM_STACK_COLOR', 'Black')
-CELERY_DEFAULT_QUEUE = STACK_COLOR
-CELERY_DEFAULT_ROUTING_KEY = "task.%s" % STACK_COLOR
+
+CELERY_TASK_DEFAULT_QUEUE = STACK_COLOR
+CELERY_TASK_DEFAULT_ROUTING_KEY = "task.%s" % STACK_COLOR
+CELERY_TASK_SERIALIZER = 'pickle'
+CELERY_ACCEPT_CONTENT = ['pickle']
 
 ROOT_URLCONF = 'opentreemap.urls'
 
@@ -295,7 +298,6 @@ INSTALLED_APPS = (
     'django.contrib.gis',
     'django.contrib.humanize',
     'django.contrib.postgres',
-    'djcelery',
     'django_js_reverse',
     'webpack_loader',
 )

--- a/opentreemap/treemap/tests/__init__.py
+++ b/opentreemap/treemap/tests/__init__.py
@@ -27,10 +27,8 @@ from treemap.audit import Authorizable, add_default_permissions
 from treemap.util import leaf_models_of_class
 from treemap.tests.base import OTMTestCase
 
-from djcelery.contrib.test_runner import CeleryTestSuiteRunner
 
-
-class OTM2TestRunner(CeleryTestSuiteRunner, DiscoverRunner):
+class OTM2TestRunner(DiscoverRunner):
 
     def run_tests(self, *args, **kwargs):
         logging.disable(logging.CRITICAL)

--- a/opentreemap/treemap/tests/base.py
+++ b/opentreemap/treemap/tests/base.py
@@ -10,6 +10,9 @@ test_settings = {
     # Without this we'd need to invalidate the cache before every test.
     'USE_OBJECT_CACHES': False,
     'USE_ECO_CACHE': False,
+
+    'CELERY_TASK_ALWAYS_EAGER': True,
+    'CELERY_TASK_EAGER_PROPAGATES': True
 }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,38 +1,55 @@
 # For outdated module report see https://requires.io/github/OpenTreeMap/otm-core/requirements/?branch=develop
 # Changelog URL shown below if not linked on above page
 
-boto==2.42.0                             # http://docs.pythonboto.org/en/latest/releasenotes/v2.39.0.html
-# https://docs.djangoproject.com/en/1.10/releases/#id2
-Django==1.11.3  # rq.filter: >=1.11,<1.12
-django-apptemplates==1.2
+amqp==1.4.9
+anyjson==0.3.3
+billiard==3.3.0.23
+boto==2.48.0                             # http://docs.pythonboto.org/en/latest/releasenotes/v2.39.0.html
 # django-celery requires celery, but is incompatible with celery
 # 4.0. django-celery has added this restriction on the master branch,
 # but it has not yet been released.
-celery>=3.1.15,<4.0
+celery==3.1.25
+certifi==2017.7.27.1
+chardet==3.0.4
+# https://docs.djangoproject.com/en/1.10/releases/#id2
+Django==1.11.4  # rq.filter: >=1.11,<1.12
+django-apptemplates==1.3
+django-celery==3.2.1
 django-celery-with-redis==3.0
 django-contrib-comments==1.8.0
 django-js-reverse==0.7.3
 django-queryset-csv==1.0.0               # https://github.com/azavea/django-queryset-csv/commits/master
 django-redis==4.8.0
-django-registration-redux==1.6
+django-registration-redux==1.7
 # django-statsd-mozilla==0.3.16  # TODO: enable when compatible with Django > 1.8 https://github.com/django-statsd/django-statsd/issues/97
-django-storages==1.6.3
+django-storages==1.6.5
 django-threadedcomments==1.1
 django-tinsel==1.0.0
 django-webpack-loader==0.5.0             # https://github.com/owais/django-webpack-loader/releases
 flake8==2.0 # rq.filter: ==2.0
-gunicorn==19.6.0                         # http://docs.gunicorn.org/en/stable/news.html
+functools32==3.2.3.post2
+gunicorn==19.7.1                         # http://docs.gunicorn.org/en/stable/news.html
 hiredis==0.2.0
+idna==2.5
+jsonschema==2.6.0
+kombu==3.0.37
 libsass==0.11.2
+mccabe==0.6.1
 # Modgrammar-py2 has a 0.9.2 release on PyPi, but no artifacts for the release
 modgrammar-py2==0.9.1 # rq.filter: !=0.9.2
+olefile==0.44
 pep8==1.4.6 # rq.filter: ==1.4.6
-Pillow==3.3.1
-psycopg2==2.6.2                          # http://initd.org/psycopg/docs/news.html
-python-dateutil==2.5.3                   # https://github.com/dateutil/dateutil/blob/master/NEWS
+Pillow==4.2.1
+psycopg2==2.7.3                          # http://initd.org/psycopg/docs/news.html
+pyflakes==1.6.0
+python-dateutil==2.6.1                   # https://github.com/dateutil/dateutil/blob/master/NEWS
 python-omgeo==3.0.0
-pytz==2016.6.1                           # https://launchpad.net/pytz/+announcements
+pytz==2017.2                             # https://launchpad.net/pytz/+announcements
+redis==2.10.5
+requests==2.18.3
 rollbar==0.13.12                         # https://github.com/rollbar/pyrollbar/blob/master/CHANGELOG.md
+six==1.10.0
 statsd==3.2.1
+unicodecsv==0.14.1
+urllib3==1.22
 wsgiref==0.1.2
-jsonschema==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,16 @@
 # For outdated module report see https://requires.io/github/OpenTreeMap/otm-core/requirements/?branch=develop
 # Changelog URL shown below if not linked on above page
 
-amqp==1.4.9
+amqp==2.2.1
 anyjson==0.3.3
-billiard==3.3.0.23
+billiard==3.5.0.3
 boto==2.48.0                             # http://docs.pythonboto.org/en/latest/releasenotes/v2.39.0.html
-# django-celery requires celery, but is incompatible with celery
-# 4.0. django-celery has added this restriction on the master branch,
-# but it has not yet been released.
-celery==3.1.25
+celery==4.1.0
 certifi==2017.7.27.1
 chardet==3.0.4
 # https://docs.djangoproject.com/en/1.10/releases/#id2
 Django==1.11.4  # rq.filter: >=1.11,<1.12
 django-apptemplates==1.3
-django-celery==3.2.1
-django-celery-with-redis==3.0
 django-contrib-comments==1.8.0
 django-js-reverse==0.7.3
 django-queryset-csv==1.0.0               # https://github.com/azavea/django-queryset-csv/commits/master
@@ -32,7 +27,7 @@ gunicorn==19.7.1                         # http://docs.gunicorn.org/en/stable/ne
 hiredis==0.2.0
 idna==2.5
 jsonschema==2.6.0
-kombu==3.0.37
+kombu==4.1.0
 libsass==0.11.2
 mccabe==0.6.1
 # Modgrammar-py2 has a 0.9.2 release on PyPi, but no artifacts for the release


### PR DESCRIPTION
Alphabetizes listed requirements

Updates:
 - boto
 - Django
 - django-apptemplates
 - django-registration-redux
 - django-storages
 - gunicorn
 - jsonschema
 - Pillow
 - psycopg2
 - python-dateutil
 - pytz

Adds transitive dependencies to requirements.txt

Depends on https://github.com/OpenTreeMap/otm-cloud/pull/406

Connects to #3113
Connects to #3114
Connects to #1812