### PR TITLE
Remove trailing space from package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "leaflet": "~1.0.3",
     "leaflet-draw": "~0.4.9",
     "leaflet-pip": "~1.0.0",
-    "leaflet.gridlayer.googlemutant ": "~0.4.3",
+    "leaflet.gridlayer.googlemutant": "~0.4.3",
     "leaflet.locatecontrol": "^0.62.0",
     "lodash": "^4.17.4",
     "moment": "2.19.3",


### PR DESCRIPTION
npm complained about this:

    $ npm audit fix
    npm ERR! code EINVALIDPACKAGENAME
    npm ERR! Invalid package name "leaflet.gridlayer.googlemutant ": name cannot contain leading or trailing spaces; name can only contain URL-friendly characters