### PR TITLE
Don't show the tree photo sharing dialog if it is not appropriate

### DIFF
--- a/opentreemap/treemap/js/src/lib/socialMediaSharing.js
+++ b/opentreemap/treemap/js/src/lib/socialMediaSharing.js
@@ -61,6 +61,13 @@ function renderPhotoModal (imageData) {
         photoDetailUrl = $photo.attr(attrs.mapFeaturePhotoDetailAbsoluteUrl),
         photoUrl = $photo.attr(attrs.mapFeaturePhotoImageAbsoluteUrl),
         $photoPreview = $(dom.photoPreview);
+
+    // Validation errors (image invalid, image too big) are only returned as DOM
+    // elements. In order to skip showing the share dialog we need to check the
+    // dialog markup for the error message element.
+    if ($(imageData.data.result).filter('[data-photo-upload-failed]').length > 0) {
+        return;
+    }
     $photoModal.modal('show');
     $photoPreview.attr('src', $photo.attr(attrs.mapFeaturePhotoPreview));
     _.each($anchors, generateHref(photoDetailUrl, photoUrl));

--- a/opentreemap/treemap/templates/treemap/map_feature_detail.html
+++ b/opentreemap/treemap/templates/treemap/map_feature_detail.html
@@ -28,7 +28,10 @@
 {% block content %}
     {% trans "Add a Photo" as upload_title %}
     {% include "treemap/partials/upload_file.html" with title=upload_title upload_url=upload_photo_endpoint %}
-    {% include "treemap/partials/photo_social_media_sharing.html" %}
+
+    {% if request.instance.is_public %}
+        {% include "treemap/partials/photo_social_media_sharing.html" %}
+    {% endif %}
 
     {# Modal for viewing and rotating photos #}
     <div id="photo-lightbox" class="modal fade" tabindex="-1" role="dialog" aria-hidden="true">

--- a/opentreemap/treemap/templates/treemap/partials/photo_carousel.html
+++ b/opentreemap/treemap/templates/treemap/partials/photo_carousel.html
@@ -46,5 +46,6 @@
 <a class="carousel-control right" href="#photo-carousel" data-slide="next"><i class="icon-right-circled"></i></a>
 {% endif %}
 {% if error %}
-<div class="alert alert-danger">{{ error }}</div>
+{# The data-photo-upload-failed attribute must appear on an element if there was a validation error #}
+<div class="alert alert-danger" data-photo-upload-failed>{{ error }}</div>
 {% endif %}


### PR DESCRIPTION
There are three tree photo upload situations where we do not want to show a social media sharing dialog after POSTing the image to the server.

- The instance is private.
- The image file was invalid.
- The image file was too big.

Private instances are not handled by not rendering the dialog markup on the page unless the instance is public.

Invalid images are handled by checking the markup returned from the response for the presence of an error element. This is not ideal, but is easier that changing the way failures are reported vs. loading updated carousel markup.

Large images are intended to be blocked by Nginx before reaching Django. If they reach Django they will trigger a validation error, which will be handled the same way invalid images are handled.

---

##### Testing

- Create 2 instances, 1 public and 1 private
- Verify that uploading a valid photo to the public instance shows the share dialog.
- Verify that uploading a valid photo to the private instance does not show the share dialog.
- Verify that uploading a non-image to the public instance shows the share dialog.
- Verify that uploading a too large image to the public instance shows the share dialog. 
[large.png.zip](https://github.com/OpenTreeMap/otm-core/files/1285635/large.png.zip)

---

Connects to #2930 


