### PR TITLE
Use strict mode when using moment.isValid to check date formatting.

### DIFF
--- a/opentreemap/treemap/js/src/lib/udfcSearch.js
+++ b/opentreemap/treemap/js/src/lib/udfcSearch.js
@@ -156,8 +156,11 @@ function resetAction(state) {
 function resetDateBox(widgetName, state) {
     var name = makeNameAttribute(state, state.dateFieldKey),
         $widget = $(widgets[widgetName].selector),
-        longDate = moment(state[widgetName], DATETIME_FORMAT),
-        shortDate = moment(state[widgetName], 'MM/DD/YYYY'),
+        // Passing `true` as the third argument when creating a moment enables
+        // strict mode, which we need for the `isValid` check below to work
+        // properly.
+        longDate = moment(state[widgetName], DATETIME_FORMAT, true),
+        shortDate = moment(state[widgetName], 'MM/DD/YYYY', true),
         shouldEnable = !_.isNull(state.modelName) && !_.isNull(state.type),
         val;
 


### PR DESCRIPTION
### Overview

Dates on the advanced search toolbar were being set incorrectly because the parsing a short date with the long date format was being interpreted as valid. Enabling "strict mode" makes the date parsing resolves this.

Connects #3245 

### Demo

Before
<img width="1042" alt="screen shot 2018-05-03 at 11 42 53 am" src="https://user-images.githubusercontent.com/17363/39596480-576838b2-4ec7-11e8-9c7c-2a6a5759ba36.png">

After
<img width="1011" alt="screen shot 2018-05-03 at 11 43 27 am" src="https://user-images.githubusercontent.com/17363/39596491-63ce7bc0-4ec7-11e8-9ce6-d858287348d5.png">

### Testing

 * Visit production https://www.opentreemap.org/phillytreemap/map/
 * Open the advanced search menu, click on Tree Care, and select any values for the first 3 dropdowns
 * Select May 1 in the date pickers and verify the bad behavior
 * Repeat the process with a local instance and verify that setting May 1 in the date pickers works.