### PR TITLE
Update Django and requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ python-dateutil==2.6.1                   # https://github.com/dateutil/dateutil/
 python-omgeo==5.1.0
 pytz==2017.2                             # https://launchpad.net/pytz/+announcements
 redis==2.10.5
-requests==2.18.3
+requests==2.20.0
 rollbar==0.13.12                         # https://github.com/rollbar/pyrollbar/blob/master/CHANGELOG.md
 six==1.10.0
 statsd==3.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ celery==4.1.0
 certifi==2017.7.27.1
 chardet==3.0.4
 # https://docs.djangoproject.com/en/1.10/releases/#id2
-Django==1.11.4  # rq.filter: >=1.11,<1.12
+Django==1.11.16  # rq.filter: >=1.11,<1.12
 django-apptemplates==1.3
 django-contrib-comments==1.8.0
 django-js-reverse==0.7.3


### PR DESCRIPTION
Connects https://github.com/OpenTreeMap/otm-cloud/issues/457

Django release notes:
https://docs.djangoproject.com/en/2.1/releases/1.11.5/
https://docs.djangoproject.com/en/2.1/releases/1.11.6/
https://docs.djangoproject.com/en/2.1/releases/1.11.7/
https://docs.djangoproject.com/en/2.1/releases/1.11.8/
https://docs.djangoproject.com/en/2.1/releases/1.11.9/
https://docs.djangoproject.com/en/2.1/releases/1.11.10/
https://docs.djangoproject.com/en/2.1/releases/1.11.11/
https://docs.djangoproject.com/en/2.1/releases/1.11.12/
https://docs.djangoproject.com/en/2.1/releases/1.11.13/
https://docs.djangoproject.com/en/2.1/releases/1.11.14/
https://docs.djangoproject.com/en/2.1/releases/1.11.15/
https://docs.djangoproject.com/en/2.1/releases/1.11.16/

requests release notes:
http://docs.python-requests.org/en/master/community/updates/

The release notes for both libraries do not list any updates that I would expect to have a negative effect on OTM functionality.