### PR TITLE
Clear location search box when clicking Reset

### DIFF
--- a/opentreemap/treemap/js/src/lib/searchBar.js
+++ b/opentreemap/treemap/js/src/lib/searchBar.js
@@ -378,7 +378,11 @@ module.exports = exports = {
                     return !(datum && datum.magicKey);
                 })
                 .map(Search.buildSearch),
-            resetStream = $(dom.resetButton).asEventStream("click"),
+            resetStream = $(dom.resetButton)
+                .asEventStream("click")
+                // We must also clear the location search box to avoid
+                // an inconsistent state when clicking reset after a geocode.
+                .doAction(function () { locationTypeahead.clear(); }),
             uSearch = udfcSearch.init(resetStream),
             searchChangedStream = Bacon
                 .mergeAll(searchStream, resetStream)


### PR DESCRIPTION
Calling `locationTypeahead.clear()` ensures that the search UI is in a consistent state when clicking "Reset" directly after geocoding.

---

##### Testing

- Follow the reproduction steps in https://github.com/OpenTreeMap/otm-core/issues/3125
- Ensure that other location search / reset workflows still work.

---

Connects to #3125