### PR TITLE
Monkey patch the Leaflet layer selector to work in Mobile Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "directories": {
     "doc": "doc"
   },
+  "//": ["!!! WARNING !!!",
+         "If you upgrade Leaflet you must update the patch in MapManager.js",
+         "!!! WARNING !!!"],
   "dependencies": {
     "autotrack": "^0.6.5",
     "baconjs": "~0.6",


### PR DESCRIPTION
## Overview

Tapping on the layers control in Mobile Safari was not opening the layer selector. I was not able to reproduce this issue in a separate test application, only within OTM.

After much trial and error I discovered that changing this line
```javascript
  L.DomEvent.on(el, L.Draggable.START.join(' '), stop);
```
to
```javascript
  L.DomEvent.on(container, 'mousedown', stop);
```
in `DomEvent.disableClickPropagation` resolved the issue. Effectively, this prevents the `touchstart` event from being stopped.

I opted to implement this as a runtime patch applied within MapManager instead of a global patch to the Leaflet source because there are no other Leaflet behaviors that are known to be broken in Mobile Safari and I did not want to risk introducing a regression in some other event handling.

I minimized the chance of forgetting about this patch if/when we upgrade our version of Leaflet by adding a comment to package.json.

Connects #3250 

## Testing Instructions

## Setup

 * Ensure that your development server is accessible from other machines on the network.
 * Obtain an iOS device for testing (hardware or simulator). Browse https://www.opentreemap.org/phillytreemap in Mobile Safari and verify that tapping on the layer selector does not work.

## Test

 * Run `vagrant provision app` and verify that it completes without error.
 * Browse an instance on your development server in Mobile Safari and verify that the layer selector works.