### PR TITLE
Set updated_at and updated_by when bulk updating plots/trees

### DIFF
--- a/opentreemap/importer/models/trees.py
+++ b/opentreemap/importer/models/trees.py
@@ -224,6 +224,7 @@ class TreeImportRow(GenericImportRow):
 
         if plot_edited:
             plot.save_with_system_user_bypass_auth()
+            plot.update_updated_fields(ie.owner)
 
     def _commit_tree_data(self, data, plot, tree, tree_edited):
         for tree_attr, field_name in TreeImportRow.TREE_MAP.iteritems():
@@ -250,6 +251,7 @@ class TreeImportRow(GenericImportRow):
         if tree_edited:
             tree.plot = plot
             tree.save_with_system_user_bypass_auth()
+            tree.plot.update_updated_fields(ie.owner)
 
     def validate_geom(self):
         x = self.cleaned.get(fields.trees.POINT_X, None)


### PR DESCRIPTION
The importer bypasses authorization and was also bypassing the updates to the updated_at and updated_by fields.

---

##### Testing

- Create an instance with two management access users, A and B. Ensure the instance is not in trial mode so that exports are enabled.
- Log in as user A.
- Create a tree with a diameter and export it.
- Modify the exported CSV.
  - Remove the stewardship columns
  - Change the diameter value
- Log in as user B.
- Import the exported and edited CSV.
- Export once more and compare the two CSVs, verifying that the updated_by and updated_at field values change.

---

Connects to #3171 