### PR TITLE
Fixed current location popping out of bounds

### DIFF
--- a/opentreemap/treemap/js/src/mapPage/addMapFeature.js
+++ b/opentreemap/treemap/js/src/mapPage/addMapFeature.js
@@ -3,6 +3,7 @@
 var $ = require('jquery'),
     _ = require('lodash'),
     L = require('leaflet'),
+    leafletPip = require('leaflet-pip'),
     toastr = require('toastr'),
     FH = require('treemap/lib/fieldHelpers.js'),
     U = require('treemap/lib/utility.js'),
@@ -40,13 +41,15 @@ function init(options) {
         $geolocateButton = U.$find('.geolocate', $sidebar),
         $geocodeError = U.$find('.geocode-error', $sidebar),
         $geolocateError = U.$find('.geolocate-error', $sidebar),
+        $pointInStreamError = U.$find('.pointnotinmap-error', $sidebar),
         triggerSearchBus = options.triggerSearchBus,
 
         $form = U.$find(formSelector, $sidebar),
         editFields = formSelector + ' [data-class="edit"]',
         validationFields = options.validationFields || formSelector + ' [data-class="error"]',
         $placeMarkerMessage = U.$find('.place-marker-message', $sidebar),
-        $moveMarkerMessage = U.$find('.move-marker-message', $sidebar);
+        $moveMarkerMessage = U.$find('.move-marker-message', $sidebar), 
+        boundsGeoJson = L.geoJson(config.instance.bounds);
 
     $(editFields).show();
     $form.find('[data-class="display"]').hide();  // Hide display fields
@@ -117,6 +120,10 @@ function init(options) {
     });
     reverseGeocodeStream.onError($addressInput, 'val', '');
 
+    markerMoveStream.onValue(function() {
+        $pointInStreamError.hide();
+    });
+
     if (config.instance.basemap.type === 'google') {
         var $streetViewContainer = $("#streetview");
         var container = null;
@@ -186,7 +193,16 @@ function init(options) {
 
     function onGeolocateSuccess(lonLat) {
         var latLng = L.latLng(lonLat.coords.latitude, lonLat.coords.longitude);
-        onLocationChosen(latLng);
+        if (!pointInMap(latLng)) {
+            $pointInStreamError.show();
+        } else {
+            onLocationChosen(latLng);
+        }
+    }
+
+    function pointInMap(latLng) {
+        var polysForPoint = leafletPip.pointInLayer(latLng, boundsGeoJson, true);
+        return polysForPoint.length > 0;
     }
 
     function onLocationChosen(latLng) {

--- a/opentreemap/treemap/templates/treemap/partials/step_set_location.html
+++ b/opentreemap/treemap/templates/treemap/partials/step_set_location.html
@@ -29,6 +29,9 @@
         <div class="alert alert-info move-marker-message hidden-xs" style="display: none;">
             {% trans "Please move marker to exact location of the" %} {{ feature_name }}
         </div>
+        <div class="alert alert-danger text-danger pointnotinmap-error" style="display: none;">
+            {% trans "Current location not within map bounds." %}
+        </div>
         <div class="alert alert-danger" data-class="error" data-field="mapFeature.geom"></div>
     </div>
     {% include 'treemap/partials/step_controls.html' %}


### PR DESCRIPTION
This PR is based on #3238 with
* Whitespace fixes.
* A complete `pointInMap` function.
* A change to the `onGeolocateSuccess` handler so that we pass a Leaflet `LatLng` to `pointInMap`. Passing the `onGeolocateSuccess` argument into `pointInMap` was failing because the object was not in the format that `leaflet-pip` expected.