### PR TITLE
Remove StatsD client support

### DIFF
--- a/opentreemap/opentreemap/celery.py
+++ b/opentreemap/opentreemap/celery.py
@@ -17,14 +17,6 @@ app = Celery('opentreemap')
 app.config_from_object('django.conf:settings', namespace='CELERY')
 app.autodiscover_tasks()
 
-# TODO: Enable when django-statsd is compatible with Django > 1.8
-# if getattr(settings, 'STATSD_CELERY_SIGNALS', False):
-#     # Import here to prevent error on Celery launch
-#     # that settings module is not defined
-#     from django_statsd.celery import register_celery_events
-#     register_celery_events()
-
-
 rollbar_setup = False
 
 

--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -246,13 +246,6 @@ if ROLLBAR_SERVER_ACCESS_TOKEN is not None:
     MIDDLEWARE += (
         'rollbar.contrib.django.middleware.RollbarNotifierMiddleware',)
 
-# Settings for StatsD metrics aggregation
-# TODO: Enable when django-statsd is compatible with Django > 1.8
-# STATSD_CLIENT = 'django_statsd.clients.normal'
-# STATSD_PREFIX = '{}.django'.format(STACK_TYPE.lower())
-# STATSD_HOST = os.environ.get('OTM_STATSD_HOST', 'localhost')
-# STATSD_CELERY_SIGNALS = True
-
 STACK_COLOR = os.environ.get('OTM_STACK_COLOR', 'Black')
 
 CELERY_TASK_DEFAULT_QUEUE = STACK_COLOR

--- a/opentreemap/opentreemap/settings/default_settings.py
+++ b/opentreemap/opentreemap/settings/default_settings.py
@@ -9,7 +9,7 @@ FEATURE_BACKEND_FUNCTION = None
 USER_ACTIVATION_FUNCTION = None
 INSTANCE_PERMISSIONS_FUNCTION = 'treemap.instance.get_instance_permission_spec'
 
-ECOSERVICE_NAME = 'ecoservice'
+ECOSERVICE_NAME = 'otm-ecoservice'
 
 UITEST_CREATE_INSTANCE_FUNCTION = 'treemap.tests.make_instance'
 UITEST_SETUP_FUNCTION = None

--- a/opentreemap/treemap/tests/__init__.py
+++ b/opentreemap/treemap/tests/__init__.py
@@ -409,7 +409,7 @@ def ecoservice_not_running():
     try:
         status = subprocess.check_output(
             ["sudo", "service", settings.ECOSERVICE_NAME, "status"])
-        return status.find('start/running') < 0
+        return status.find('active (running)') < 0
     except subprocess.CalledProcessError:
         return True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ django-queryset-csv==1.0.0               # https://github.com/azavea/django-quer
 django-recaptcha==1.4.0
 django-redis==4.8.0
 django-registration-redux==1.7
-# django-statsd-mozilla==0.3.16  # TODO: enable when compatible with Django > 1.8 https://github.com/django-statsd/django-statsd/issues/97
 django-storages==1.6.5
 django-threadedcomments==1.1
 django-tinsel==1.0.0
@@ -45,7 +44,6 @@ redis==2.10.5
 requests==2.20.0
 rollbar==0.13.12                         # https://github.com/rollbar/pyrollbar/blob/master/CHANGELOG.md
 six==1.10.0
-statsd==3.2.1
 unicodecsv==0.14.1
 urllib3==1.23
 wsgiref==0.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ modgrammar-py2==0.9.1 # rq.filter: !=0.9.2
 olefile==0.44
 pep8==1.4.6 # rq.filter: ==1.4.6
 Pillow==4.2.1
-psycopg2==2.7.3                          # http://initd.org/psycopg/docs/news.html
+psycopg2==2.7.3.2                        # http://initd.org/psycopg/docs/news.html
 pyflakes==1.6.0
 python-dateutil==2.6.1                   # https://github.com/dateutil/dateutil/blob/master/NEWS
 python-omgeo==5.1.0


### PR DESCRIPTION
The metrics aggregation agents to support flushing metrics have been removed in https://github.com/OpenTreeMap/otm-cloud/pull/487.

In addition, this PR contains several other supporting fixes:

- Update reference to the ecoservice name
- Bump `psycopg2` to a functionally equivalent version that resolves [packaging](https://github.com/psycopg/psycopg2-wheels/issues/2) issues

---

**Testing**

Please use https://github.com/OpenTreeMap/otm-cloud/pull/487 to review this PR.