### PR TITLE
Add client-side validation to prevent extra udf choice whitespace

### DIFF
--- a/assets/css/sass/partials/pages/_admin.scss
+++ b/assets/css/sass/partials/pages/_admin.scss
@@ -904,6 +904,11 @@
                 display: block;
             }
         }
+        &.whitespace-error {
+            [data-item="whitespace"] {
+                display: block;
+            }
+        }
         &.blank-error {
             [data-item="blank"] {
                 display: block;

--- a/opentreemap/manage_treemap/js/src/udfs.js
+++ b/opentreemap/manage_treemap/js/src/udfs.js
@@ -41,6 +41,7 @@ var dom = {
     saveBtn: '.saveBtn',
     cancelBtn: '.cancelBtn',
 
+    udfCreate: '#udf-create',
     createNewUdf: '#create-new-udf',
     createUdfPopup: '#add-udf-panel',
     udfFieldsContainer: '#udf-create-fields',
@@ -215,6 +216,7 @@ $('body').on('keydown paste cut', dom.choiceInput, function(e) {
         validate($choiceList, $choice, $input);
         checkDuplicates($choiceList, $choice, $input);
         enableDisableSaveBtn();
+        enableDisableCreateBtn();
     });
 });
 $('body').on('blur', dom.choiceInput, function(e) {
@@ -255,6 +257,7 @@ function prepareChoiceForRemoval($trashButton, $choice) {
                 $choice.appendTo($trashCan);
                 checkAllDuplicates($choiceList);
                 enableDisableSaveBtn();
+                enableDisableCreateBtn();
             });
     } else {
         removeChoice($choice);
@@ -395,6 +398,7 @@ function restoreValues() {
         $choiceList.find('.reused-error').removeClass('reused-error');
         $choiceList.find('.blank-error').removeClass('blank-error');
         $choiceList.find('.empty-error').removeClass('empty-error');
+        $choiceList.find('.whitespace-error').removeClass('whitespace-error');
         $choiceList.find('.no-double-quotes-error').removeClass('no-double-quotes-error');
         $choiceList.find('input[type="text"]').each(function() {
             var $input = $(this),
@@ -484,11 +488,23 @@ function canBeSaved() {
     return 0 === $(dom.udfs).find('.form-control.error').length && 0 < getChanged().length;
 }
 
+function canBeCreated() {
+    return 0 === $(dom.udfCreate).find('.form-control.error').length;
+}
+
 function enableDisableSaveBtn() {
     if (canBeSaved()) {
         $(dom.saveBtn).prop('disabled', false);
     } else {
         $(dom.saveBtn).attr('disabled', 'disabled');
+    }
+}
+
+function enableDisableCreateBtn() {
+    if (canBeCreated()) {
+        $(dom.createNewUdf).prop('disabled', false);
+    } else {
+        $(dom.createNewUdf).prop('disabled', 'disabled');
     }
 }
 
@@ -513,6 +529,7 @@ function removeChoice($choice, keep) {
                 $choice.remove();
                 checkAllDuplicates($list);
                 enableDisableSaveBtn();
+                enableDisableCreateBtn();
             }
             $(dom.cancelBtn).prop('disabled', false);
         });
@@ -557,9 +574,12 @@ function validate($choiceList, $choice, $input) {
     } else if ($choice.is(':only-child') ||
         ($choice.is(':first-child:not(' + dom.existingChoice + ')') && $input.val() === '')) {
         $choice.toggleClass('empty-error', true);
+    } else if ($input.val() !== $input.val().trim()) {
+        $choice.toggleClass('whitespace-error', true);
     } else {
         $choice.toggleClass('blank-error', false);
         $choice.toggleClass('empty-error', false);
+        $choice.toggleClass('whitespace-error', false);
     }
 }
 
@@ -655,6 +675,8 @@ function highlightErrors($choiceList) {
     $choiceList.find('.blank-error .form-control')
         .toggleClass('error', true);
     $choiceList.find('.empty-error .form-control')
+        .toggleClass('error', true);
+    $choiceList.find('.whitespace-error .form-control')
         .toggleClass('error', true);
     $choiceList.find('.no-double-quotes-error .form-control')
         .toggleClass('error', true);

--- a/opentreemap/manage_treemap/templates/manage_treemap/partials/fields/udf_choice_item.html
+++ b/opentreemap/manage_treemap/templates/manage_treemap/partials/fields/udf_choice_item.html
@@ -23,6 +23,10 @@
         <i class="icon-attention"></i>{% trans "Double quotes are not allowed in multiple choice fields" %}
     </div>
 
+    <div class="error" data-item="whitespace">
+        <i class="icon-attention"></i>{% trans "You cannot have extra spaces before or after the choice" %}
+    </div>
+
     {# Necessary for adding choices on existing custom field definitions #}
     <div class="error" data-item="reused">
         <i class="icon-attention"></i>{% trans "You cannot reuse a former name without saving first" %}


### PR DESCRIPTION
## Overview

Leading or trailing whitespace cannot be easily seen, but causes problems matching values. This change follows the pattern of other client-side choice validations.

Connects https://github.com/OpenTreeMap/otm-clients/issues/442

### Demo

<img width="790" alt="screen shot 2018-11-06 at 11 21 45 am" src="https://user-images.githubusercontent.com/17363/48085069-86ffab00-e1b6-11e8-8950-7a3dd0faec7e.png">


### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.


## Testing Instructions

* Visit http://localhost:6060/create and create an instance named `trailing-choice`
* Visit http://localhost:6060/trailing-choice/management/udfs/, click `Edit` and verify that an error message is displayed and the save button is disabled if an existing choice or a new choice has leading or trailing whitespace
* Verify that new and edited choices can still be saved if they do not have excess whitespace.
