### PR TITLE
Make email notifications for accepted invitations pluggable

### DIFF
--- a/opentreemap/treemap/plugin.py
+++ b/opentreemap/treemap/plugin.py
@@ -102,3 +102,7 @@ can_add_user = get_plugin_function(
 
 does_user_own_instance = get_plugin_function(
     'INSTANCE_OWNER_FUNCTION', lambda instance, user: False)
+
+
+invitation_accepted_notification_emails = get_plugin_function(
+    'INVITATION_ACCEPTED_NOTIFICATION_EMAILS', lambda invitation: [])


### PR DESCRIPTION
We have decided that instead of notifying every user with management access, which could be a long list of people uninterested or confused by the notification we will instead notify only the person who sent the invitation. Additional recipients can be added by implementing a new plugin function.

---


##### Testing

- Tail the syslog so that you can see the emails being sent.
- Create an instance.
- Invite a user and make them an administrator with management access.
- Invite a third user.
- Accept the invitation sent to the fourth user. Verify that the notification email was sent to just the instance owner.

---

Related to https://github.com/OpenTreeMap/otm-addons/pull/1544
Related to https://github.com/OpenTreeMap/otm-cloud/pull/403

Connects to https://github.com/OpenTreeMap/otm-clients/issues/388
