### PR TITLE
Encode field names as UTF-8 when generating CSV import templates

### DIFF
--- a/opentreemap/importer/tasks.py
+++ b/opentreemap/importer/tasks.py
@@ -24,7 +24,7 @@ def _create_rows_for_event(ie, csv_file):
     # so we can show progress. Caller does manual cleanup if necessary.
     reader = utf8_file_to_csv_dictreader(csv_file)
 
-    field_names = [f.strip() for f in reader.fieldnames
+    field_names = [f.strip().decode('utf-8') for f in reader.fieldnames
                    if f.strip().lower() not in ie.ignored_fields()]
     ie.field_order = json.dumps(field_names)
     ie.save()

--- a/opentreemap/importer/views.py
+++ b/opentreemap/importer/views.py
@@ -782,6 +782,10 @@ def download_import_template(request, instance, import_type):
         ie = TreeImportEvent(instance=instance)
         field_names = ie.ordered_legal_fields_title_case()
 
+    # Encoding the field names prevents an error when the field names have
+    # non-ASCII characters.
+    field_names = [field_name.encode('utf-8') for field_name in field_names]
+
     response = HttpResponse(content_type="text/csv")
     response["Content-Disposition"] = "attachment; filename=%s" % filename
     writer = csv.DictWriter(response, field_names)


### PR DESCRIPTION
NOTE: This PR builds on top of #3219. Only the last commit is specific to this PR.

Template downloads were failing for instances with user defined field names
containing non-ASCII characters.

---

##### Testing

- Create a new instance centered on Los Angeles
- Add a new text custom field to Tree named Localização
- Export the tree import CSV template and verify that all the column headers in the template are correct.

---

Connects to #1466