### PR TITLE
Add more detail to export error messages

### DIFF
--- a/opentreemap/exporter/__init__.py
+++ b/opentreemap/exporter/__init__.py
@@ -3,5 +3,11 @@ from django.utils.translation import ugettext_lazy as _
 
 EXPORTS_NOT_ENABLED_CONTEXT = {
     'start_status': 'ERROR',
-    'message': _('Data exports are not enabled.')
+    'message': _('Data exports are not enabled for this user.')
+}
+
+
+EXPORTS_FEATURE_DISABLED_CONTEXT = {
+    'start_status': 'ERROR',
+    'message': _('Data exports are not enabled for trial maps.')
 }

--- a/opentreemap/manage_treemap/routes.py
+++ b/opentreemap/manage_treemap/routes.py
@@ -26,8 +26,7 @@ from manage_treemap.views.user_roles import (
     user_roles_list, update_user_roles, create_user_role,
     remove_invited_user_from_instance)
 from treemap.decorators import (require_http_method, admin_instance_request,
-                                return_400_if_validation_errors,
-                                requires_feature)
+                                return_400_if_validation_errors)
 
 admin_route = lambda **kwargs: admin_instance_request(route(**kwargs))
 
@@ -120,7 +119,6 @@ user_invites = admin_route(DELETE=remove_invited_user_from_instance)
 begin_export_users = do(
     json_api_call,
     admin_instance_request,
-    requires_feature('exports'),
     begin_export_users)
 
 roles = admin_route(


### PR DESCRIPTION
Adds an additional error message, to distinguish between exports being
disabled for non-admins vs. trial maps.

Also ensures that error messages when starting an export are displayed,
in additional to when checking on export status.

Connects to OpenTreeMap/otm-addons#1416