### PR TITLE
Fix search address in redirect

### DIFF
--- a/opentreemap/treemap/js/src/lib/searchBar.js
+++ b/opentreemap/treemap/js/src/lib/searchBar.js
@@ -75,6 +75,9 @@ function redirectToSearchPage(filters, latLng) {
     if (latLng) {
         query += '&z=' + mapManager.ZOOM_PLOT + '/' + latLng.lat + '/' + latLng.lng;
     }
+    if (filters.address) {
+        query += '&a=' + filters.address;
+    }
     window.location.href = reverse.map(config.instance.url_name) + '?' + query;
 }
 


### PR DESCRIPTION
While OpenTreeMap/otm-core@b65bcf94 fixed issues with reloads on the map page, it broke forwarding the address when redirecting to the map page.

Connects to #1123