### PR TITLE
Encode the searchExtent param when making ESRI geocode request

### DIFF
--- a/opentreemap/treemap/js/src/lib/otmTypeahead.js
+++ b/opentreemap/treemap/js/src/lib/otmTypeahead.js
@@ -189,7 +189,7 @@ var create = exports.create = function(options) {
                     if (options.geocoderBbox) {
                         // wkid 102100 == webmercator
                         var searchExtent = _.extend({spatialReference:{wkid:102100}}, options.geocoderBbox);
-                        settings.url += '&searchExtent=' + JSON.stringify(searchExtent);
+                        settings.url += '&searchExtent=' + encodeURI(JSON.stringify(searchExtent));
                     }
 
                     settings = _.extend({crossDomain: true}, settings);


### PR DESCRIPTION
Requests with unescaped curly brace characters started returning 400s.

Connects https://github.com/OpenTreeMap/otm-cloud/issues/476

Depends on https://github.com/OpenTreeMap/otm-cloud/pull/477
Depends on https://github.com/OpenTreeMap/otm-website/pull/190