### PR TITLE
Fixed issue diameter value is not showing directly below diameter field.

### DIFF
--- a/opentreemap/treemap/templates/treemap/field/diameter_div.html
+++ b/opentreemap/treemap/templates/treemap/field/diameter_div.html
@@ -5,5 +5,8 @@
   <div style="display: none;">
     {% include "treemap/field/inputs.html" %}
   </div>
-  {% include "treemap/partials/diameter_calculator.html" %}
+   {% include "treemap/partials/diameter_calculator.html" %}
 {% endblock inputs %}
+{% block diameter_video %}
+   {% include "treemap/partials/diameter_video.html" %}
+{% endblock diameter_video %}

--- a/opentreemap/treemap/templates/treemap/field/diameter_tr.html
+++ b/opentreemap/treemap/templates/treemap/field/diameter_tr.html
@@ -12,7 +12,9 @@
         <div style="display: none;">
           {% include "treemap/field/inputs.html" %}
         </div>
-        {% include "treemap/partials/diameter_calculator.html" %}
+        {% include "treemap/partials/diameter_calculator.html" %}     
+        {% include "treemap/partials/diameter_video.html" %}     
+
       </td>
   {% endif %}
   </tr>

--- a/opentreemap/treemap/templates/treemap/field/div.html
+++ b/opentreemap/treemap/templates/treemap/field/div.html
@@ -19,6 +19,8 @@
             <div class="alert alert-danger text-danger"
                 style="display: none;"
                 {% include "treemap/field/attrs.html" with class="error" %}></div>
+            {% block diameter_video %}
+            {% endblock diameter_video %}
         {% endif %}
     </div>
 {% endif %}

--- a/opentreemap/treemap/templates/treemap/partials/diameter_calculator.html
+++ b/opentreemap/treemap/templates/treemap/partials/diameter_calculator.html
@@ -43,7 +43,4 @@
 <p id="diameter-calculator-total-row" style="display: none">
   {% trans "Combined Diameter:" %} <span id="diameter-calculator-total-reference" class="inline"></span>{% if field.units %} {{ field.units }}{% endif %}
 </p>
-<a id="diameter-video"
-   class="external-help-link"
-   href="http://player.vimeo.com/video/11119129"
-   target="_blank"><i class="icon-videocam"></i> {% trans "Need help measuring the tree?" %}</a>
+

--- a/opentreemap/treemap/templates/treemap/partials/diameter_video.html
+++ b/opentreemap/treemap/templates/treemap/partials/diameter_video.html
@@ -1,0 +1,5 @@
+{% load i18n %}
+ <a id="diameter-video"
+   class="external-help-link"
+   href="http://player.vimeo.com/video/11119129"
+   target="_blank"><i class="icon-videocam"></i> {% trans "Need help measuring the tree?" %}</a>


### PR DESCRIPTION
connects to #2450. When adding tree error message will be displayed above video link and an error message will display after video link in edit tab. 