### PR TITLE
Update universal rev after changing instance units.

### DIFF
--- a/opentreemap/manage_treemap/js/src/units.js
+++ b/opentreemap/manage_treemap/js/src/units.js
@@ -8,7 +8,7 @@ var inlineEditForm = require('treemap/lib/inlineEditForm.js'),
 
 adminPage.init();
 inlineEditForm.init({
-    updateUrl: reverse.units_endpoint(config.instance.url_name),
+    updateUrl: reverse.units_endpoint(config.instance.url_name) + '?update_universal_rev=1',
     section: '#units',
     errorCallback: alerts.errorCallback
 });


### PR DESCRIPTION
## Overview

Calculating ecobenefits for a large number of trees can be expensive, so we cache the results based on query string arguments and the `universal_rev` of the instance. After changing the units of a field, the same query string can produce different results so we must increment the `universal_rev` to bust the cache.

Connects #3224 

## Testing Instructions

 * Create a new instance with the URL name `unit-eco-test` via http://localhost:6060/create
 * Add three trees with the following diameters
   * 3.1in
   * 5in
   * 7.9in
 * Click the "Advanced" button above the "Search" button and in the "Tree" down down enter a range of 3in to 8in.
 * Click "Search" and verify that "3 Trees" appears in the search result
<img width="267" alt="screen shot 2017-10-18 at 10 46 16 am" src="https://user-images.githubusercontent.com/17363/31733818-9da23498-b3f1-11e7-842d-45e888e4b4fc.png">

 * Go to the units management page http://localhost:6060/unit-eco-test/management/units/
   * Click "Edit"
   * Change the units for Tree Diameter to `centimeters`
   * Open the the dev tools network panel.
   * Click Save. Verify that the request succeeds and the URL includes `?update_universal_rev=1`
 * Click "Explore Map" in the header.
 * Run the same advanced search for tree diameter, entering 3 and 8 into the range boxes (the unit label will now be cm.
 * Click "Search" and verify that only "1 Tree" is shown in the search results.
 * Go to the "Basic Information" management page http://localhost:6060/unit-eco-test/management/site-config/
   * Click "Edit"
   * Set a value in the "Contact Email" field
   * Open the the dev tools network panel.
   * Click "Save". Verify that the request does not include an `update_universal_rev` query parameter.
