### PR TITLE
Update django-queryset-csv and django-tinsel to Python 3 versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,13 +13,13 @@ Django==1.11.16  # rq.filter: >=1.11,<1.12
 django-apptemplates==1.3
 django-contrib-comments==1.8.0
 django-js-reverse==0.7.3
-django-queryset-csv==1.0.0               # https://github.com/azavea/django-queryset-csv/commits/master
+django-queryset-csv==1.0.2             # https://github.com/azavea/django-queryset-csv/commits/master
 django-recaptcha==1.4.0
 django-redis==4.8.0
 django-registration-redux==1.7
 django-storages==1.6.5
 django-threadedcomments==1.1
-django-tinsel==1.0.0
+django-tinsel==1.0.1
 django-webpack-loader==0.5.0             # https://github.com/owais/django-webpack-loader/releases
 flake8==2.0 # rq.filter: ==2.0
 functools32==3.2.3.post2


### PR DESCRIPTION
## Overview

Support for Python 3 was added before these versions, but was only correctly
declared in the patch releases.

Connects #3278 

## Demo

<img width="673" alt="Screen Shot 2019-12-18 at 2 28 04 PM" src="https://user-images.githubusercontent.com/17363/71124681-a0896980-21a2-11ea-91d9-e8740a1578e6.png">

## Notes

The django-queryset-csv upgrade also includes Django 2 compatibility but the changes are minor

https://github.com/azavea/django-queryset-csv/pull/100/files

## Testing Instructions

These assume you are starting in the `otm-cloud` working directory and the this branch is checked out in `otm-cloud/src/otm-core`

* Provision the app VM `vagrant up app --provision`
* Verify the installed versions
  * `vagrant ssh app -c "pip freeze | grep django-queryset-csv"`
  * `vagrant ssh app -c "pip freeze | grep django-tinsel"`
* `pip install caniusepython3` and verify `caniusepython3` results
  * `caniusepython3 -r  src/otm-core/requirements.txt`
  * `caniusepython3 -r  src/otm-core/test-requirements.txt`
  * `caniusepython3 -r  src/otm-core/dev-requirements.txt`
  * `caniusepython3 -r  src/otm-core/travis-requirements.txt`
  * `caniusepython3 -r  src/otm-addons/requirements.txt`
* Verify that the unit tests pass `./scripts/manage.sh test`

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
