### PR TITLE
Allow a hidden Tree ID field to be shown

### DIFF
--- a/opentreemap/manage_treemap/views/fields.py
+++ b/opentreemap/manage_treemap/views/fields.py
@@ -9,7 +9,7 @@ from django.utils.translation import ugettext as _
 
 from opentreemap.util import json_from_request
 
-from treemap.models import Species
+from treemap.models import Species, Tree
 from treemap.util import to_model_name, safe_get_model_class, to_object_name
 from treemap.lib.object_caches import udf_defs
 from treemap.search_fields import (
@@ -37,7 +37,7 @@ def set_fields_page(request, instance):
         mobj = Model(instance=instance)
 
         model_fields = {field for field in mobj.tracked_fields
-                        if _should_show_field(mobj, field)}
+                        if _should_show_field(Model, field)}
         model_fields = {'%s.%s' % (group['model'], f) for f in model_fields}
         disabled_fields = model_fields - set(group['field_keys'])
 
@@ -210,7 +210,9 @@ def _add_field_info(instance, field_names):
 def _should_show_field(model, field_name):
     if field_name.startswith('udf:'):
         return True
-    elif field_name == 'id':
+    elif field_name == 'id' and model != Tree:
+        # We show tree.id on the detail and have special handling for it so we
+        # do not want to filter it out. Other id fields are always hidden.
         return False
     elif model == Species:
         # latreemap shows these; it's easiest to include them for all maps


### PR DESCRIPTION
## Overview

The management page was allowing the Tree ID field to be hidden, but was not rendering the option in the hidden field list so that it could be shown again. We have corrected the `_should_show_field` predicate function and corrected the model argument passed to it so that the Tree ID field is correctly shown in the disabled field list.

Connects #3264 
Depends on https://github.com/OpenTreeMap/otm-cloud/pull/467

### Demo

![2018-12-21 14 48 40](https://user-images.githubusercontent.com/17363/50364970-9309b700-052f-11e9-9372-9b5bcf1c72a3.gif)

## Testing Instructions

- Create an instance named `tree-id-show-and-hide-test`
- Browse http://localhost:6060/tree-id-show-and-hide-test/management/field-configuration/
- Click "Edit"
- Uncheck "ID" in the "Tree" section.
- Click "Save"
- Refresh the page and click "Edit". Verify that "ID" appears in the "Tree" section.
- Check "ID" and click "Save"
- Refresh the page and verify that "ID" appears in the "Tree" section.