### PR TITLE
Add 'other_part_of_name' (Variety) to species scientific name

### DIFF
--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -469,13 +469,19 @@ class Instance(models.Model):
         # To get a unique thumbprint across instances and species updates
         # we use the instance's url_name, latest species update time, and
         # species count (to handle deletions).
+        #
+        # Note: On 8/28/17, added a version to invalidate cache after changing
+        # data included in scientific name
         from treemap.models import Species
         my_species = Species.objects \
             .filter(instance_id=self.id) \
             .order_by('-updated_at')
+        version = 1
         if my_species.exists():
-            return "%s_%s_%s" % (
-                self.url_name, my_species.count(), my_species[0].updated_at)
+            return "%s_%s_%s_%s" % (
+                self.url_name, my_species.count(), my_species[0].updated_at,
+                version
+            )
         else:
             return self.url_name
 

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -491,19 +491,20 @@ class Species(PendingAuditable, models.Model):
         return "%s [%s]" % (self.common_name, self.scientific_name)
 
     @classmethod
-    def get_scientific_name(clazz, genus, species, cultivar):
+    def get_scientific_name(clz, genus, species, cultivar, other_part_of_name):
         name = genus
         if species:
             name += " " + species
+        if other_part_of_name:
+            name += " " + other_part_of_name
         if cultivar:
             name += " '%s'" % cultivar
         return name
 
     @property
     def scientific_name(self):
-        return Species.get_scientific_name(self.genus,
-                                           self.species,
-                                           self.cultivar)
+        return Species.get_scientific_name(
+            self.genus, self.species, self.cultivar, self.other_part_of_name)
 
     def dict(self):
         props = self.as_dict()

--- a/opentreemap/treemap/tests/test_views.py
+++ b/opentreemap/treemap/tests/test_views.py
@@ -1711,6 +1711,7 @@ class SpeciesViewTests(ViewTestCase):
             js_species['genus'] = species.genus
             js_species['species'] = species.species
             js_species['cultivar'] = species.cultivar
+            js_species['other_part_of_name'] = species.other_part_of_name
 
     def test_get_species_list(self):
         self.assertEquals(species_list(make_request(), self.instance),

--- a/opentreemap/treemap/views/misc.py
+++ b/opentreemap/treemap/views/misc.py
@@ -149,8 +149,8 @@ def species_list(request, instance):
 
     species_qs = instance.scope_model(Species)\
                          .order_by('common_name')\
-                         .values('common_name', 'genus',
-                                 'species', 'cultivar', 'id')
+                         .values('common_name', 'genus', 'species', 'cultivar',
+                                 'other_part_of_name', 'id')
 
     if max_items:
         species_qs = species_qs[:max_items]
@@ -160,7 +160,8 @@ def species_list(request, instance):
         names = (species['common_name'],
                  species['genus'],
                  species['species'],
-                 species['cultivar'])
+                 species['cultivar'],
+                 species['other_part_of_name'])
 
         tokens = set()
 
@@ -174,7 +175,8 @@ def species_list(request, instance):
     def annotate_species_dict(sdict):
         sci_name = Species.get_scientific_name(sdict['genus'],
                                                sdict['species'],
-                                               sdict['cultivar'])
+                                               sdict['cultivar'],
+                                               sdict['other_part_of_name'])
 
         display_name = "%s [%s]" % (sdict['common_name'],
                                     sci_name)


### PR DESCRIPTION
To test:

Search for 'Cockspur Hawthorn' on an international map. On the `develop` branch there should two identical entries, and on this branch one entry should include the variety as part of the scientific name.

Connects to #2920