### PR TITLE
Update requirements for Python 3 compatibility

### DIFF
--- a/opentreemap/manage.py
+++ b/opentreemap/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3.7
 import os
 import sys
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ celery==4.1.0
 certifi==2017.7.27.1
 chardet==3.0.4
 # https://docs.djangoproject.com/en/1.10/releases/#id2
-Django==1.11.16  # rq.filter: >=1.11,<1.12
+Django==1.11.17  # rq.filter: >=1.11,<1.12
 django-apptemplates==1.3
 django-contrib-comments==1.8.0
 django-js-reverse==0.7.3
@@ -22,16 +22,14 @@ django-threadedcomments==1.1
 django-tinsel==1.0.1
 django-webpack-loader==0.5.0             # https://github.com/owais/django-webpack-loader/releases
 flake8==2.0 # rq.filter: ==2.0
-functools32==3.2.3.post2
 gunicorn==19.7.1                         # http://docs.gunicorn.org/en/stable/news.html
 hiredis==0.2.0
 idna==2.5
 jsonschema==2.6.0
-kombu==4.1.0
+kombu==4.2.0
 libsass==0.11.2
 mccabe==0.6.1
-# Modgrammar-py2 has a 0.9.2 release on PyPi, but no artifacts for the release
-modgrammar-py2==0.9.1 # rq.filter: !=0.9.2
+modgrammar==0.10
 olefile==0.44
 pep8==1.4.6 # rq.filter: ==1.4.6
 Pillow==4.2.1
@@ -46,4 +44,3 @@ rollbar==0.13.12                         # https://github.com/rollbar/pyrollbar/
 six==1.10.0
 unicodecsv==0.14.1
 urllib3==1.23
-wsgiref==0.1.2


### PR DESCRIPTION
## Overview

Update requirements for Python 3 compatibility 

This PR is targeted at a `python3` branch rather than `develop`. This will be the first in a set of PRs that convert the application to run exclusively under Python 3. Merging this PR will break the application until it is updated to use Python 3 syntax.

Required by https://github.com/OpenTreeMap/otm-cloud/pull/501
Connects https://github.com/OpenTreeMap/otm-cloud/issues/500

## Notes

Django 1.11.17 is the minimum version required to run under Python 3.
https://docs.djangoproject.com/en/1.11/faq/install/#what-python-version-can-i-use-with-django

`functools32` was a backport of a Python 3 included library.

The 4.2.0 version of kombu fixes a syntax error under Python 3.
https://github.com/celery/kombu/issues/841

wsgiref is part of the Python 3 standard library.

## Testing Instructions

This should be tested as part of https://github.com/OpenTreeMap/otm-cloud/pull/501

## Checklist

- [ ] `fixup!` commits have been squashed
- [ ] CI passes after rebase
