### PR TITLE
Add django-recaptca to the user registration page

### DIFF
--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -277,6 +277,7 @@ INSTALLED_APPS = (
     'django.contrib.contenttypes',
     'django.contrib.sites',
     'django.contrib.auth',
+    'captcha',
     'treemap',
     'geocode',
     'api',
@@ -405,3 +406,16 @@ WEBPACK_LOADER = {
                                    'webpack-stats.json')
     }
 }
+
+# For django-recaptcha https://github.com/praekelt/django-recaptcha
+# Setting NOCAPTCHA to True enables v2
+NOCAPTCHA = True
+
+if os.environ.get('RECAPTCHA_PUBLIC_KEY', '') != '':
+    # We use an if block here because django-recaptcha will only use a default
+    # test key if these settings are undefined.
+    RECAPTCHA_PUBLIC_KEY = os.environ.get('RECAPTCHA_PUBLIC_KEY', None)
+    RECAPTCHA_PRIVATE_KEY = os.environ.get('RECAPTCHA_PRIVATE_KEY', None)
+    USE_RECAPTCHA = True
+else:
+    USE_RECAPTCHA = False

--- a/opentreemap/registration_backend/views.py
+++ b/opentreemap/registration_backend/views.py
@@ -5,6 +5,7 @@ from __future__ import division
 
 from django import forms
 from django.core.exceptions import ValidationError
+from django.conf import settings
 from django.contrib.auth.forms import AuthenticationForm
 from django.utils.translation import ugettext_lazy as _
 from django.core.urlresolvers import reverse
@@ -62,6 +63,10 @@ class RegistrationForm(DefaultRegistrationForm):
         required=False,
         label=_('I wish to receive occasional email '
                 'updates from the tree maps to which I contribute.'))
+
+    if settings.USE_RECAPTCHA:
+        from captcha.fields import ReCaptchaField
+        captcha = ReCaptchaField(label='Verification')
 
     def __init__(self, *args, **kwargs):
         super(RegistrationForm, self).__init__(*args, **kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ django-apptemplates==1.3
 django-contrib-comments==1.8.0
 django-js-reverse==0.7.3
 django-queryset-csv==1.0.0               # https://github.com/azavea/django-queryset-csv/commits/master
+django-recaptcha==1.4.0
 django-redis==4.8.0
 django-registration-redux==1.7
 # django-statsd-mozilla==0.3.16  # TODO: enable when compatible with Django > 1.8 https://github.com/django-statsd/django-statsd/issues/97


### PR DESCRIPTION
## Overview

We are attempting to prevent spam account registrations by adding a robot test via Google's reCAPTCHA service and the `django-recaptcha` library.

Connects https://github.com/OpenTreeMap/otm-cloud/issues/461
Depends on https://github.com/OpenTreeMap/otm-cloud/pull/469

### Demo

<img width="1044" alt="screen shot 2019-01-08 at 7 14 43 pm" src="https://user-images.githubusercontent.com/17363/50871804-0c9c0480-137a-11e9-9c73-555013ad26a9.png">


### Notes

From https://developers.google.com/recaptcha/docs/faq

>reCAPTCHA v2 is not going away! We will continue to fully support and improve security and usability for v2.

>reCAPTCHA v3 is intended for power users, site owners that want more data about their traffic, and for use cases in which it is not appropriate to show a challenge to the user.

## Testing Instructions

NOTE: This is currently deployed to staging: https://staging.opentreemap.org/accounts/register/

 * Log out and visit the registration page at `/accounts/register/`
 * Verify that the reCAPTCHA is shown and that the registration form cannot be submitted without checking the I am not a robot box.