### PR TITLE
Read tree ID from detail page tree section header rather than field

### DIFF
--- a/opentreemap/treemap/js/src/lib/plotDetail.js
+++ b/opentreemap/treemap/js/src/lib/plotDetail.js
@@ -14,7 +14,6 @@ var $ = require('jquery'),
 
 var dom = {
     form: '#map-feature-form',
-    treeIdColumn: '#tree-id-column',
     treePresenceSection: '#tree-presence-section',
     beginAddTree: '#begin-add-tree',
     addTreeControls: '#add-tree-controls',
@@ -27,8 +26,8 @@ exports.init = function(form) {
             .filter(R.complement(_.isUndefined))
             .filter(R.complement(_.isNull));
     }
-    
-    var treeId = $(dom.treeIdColumn).attr('data-tree-id'),
+
+    var treeId = $(dom.treeSection).attr('data-tree-id'),
         newTreeIdStream = excludeNullMap(form.saveOkStream,
             '.responseData.treeId');
 

--- a/opentreemap/treemap/templates/treemap/partials/tree_section.html
+++ b/opentreemap/treemap/templates/treemap/partials/tree_section.html
@@ -11,7 +11,11 @@
 {% include "treemap/partials/plot_detail_add_tree.html" %}
 
 <!-- Tree Information -->
-<div id="tree-details" {{ has_tree|yesno:",style=display:none;" }}>
+{% if has_tree %}
+<div id="tree-details" data-tree-id="{{ tree.id|unlocalize }}">
+{% else %}
+<div id="tree-details" style="display:none;">
+{% endif %}
     <table class="table table-hover">
         <tbody>
         {% for tuple in group.fields %}


### PR DESCRIPTION
## Overview

Instance managers can hide the tree ID field from view, which was breaking the delete logic.

Connects #3265 
Connects https://github.com/OpenTreeMap/otm-clients/issues/439
Depends on https://github.com/OpenTreeMap/otm-cloud/pull/467

## Testing Instructions

- Create an instance named `delete-without-tree-id-test`
- Browse http://localhost:6060/delete-without-tree-id-test/management/field-configuration/
- Click "Edit"
- Uncheck "ID" in the "Tree" section.
- Click "Save"
- Click "Add a tree." Complete the add tree process, filling in a species and diameter.
- Browse the detail page for the tree
- Click "Delete" and "Confirm Deletion". Verify that the tree is deleted without error.