### PR TITLE
Upgrade Omgeo to v5.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ Pillow==4.2.1
 psycopg2==2.7.3                          # http://initd.org/psycopg/docs/news.html
 pyflakes==1.6.0
 python-dateutil==2.6.1                   # https://github.com/dateutil/dateutil/blob/master/NEWS
-python-omgeo==3.0.0
+python-omgeo==5.1.0
 pytz==2017.2                             # https://launchpad.net/pytz/+announcements
 redis==2.10.5
 requests==2.18.3


### PR DESCRIPTION
Replaces use of `urllib` and `urllib2` with Requests library while attempting to maintain backwards compatibility.

Fixes https://github.com/azavea/operations/issues/200

---

**Testing**

Provision the `app` virtual machine with this branch, then ensure that v5.1.0 of Omgeo was installed:

```bash
vagrant@app:~$ pip freeze 2> /dev/null | grep omgeo
python-omgeo==5.1.0
```

In addition, interact with the `/geocode` endpoint to ensure that it continues to function.

```bash
$ http "http://localhost:6060/geocode?address=990%20Spring%20Garden%20St%2C%20Philadelphia%2C%20PA%2C%2019123%2C%20USA&key=dHA9MCNsb2M9MTY2NTMzMSNsbmc9MzMjZmE9NTA0NjI3MiNobj05OTA%3D"
HTTP/1.1 200 OK
Connection: keep-alive
Content-Encoding: gzip
Content-Language: en
Content-Type: application/json
Date: Wed, 20 Jun 2018 17:34:28 GMT
Server: nginx
Transfer-Encoding: chunked
Vary: Accept-Encoding
Vary: Accept-Language, Cookie

{
    "lat": 39.96114299999999,
    "lng": -75.15422099999999
}
```