### PR TITLE
Update urllib3 from 1.22 to 1.23

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,5 +46,5 @@ rollbar==0.13.12                         # https://github.com/rollbar/pyrollbar/
 six==1.10.0
 statsd==3.2.1
 unicodecsv==0.14.1
-urllib3==1.22
+urllib3==1.23
 wsgiref==0.1.2


### PR DESCRIPTION
## Overview

Includes bug fixes. A transitive dependency of [requests](http://python-requests.org/).

Connects https://github.com/OpenTreeMap/otm-cloud/issues/466

### Notes

Searching through the core, cloud, and addons code bases using the regex `import.*requests` returns just 2 usages.

 * A geocoding unit test.
 * An non-critical add-on utility for POSTing data to Salesforce 

## Testing Instructions

 * Reprovision and `pip freeze` to ensure that the updated version is installed.
 * Verify that the unit tests pass.