### PR TITLE
Add lookups to enable modeling scenarios with overridden species

### DIFF
--- a/opentreemap/modeling/run_model/GrowthModelUrbanTreeDatabase.py
+++ b/opentreemap/modeling/run_model/GrowthModelUrbanTreeDatabase.py
@@ -102,6 +102,11 @@ def _get_species_for_planting(instance):
     otm_codes = _growth_data[itree_region.code].keys()
     species = [species_for_otm_code(otm_code) for otm_code in otm_codes]
     species = sorted(species, key=itemgetter('common_name'))
+
+    def can_get_species(otm_code):
+        return Species.get_by_code(instance, otm_code, itree_region.code) is not None
+    species = [s for s in species if can_get_species(s['otm_code'])]
+
     return species
 
 


### PR DESCRIPTION
Instances that were migrated into the database have species rows that do not have an `otm_code`, which modeling scenarios depend on.

To resolve this we have:

- Added class method to `Species` to try fetching a species and fall back to using an `ITreeCodeOverride`

- Added a validation to prevent loading species into the scenario drop-down lists that cannot be matched to an instance species

PhillyTreeMap before

<img width="170" alt="screen shot 2017-09-06 at 2 17 21 pm" src="https://user-images.githubusercontent.com/17363/30135034-3118afb8-930e-11e7-9bf1-ca87ff1186f8.png">

PhillyTreeMap after

<img width="159" alt="screen shot 2017-09-06 at 2 16 58 pm" src="https://user-images.githubusercontent.com/17363/30135051-3dc127a4-930e-11e7-83d8-ec51b6327767.png">


- Modified the scenario run view function to use the new species fetch method.

---

##### Testing

- Create a modeling scenario on PhillyTreeMap and add a single tree for every species in the list. Verify that the "Calculate Scenario" button works.
- Create a modeling scenario on PhillyTreeMap, add a distribution area, and add a distribution for every species in the list. Verify that the "Calculate Scenario" button works.

---

Connects to https://github.com/OpenTreeMap/otm-clients/issues/352