### PR TITLE
Fix stale search results by incrementing rev after adding a photo

### DIFF
--- a/opentreemap/treemap/lib/tree.py
+++ b/opentreemap/treemap/lib/tree.py
@@ -44,4 +44,7 @@ def add_tree_photo_helper(request, instance, feature_id, tree_id=None):
     data = get_image_from_request(request)
     treephoto = tree.add_photo(data, request.user)
 
+    # We must update a rev so that missing photo searches are up to date
+    instance.update_universal_rev()
+
     return treephoto, tree

--- a/opentreemap/treemap/views/map_feature.py
+++ b/opentreemap/treemap/views/map_feature.py
@@ -56,7 +56,10 @@ def _request_to_update_map_feature(request, feature):
 def _add_map_feature_photo_helper(request, instance, feature_id):
     feature = get_map_feature_or_404(feature_id, instance)
     data = get_image_from_request(request)
-    return feature.add_photo(data, request.user)
+    photo = feature.add_photo(data, request.user)
+    # We must update a rev so that missing photo searches are up to date
+    instance.update_universal_rev()
+    return photo
 
 
 def get_photo_context_and_errors(fn):


### PR DESCRIPTION
Searches results for trees or green infrastructure resources with missing photos were not updating after adding photos. I resolved this by ensuring that we increment the `universal_rev` after adding a photo.

---

##### Testing

- Create an instance with green infrastructure and enable the GI features.
- Add 2 trees and a GI resource.
- Search for missing photos, should match 2 trees and 1 resource.
- In a separate tab, load the detail page for the GI resource and add a photo.
- Refresh the search page. The missing photo count should drop to 2 trees and 0 resources.
- Repeat the process and add a photo to a tree. The count should drop to 1 tree and 0 resources.
- Use a mobile app to add a photo to the remaining tree. After refreshing the map page the count should drop to 0 trees and 0 resources.

---

Connects to #3126 