### PR TITLE
Store geocoded address in URL when searching and show on page load

### DIFF
--- a/opentreemap/treemap/js/src/lib/otmTypeahead.js
+++ b/opentreemap/treemap/js/src/lib/otmTypeahead.js
@@ -319,6 +319,13 @@ var create = exports.create = function(options) {
                 }
             }
         },
+        getGeocodeDatums: function(val, cb) {
+            if (geocoderEngine) {
+                geocoderEngine.initialize().done(function() {
+                    geocoderEngine.search($input.val(), $.noop, cb);
+                });
+            }
+        },
         getDatum: function() {
             return exports.getDatum($input);
         },

--- a/opentreemap/treemap/js/src/lib/otmTypeahead.js
+++ b/opentreemap/treemap/js/src/lib/otmTypeahead.js
@@ -228,7 +228,7 @@ var create = exports.create = function(options) {
     // to avoid a redundant call to `autocomplete` that could mistakenly
     // change the selected value.
     $input.bind('typeahead:select', function(ev, suggestion) {
-        lastSelection = suggestion;
+        lastSelection = suggestion.value;
     });
 
     selectStream.onValue(function() {
@@ -308,7 +308,7 @@ var create = exports.create = function(options) {
         autocomplete: function () {
             var top, success;
             if ($input.val()) {
-                if (lastSelection && lastSelection.value == $input.val()) {
+                if (lastSelection === $input.val()) {
                     success = true;
                 } else {
                     top = $input.data('ttTypeahead').menu.getTopSelectable();
@@ -319,10 +319,16 @@ var create = exports.create = function(options) {
                 }
             }
         },
-        getGeocodeDatums: function(val, cb) {
+        getGeocodeDatum: function(val, cb) {
             if (geocoderEngine) {
                 geocoderEngine.initialize().done(function() {
-                    geocoderEngine.search($input.val(), $.noop, cb);
+                    geocoderEngine.search($input.val(), $.noop, function(datums) {
+                        if (datums.length > 0) {
+                            lastSelection = datums[0].text;
+                            $input.data('datum', datums[0]);
+                            cb(datums[0]);
+                        }
+                    });
                 });
             }
         },

--- a/opentreemap/treemap/js/src/lib/searchBar.js
+++ b/opentreemap/treemap/js/src/lib/searchBar.js
@@ -421,11 +421,7 @@ module.exports = exports = {
                 if (firstPageLoad) {
                     firstPageLoad = false;
                     if (search.address && $(dom.locationSearchTypeahead).val() == search.address) {
-                        locationTypeahead.getGeocodeDatums(search.address, function(datums) {
-                            if (datums.length > 0) {
-                                ui.triggerGeocode(datums[0]);
-                            }
-                        });
+                        locationTypeahead.getGeocodeDatum(search.address, ui.triggerGeocode);
                     }
                 }
             }

--- a/opentreemap/treemap/js/src/lib/searchBar.js
+++ b/opentreemap/treemap/js/src/lib/searchBar.js
@@ -20,6 +20,7 @@ var $ = require('jquery'),
     reverse = require('reverse'),
     config = require('treemap/lib/config.js'),
     stickyTitles = require('treemap/lib/stickyTitles.js'),
+    urlState = require('treemap/lib/urlState.js'),
     toastr = require('toastr'),
     mapManager = new MapManager();
 
@@ -386,7 +387,9 @@ module.exports = exports = {
             uSearch = udfcSearch.init(resetStream),
             searchChangedStream = Bacon
                 .mergeAll(searchStream, resetStream)
-                .map(true);
+                .map(true),
+
+            firstPageLoad = true;
 
         geocodedLocationStream.onError(showGeocodeError);
         initSearchUi(searchStream);
@@ -415,6 +418,16 @@ module.exports = exports = {
                 Search.applySearchToDom(search);
                 uSearch.applyFilterObjectToDom(search);
                 updateUi(search);
+                if (firstPageLoad) {
+                    firstPageLoad = false;
+                    if (search.address && $(dom.locationSearchTypeahead).val() == search.address) {
+                        locationTypeahead.getGeocodeDatums(search.address, function(datums) {
+                            if (datums.length > 0) {
+                                ui.triggerGeocode(datums[0]);
+                            }
+                        });
+                    }
+                }
             }
         };
     }

--- a/opentreemap/treemap/js/src/lib/urlState.js
+++ b/opentreemap/treemap/js/src/lib/urlState.js
@@ -73,6 +73,9 @@ var serializers = {
         if (state.search && state.search.display) {
             query.show = JSON.stringify(state.search.display);
         }
+        if (state.search && state.search.address) {
+            query.a = state.search.address;
+        }
     },
 
     modeName: function(state, query) {
@@ -112,6 +115,11 @@ var deserializers = {
     show: function(newState, query) {
         newState.search = newState.search || {};
         newState.search.display = query.show ? JSON.parse(query.show) : undefined;
+    },
+
+    a: function(newState, query) {
+        newState.search = newState.search || {};
+        newState.search.address = query.a || undefined;
     },
 
     m: function(newState, query) {

--- a/opentreemap/treemap/js/src/mapPage/locationSearchUI.js
+++ b/opentreemap/treemap/js/src/mapPage/locationSearchUI.js
@@ -135,5 +135,6 @@ module.exports = {
     showDrawAreaControls: _.partial(showControls, dom.controls.drawArea),
     showCustomAreaControls: _.partial(showControls, dom.controls.customArea),
     showEditAreaControls: _.partial(showControls, dom.controls.editArea),
-    clearCustomArea: clearCustomArea
+    clearCustomArea: clearCustomArea,
+    showAppropriateWellButton: showAppropriateWellButton
 };


### PR DESCRIPTION
Adds a new `a` parameter to the URL which is set when there is a
non-boundary value in the location typeahead.

On page load on the map page, if the `a` parameter is present in the URL
and no boundary filter is present, we geocode the address and display a map
pin (which will also recenter the map on the pin).

Connects to #1123