### PR TITLE
Fix UDF choice editing helper function (hotfix)

### DIFF
--- a/opentreemap/manage_treemap/js/src/udfs.js
+++ b/opentreemap/manage_treemap/js/src/udfs.js
@@ -565,7 +565,7 @@ function validate($choiceList, $choice, $input) {
 
 // For use in jQuery filters
 function trimOrNull(value) {
-    return !!value ? value.trim() : null;
+    return !!value ? value.toString().trim() : null;
 }
 function getValue(choiceElem) {
     var value = $(choiceElem).find('.form-control').val();


### PR DESCRIPTION
NOTE:  This is a copy of #3259 targeted at the 2.21.4 hotfix branch.

## Overview

In the case where choice fields contain numeric values, this helper is called with a number and fails unless we force the value to a string.

Connects https://github.com/OpenTreeMap/otm-clients/issues/441

## Testing Instructions

* Checkout the `develop` branch
* Browse http://localhost:6060/create/ and create an instance called 'numeric-choices'
* Visit http://localhost:6060/numeric-choices/management/udfs/ and click `+ Add Field`
* Create a choice field like this and click `Finish` to save it.
<img width="901" alt="screen shot 2018-11-02 at 10 35 46 am" src="https://user-images.githubusercontent.com/17363/47931116-1c373280-de8b-11e8-883f-8ccc328303b5.png">
* Refresh the page and click `Edit`. Start typing a new choice value and you will see an exception in the console
<img width="1105" alt="screen shot 2018-11-02 at 10 38 45 am" src="https://user-images.githubusercontent.com/17363/47931289-a2537900-de8b-11e8-8482-15cc38bd68da.png">
* Checkout this branch, reload the page, and click `Edit`.
* Verify that you can successfully add a new choice value and save it.

