### PR TITLE
Decode CSV header row field names so that they correctly validate

### DIFF
--- a/opentreemap/importer/tasks.py
+++ b/opentreemap/importer/tasks.py
@@ -24,7 +24,7 @@ def _create_rows_for_event(ie, csv_file):
     # so we can show progress. Caller does manual cleanup if necessary.
     reader = utf8_file_to_csv_dictreader(csv_file)
 
-    field_names = [f.strip() for f in reader.fieldnames
+    field_names = [f.strip().decode('utf-8') for f in reader.fieldnames
                    if f.strip().lower() not in ie.ignored_fields()]
     ie.field_order = json.dumps(field_names)
     ie.save()


### PR DESCRIPTION
The CSV reader encodes non-ASCII characters as UTF-8, which was causing the header row field validation to fail. Decoding the CSV field names before comparing them to the field names stored in the database resolves the issue.

---

##### Testing

- Create a new instance centered on Los Angeles
- Add a new text custom field to Tree named `Localização`
- Import this CSV that includes a `Tree: Localização` column: [import-with-unicode.csv.zip](https://github.com/OpenTreeMap/otm-core/files/851616/import-with-unicode.csv.zip)

The the file should validate successfully and trees added to the map should have values in the `Localização` field.

---

Connects to https://github.com/OpenTreeMap/otm-addons/issues/1467