### PR TITLE
Fix test suite issues related to OS upgrade

### DIFF
--- a/opentreemap/importer/tests.py
+++ b/opentreemap/importer/tests.py
@@ -1151,7 +1151,7 @@ class TreeIntegrationTests(IntegrationTests):
 
         p2_geom = plot2.geom
         p2_geom.transform(4326)
-        self.assertEqual(int(p2_geom.x*10), 191)
+        self.assertIn(int(p2_geom.x*10), [191, 192])
         # FP math is annoying, some systems the following is 271, others 272
         self.assertIn(int(p2_geom.y*10), [271, 272])
         self.assertEqual(plot2.current_tree().diameter, 14)

--- a/opentreemap/stormwater/tests.py
+++ b/opentreemap/stormwater/tests.py
@@ -19,6 +19,9 @@ from django.test.utils import override_settings
 
 from stormwater.models import Bioswale, RainGarden, RainBarrel
 
+ASSERT_ALMOST_EQUAL_AREA_DELTA = 0.00000005
+ASSERT_ALMOST_EQUAL_RUNOFF_REDUCTION_DELTA = 0.00000004
+
 
 @override_settings(FEATURE_BACKEND_FUNCTION=None)
 class UdfGenericCreateTest(UdfCRUTestCase):
@@ -222,7 +225,8 @@ class PolygonalMapFeatureTest(OTMTestCase):
     def test_calculate_area(self):
         bioswale = self._make_map_feature(Bioswale)
         self.assertAlmostEqual(bioswale.calculate_area(),
-                               self.polygon_area_sq_meters, places=0)
+                               self.polygon_area_sq_meters,
+                               delta=ASSERT_ALMOST_EQUAL_AREA_DELTA * self.polygon_area_sq_meters)  # NOQA
 
     def assert_basis(self, basis, n_used, n_discarded):
         self.assertEqual(basis['resource']['n_objects_used'], n_used)
@@ -247,7 +251,8 @@ class PolygonalMapFeatureTest(OTMTestCase):
         rainfall_ft = self.instance.annual_rainfall_inches * FEET_PER_INCH
         adjusted_area = area + (drainage_area * diversion_rate)
         expected = rainfall_ft * adjusted_area * GALLONS_PER_CUBIC_FT
-        self.assertAlmostEqual(runoff_reduced, expected, places=0)
+        self.assertAlmostEqual(runoff_reduced, expected,
+                               delta=ASSERT_ALMOST_EQUAL_RUNOFF_REDUCTION_DELTA * expected)  # NOQA
 
     def test_rain_garden(self):
         RainGarden.set_config_property(self.instance, 'should_show_eco', True)

--- a/opentreemap/treemap/tests/__init__.py
+++ b/opentreemap/treemap/tests/__init__.py
@@ -409,7 +409,7 @@ def ecoservice_not_running():
     try:
         status = subprocess.check_output(
             ["sudo", "service", settings.ECOSERVICE_NAME, "status"])
-        return status.find('active (running)') < 0
+        return status.decode('utf-8').find('active (running)') < 0
     except subprocess.CalledProcessError:
         return True
 


### PR DESCRIPTION
When checking to determine the ecoservice status via `systemd`, ensure that Python decodes the command output as UTF-8 instead of ASCII because the `systemd` output contains non-ASCII values.

Also, alter the approach when making area and runoff reduction assertions. Aim to be within a small percentage of the expected value vs. matching the integer-parts
exactly.

Depends on https://github.com/OpenTreeMap/otm-cloud/pull/487

**Testing**

Please use https://github.com/OpenTreeMap/otm-cloud/pull/487 to review this PR.