### PR TITLE
Fix can_edit_tree instance meta permission

### DIFF
--- a/opentreemap/api/instance.py
+++ b/opentreemap/api/instance.py
@@ -275,7 +275,8 @@ def instance_info(request, instance):
 
     info['meta_perms'] = {
         'can_add_tree': perms_lib.plot_is_creatable(role),
-        'can_edit_tree': perms_lib.plot_is_writable(role),
+        'can_edit_tree': (perms_lib.plot_is_writable(role) or
+                          perms_lib.tree_is_writable(role)),
         'can_edit_tree_photo': perms_lib.photo_is_addable(role, Plot),
     }
 

--- a/opentreemap/treemap/lib/perms.py
+++ b/opentreemap/treemap/lib/perms.py
@@ -229,6 +229,12 @@ def plot_is_creatable(role_related_obj):
     return model_is_creatable(role_related_obj, Plot)
 
 
+def tree_is_writable(role_related_obj, field=None):
+    return _allows_perm(role_related_obj, 'Tree',
+                        perm_attr=ALLOWS_WRITES,
+                        predicate=any, field=field)
+
+
 def model_is_creatable(role_related_obj, Model):
     role = _get_role_from_related_object(role_related_obj)
     if role is None:


### PR DESCRIPTION
## Overview

The Android application checks the value of the `can_edit_tree` instance meta permission and does not PUT changes to the API if it has a value of false. This meta permission was incorrectly looking only at plot fields. This resulted in members of a role that could only edit tree fields being prevented from saving any tree changes.

Connects https://github.com/OpenTreeMap/otm-clients/issues/446

### Notes

The `can_edit_tree` instance meta permission is not used by the web app or the iOS app, so the effect of this change is limited.

## Testing Instructions

### Setup

* Ensure that you can run the Android application and have it connect to your development OTM environment.
* Ensure that you have 2 separate user accounts set up.
* Log in as "user A," browse http://localhost:6060/create, and create an instance named `sdtest`.
* Browse http://localhost:6060/sdtest/management/roles/ and create a "Tree Steward" role.
   * Allow "Full Write Access" to "Date Planted" and "Stewardship" under "Tree Permissions." for the "Tree Steward" role.
   * Do NOT allow any planting site permissions

<img width="822" alt="screen shot 2019-01-02 at 4 00 57 pm" src="https://user-images.githubusercontent.com/17363/50617027-57180f80-0ea8-11e9-9bde-4f27a29cb64e.png">

* Browse http://localhost:6060/sdtest/management/user-roles/ and invite "User B" to the instance by email address.
* Click "Edit," change the role for "User B" to "Tree Steward" and click "Save.
* Click "Add a tree" and add a single tree to the instance with a diameter and species.

### Test

 * Check out the `master` branches of the application.
 * Log into the Android app as "User B" and select the `sdtrees` instance.
 * Select the single tree, click "EDIT," change the "Date Planted," and click "SAVE"
 * Verify that a saving spinner is NOT shown. Browse the tree detail page on the website and verify that the change was not saved.
 * Check out this PR branch
 * In the Android app use the Profile tab to switch treemap, but return to the `sdtrees` instance (this ensures that the permissions are reloaded.
 * Repeat the process of using the Android app to change the "Date Planted" and verify that the process now works.