### PR TITLE
 Incorporate the basemap provider into selected basemap storage

### DIFF
--- a/opentreemap/treemap/js/src/lib/MapManager.js
+++ b/opentreemap/treemap/js/src/lib/MapManager.js
@@ -146,7 +146,7 @@ MapManager.prototype = {
             bounds = options.bounds,
             map = L.map(options.domId),
             type = options.type,
-            basemapMapping = getBasemapLayers(type);	
+            basemapMapping = getBasemapLayers(type);
 
 	L.control.locate({
 	    icon: "icon icon-location"
@@ -172,15 +172,15 @@ MapManager.prototype = {
                 });
         } else {
             var visible = window.localStorage.getItem('basemapMapping');
-             if (visible === null) {
-                visible = _.keys(basemapMapping)[0];                  
+            if (visible === null) {
+                visible = _.keys(basemapMapping)[0];
             }
             map.addLayer(basemapMapping[visible]);
             this.layersControl = L.control.layers(basemapMapping, null, {
                 autoZIndex: false
             }).addTo(map);
             map.on('baselayerchange', function(e) {
-                window.localStorage.setItem('basemapMapping', e.name);  
+                window.localStorage.setItem('basemapMapping', e.name);
             });
         }
 

--- a/opentreemap/treemap/js/src/lib/MapManager.js
+++ b/opentreemap/treemap/js/src/lib/MapManager.js
@@ -146,7 +146,8 @@ MapManager.prototype = {
             bounds = options.bounds,
             map = L.map(options.domId),
             type = options.type,
-            basemapMapping = getBasemapLayers(type);
+            basemapMapping = getBasemapLayers(type),
+            basemapStorageKey = ['basemapMapping', type].join(':');
 
 	L.control.locate({
 	    icon: "icon icon-location"
@@ -171,7 +172,7 @@ MapManager.prototype = {
                     map.addLayer(layer);
                 });
         } else {
-            var visible = window.localStorage.getItem('basemapMapping');
+            var visible = window.localStorage.getItem(basemapStorageKey);
             if (visible === null) {
                 visible = _.keys(basemapMapping)[0];
             }
@@ -180,7 +181,7 @@ MapManager.prototype = {
                 autoZIndex: false
             }).addTo(map);
             map.on('baselayerchange', function(e) {
-                window.localStorage.setItem('basemapMapping', e.name);
+                window.localStorage.setItem(basemapStorageKey, e.name);
             });
         }
 


### PR DESCRIPTION
## Overview

OTM supports multiple basemap providers, each with different basemap names. When we store the selected basemap, we need to namespace that selection under the provider name.

Connects https://github.com/OpenTreeMap/otm-cloud/issues/438

## Testing Instructions

- Browse the map page of an existing instance
- Change the basemap to satellite
- Refresh the page and verify that the basemap change persists
- Browse `/create` and work through the instance creation wizard
- Verify that the Bing basemap correctly appears on the 3rd page of the create wizard
