### PR TITLE
Mark registration profile activated when confirming invited user

### DIFF
--- a/opentreemap/manage_treemap/views/user_roles.py
+++ b/opentreemap/manage_treemap/views/user_roles.py
@@ -260,6 +260,13 @@ def activate_user(sender, user, request, password=None, **kwargs):
 
             user.is_active = True
             user.save_with_user(user)
+            # The registration system uses both the `activated` field in
+            # addition to the `User.is_active` fields. Setting `User.is_active`
+            # to false after activation lets us disable an account and prevent
+            # the user from reactivating it. Because of this we must also
+            # update the `activated` field.
+            user.registrationprofile.activated = True
+            user.registrationprofile.save()
 
             auser = authenticate(username=user.username,
                                  password=password)


### PR DESCRIPTION
## Overview

The registration system uses both the `activated` field in addition to the `User.is_active` fields. Setting `User.is_active` to false after activation lets us disable an account and prevent the user from reactivating it. Because of this we must also update the `activated` field.

Connects #3247

## Notes
Before this fix, users who accepted invitations were unable to reset their passwords because of this code:

https://github.com/OpenTreeMap/otm-core/blob/2.21.0/opentreemap/registration_backend/views.py#L211-L212

## Testing Instructions

 * Run `./scripts/debugserver.sh`
 * Browse http://localhost:6060/create and make an instance named `activation-test`
 * Browse http://localhost:6060/activation-test/management/user-roles/
 * Click "Add User" and submit an email address that does not yet exist in the database.
 * An invitation email will be logged to the console. Open the link included in that email in a different browser or incognito window.
 * Fill out the registration form making sure to use the exact same email address associated with the invitation.
 * Submit the registration form and verify that you are successfully logged in.
 * Click logout, then browse http://localhost:6060/activation-test/. You should be prompted to log in.
 * Click "Reset my Password"
 * Submit the email address used to create the test user and verify that a password reset email is printed to the console.