### PR TITLE
Update map_feature_is_writable to check tree permissions

### DIFF
--- a/opentreemap/stormwater/tests.py
+++ b/opentreemap/stormwater/tests.py
@@ -50,11 +50,11 @@ class ResourcePermsTest(PermissionsTestCase):
         rainbarrel.refresh_from_db()
         return MapFeature.objects.get(pk=rainbarrel.pk)
 
-    def test_map_feature_is_creatable(self):
+    def test_model_is_creatable(self):
         self._add_builtin_permission(self.role_yes, RainBarrel,
                                      'add_rainbarrel')
         self.assertTrue(
-            perms.map_feature_is_creatable(self.role_yes, RainBarrel))
+            perms.model_is_creatable(self.role_yes, RainBarrel))
 
     def test_any_resource_is_creatable(self):
         self._add_builtin_permission(self.role_yes, RainBarrel,
@@ -64,7 +64,7 @@ class ResourcePermsTest(PermissionsTestCase):
 
     def test_map_feature_is_not_creatable(self):
         self.assertFalse(
-            perms.map_feature_is_creatable(self.role_no, RainBarrel))
+            perms.model_is_creatable(self.role_no, RainBarrel))
 
     def test_no_resource_is_creatable(self):
         self.assertFalse(

--- a/opentreemap/treemap/views/misc.py
+++ b/opentreemap/treemap/views/misc.py
@@ -24,7 +24,7 @@ from treemap.plugin import get_viewable_instances_filter
 
 from treemap.lib.user import get_audits, get_audits_params
 from treemap.lib import COLOR_RE
-from treemap.lib.perms import map_feature_is_creatable
+from treemap.lib.perms import model_is_creatable
 from treemap.units import get_unit_abbreviation, get_units
 from treemap.util import leaf_models_of_class
 
@@ -74,7 +74,7 @@ def get_map_view_context(request, instance):
     if request.user and not request.user.is_anonymous():
         iuser = request.user.get_effective_instance_user(instance)
         resource_classes = [resource for resource in instance.resource_classes
-                            if map_feature_is_creatable(iuser, resource)]
+                            if model_is_creatable(iuser, resource)]
     else:
         resource_classes = []
 


### PR DESCRIPTION
This addresses an edge case where a role has permission to add trees but not add plots.

I made use of a helper function to check tree creatability so I renamed it from `map_feature_is_creatable` to `model_is_creatable`.

---

Testing

- Create a new instance.
- Enable `Can add tree` on the `Public` role.
- Invite a secondary user to the `Public` role.
- As the admin user, create an empty plot.
- Log in as the secondary user and go to the empty plot detail page.
  - The `Edit` button should be enabled.
  - Clicking `Edit` should show the `Add tree` button, but none of the plot fields should be editable.
  - Saving the new tree succeeds.

---

Connects to #2856