### PR TITLE
Restrict supported import file delimiters to , and \t

### DIFF
--- a/opentreemap/importer/util.py
+++ b/opentreemap/importer/util.py
@@ -36,7 +36,7 @@ def _as_utf8(f):
 
 
 def _guess_dialect_and_reset_read_pointer(f):
-    dialect = csv.Sniffer().sniff(_as_utf8(f).read(4096))
+    dialect = csv.Sniffer().sniff(_as_utf8(f).read(4096), delimiters=',\t')
     f.seek(0)
     return dialect
 


### PR DESCRIPTION
## Overview

When importing a file with multichoice values (i.e. "[""A"", ""B""]") the `csv.Sniffer` was incorrectly identifying the delimiter as '['. Passing a string of allowed delimiters to the `sniff` method avoids this. 

https://docs.python.org/2/library/csv.html#csv.Sniffer.sniff

Connects https://github.com/OpenTreeMap/otm-clients/issues/412
Connects https://github.com/OpenTreeMap/otm-clients/issues/407

## Testing Instructions

### Setup

 * Log in. Use http://localhost:6060/create to create a new instance.
   * Set the URL name to `multi-fix`.
   * On step "3. Choose tree map location" use the geocoder to set the center to "South El Monte, CA, USA"
 * Add a multi-choice field
   * Browse http://localhost:6060/multi-fix/management/udfs/
   * Click "Add"
   * Create a multi-choice field matching this screenshot:
<img width="896" alt="screen shot 2017-11-15 at 3 17 01 pm" src="https://user-images.githubusercontent.com/17363/32863252-15b9dc1a-ca18-11e7-8b5d-647e1b5f0068.png">
 
 * Download [CAReLeafTreesTest.csv.txt](https://github.com/OpenTreeMap/otm-core/files/1476581/CAReLeafTreesTest.csv.txt) and rename to CAReLeafTreesTest.csv

### Test

 * Confirm the failure
   * Check out the `develop` branch.
   * Restart celery with `vagrant ssh app -c "sudo service celery restart"` 
   * Browse to the bulk uploader http://localhost:6060/multi-fix/management/bulk-uploader/
   * Select `CAReLeafTreesTest.csv` in the Tree Import file chooser and click "Import"
   * Verify that after some processing time the import appears in the "Finished Tree Imports" list with a "Status" of "Invalid File Structure"
 * Confirm the fix
   * Check out this branch
   * Restart celery with `vagrant ssh app -c "sudo service celery restart"` 
   * Refresh http://localhost:6060/multi-fix/management/bulk-uploader/
   * Select `CAReLeafTreesTest.csv` in the Tree Import file chooser and click "Import"
   * Verify that after some processing time the import has a "Status" of "Verification Complete".

