### PR TITLE
Handle basemap preference not available

### DIFF
--- a/opentreemap/treemap/js/src/lib/MapManager.js
+++ b/opentreemap/treemap/js/src/lib/MapManager.js
@@ -257,7 +257,7 @@ MapManager.prototype = {
                 });
         } else {
             var visible = window.localStorage.getItem(basemapStorageKey);
-            if (visible === null) {
+            if (visible === null || !basemapMapping[visible]) {
                 visible = _.keys(basemapMapping)[0];
             }
             map.addLayer(basemapMapping[visible]);


### PR DESCRIPTION
Avoids an unhandled exception when the `basemap_type` of an instance has changed and a previous layer selection persisted in local storage no longer exists.

Connects #3255 

### Testing

* Browse an instance with the `google` basemap.
* Select the `Satellite` layer
* Refresh the page and verify that the `Satellite` layer is displayed
* Update the instance `basemap_type` to `bing`.
```
otm=# update treemap_instance set basemap_type = 'google', universal_rev = universal_rev + 1;
```
* Refresh the map page
* Verify that the street layer loads and no error is logged in the JS console.