### PR TITLE
Return plot create/update validation errors with a 400 status

### DIFF
--- a/opentreemap/api/plots.py
+++ b/opentreemap/api/plots.py
@@ -29,7 +29,7 @@ def transform_plot_update_dict(plot_update_fn):
     def wrapper(request, *args, **kwargs):
         plot_dict = plot_update_fn(request, *args, **kwargs)
 
-        if request.api_version < 5:
+        if request.api_version < 5 and 'universalRevHash' in plot_dict:
             plot_dict['geoRevHash'] = plot_dict['universalRevHash']
             del plot_dict['universalRevHash']
         return plot_dict

--- a/opentreemap/api/views.py
+++ b/opentreemap/api/views.py
@@ -309,6 +309,7 @@ plots_endpoint = instance_api_do(
               login_required,
               creates_instance_user,
               transform_plot_update_dict,
+              return_400_if_validation_errors,
               update_or_create_plot)))
 
 
@@ -317,7 +318,8 @@ plot_endpoint = instance_api_do(
           ELSE=do(login_required,
                   creates_instance_user,
                   route(
-                      PUT=update_or_create_plot,
+                      PUT=do(return_400_if_validation_errors,
+                             update_or_create_plot),
                       DELETE=remove_plot))))
 
 species_list_endpoint = instance_api_do(


### PR DESCRIPTION
Previously, validation errors in the plot create and update views were not being
caught, resulting in a 500 error being logged in Rollbar.

Updating these views to properly handle the validation errors required a fix to
the `transform_plot_update_dict` function to check for the existence of a key
before trying to read it from the plot dict.

---

##### Testing

Use a mobile app and attempt to both create and update a tree with zero diameter and verify that the API response has a 400 status code.

---

Connects to https://github.com/OpenTreeMap/otm-ios/issues/353