### PR TITLE
Fix streetview update after saving on the tree detail page

### DIFF
--- a/opentreemap/treemap/js/src/mapFeatureDetail.js
+++ b/opentreemap/treemap/js/src/mapFeatureDetail.js
@@ -198,10 +198,14 @@ function init() {
             location: window.otm.mapFeature.location.point
         });
         form.saveOkStream
-            .map('.formData')
-            .map(BU.getValueForKey('plot.geom'))
-            .filter(BU.isDefined)
-            .onValue(panorama.update);
+            .onValue(function () {
+                // If location is an array, we are editing a polygonal map
+                // feature. The page triggers a full postback after editing a
+                // polygon map feature.
+                if (!_.isArray(currentMover.location)) {
+                    panorama.update(currentMover.location);
+                }
+            });
     }
 
     handleFavoriteClick();


### PR DESCRIPTION
There was existing code to update streeview after a successful save, but that code expected the form data to include `plot.geom`. It does not. `plot.geom` is appended directly to the data PUT back to the server in a before save handler.

To get around this, we just read the location from the plot mover. It is safe to call `panorama.update` even if there is no geometry change. It is effectively a noop.

---

##### Testing

- Add a plot then edit it.
- Move the plot location and save. Verify that the streetview changes.

---

Connects to #2935