### PR TITLE
First pass at fixing tests from Py2->3 upgrade

### DIFF
--- a/opentreemap/api/auth.py
+++ b/opentreemap/api/auth.py
@@ -59,7 +59,10 @@ def get_signature_for_request(request, secret_key):
         ).digest()
     )
 
-    return sig
+    if sig is None:
+        return sig
+
+    return sig.decode()
 
 
 def create_401unauthorized(body="Unauthorized"):

--- a/opentreemap/api/auth.py
+++ b/opentreemap/api/auth.py
@@ -9,7 +9,7 @@ import urllib.request
 import urllib.parse
 import urllib.error
 
-from django.http import HttpResponse
+from django.http import HttpResponse, RawPostDataException
 from django.contrib.auth import authenticate
 
 
@@ -37,17 +37,27 @@ def get_signature_for_request(request, secret_key):
 
     sign_string = '\n'.join([httpverb, hostheader, request_uri, paramstr])
 
-    # Sometimes reeading from body fails, so try reading as a file-like
+    # Sometimes reading from body fails, so try reading as a file-like object
     try:
-        body_encoded = base64.b64encode(request.body)
-    except:
-        body_encoded = base64.b64encode(request.read())
+        body_decoded = base64.b64encode(request.body).decode()
+    except RawPostDataException:
+        body_decoded = base64.b64encode(request.read()).decode()
 
-    if body_encoded:
-        sign_string += body_encoded
+    if body_decoded:
+        sign_string += body_decoded
+
+    try:
+        binary_secret_key = secret_key.encode()
+    except (AttributeError, UnicodeEncodeError):
+        binary_secret_key = secret_key
 
     sig = base64.b64encode(
-        hmac.new(secret_key, sign_string, hashlib.sha256).digest())
+        hmac.new(
+            binary_secret_key,
+            sign_string.encode(),
+            hashlib.sha256
+        ).digest()
+    )
 
     return sig
 
@@ -67,11 +77,15 @@ def firstmatch(regx, strg):
         return m.group(1)
 
 
-def decodebasicauth(strg):
-    if strg is None:
+def split_basicauth(strg):
+    """
+    Returns username, password from decoded,
+    stringified, basic auth credentials
+    """
+    if strg is None or len(strg) == 0:
         return None
     else:
-        m = re.match(r'([^:]*)\:(.*)', base64.decodestring(strg))
+        m = re.match(r'([^:]*)\:(.*)', strg)
         if m is not None:
             return (m.group(1), m.group(2))
         else:
@@ -79,7 +93,22 @@ def decodebasicauth(strg):
 
 
 def parse_basicauth(authstr):
-    auth = decodebasicauth(firstmatch('Basic (.*)', authstr))
+    string_wrapped_binary_credentials = firstmatch("Basic (.*)", authstr)
+    if string_wrapped_binary_credentials is None:
+        return None
+
+    # tease bytes-like object out of string, i.e. "b'credentials'"
+    reg_exp = r"'(.*?)\'"
+    parsed_credentials = re.search(r"'(.*?)\'", string_wrapped_binary_credentials)
+    str_credentials = parsed_credentials.groups()[0]
+
+    # decode the binary encoded credentials
+    decoded_str_credentials = base64.decodebytes(
+        bytes(str_credentials, 'utf-8')
+    ).decode()
+
+    auth = split_basicauth(decoded_str_credentials)
+
     if auth is None:
         return None
     else:

--- a/opentreemap/api/decorators.py
+++ b/opentreemap/api/decorators.py
@@ -78,7 +78,7 @@ def _check_signature(view_f, require_login):
         if not cred.enabled:
             return create_401unauthorized()
 
-        signed = get_signature_for_request(request, cred.secret_key)
+        signed = get_signature_for_request(request, cred.secret_key).decode()
 
         if len(signed) != len(sig):
             return _bad_request

--- a/opentreemap/api/decorators.py
+++ b/opentreemap/api/decorators.py
@@ -78,7 +78,7 @@ def _check_signature(view_f, require_login):
         if not cred.enabled:
             return create_401unauthorized()
 
-        signed = get_signature_for_request(request, cred.secret_key).decode()
+        signed = get_signature_for_request(request, cred.secret_key)
 
         if len(signed) != len(sig):
             return _bad_request

--- a/opentreemap/api/models.py
+++ b/opentreemap/api/models.py
@@ -31,7 +31,7 @@ class APIAccessCredential(models.Model):
     def create(clz, user=None):
         secret_key = base64.urlsafe_b64encode(os.urandom(64))
         access_key = base64.urlsafe_b64encode(uuid.uuid4().bytes)\
-                           .replace('=', '')
+                           .replace(b'=', b'')
 
         return APIAccessCredential.objects.create(
             user=user, access_key=access_key, secret_key=secret_key)

--- a/opentreemap/api/plots.py
+++ b/opentreemap/api/plots.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.shortcuts import get_object_or_404
 from django.contrib.gis.geos import Point
 from django.contrib.gis.measure import D
+from django.http import RawPostDataException
 
 from django_tinsel.exceptions import HttpBadRequestException
 
@@ -50,8 +51,7 @@ def plots_closest_to_point(request, instance, lat, lng):
         distance = float(request.GET.get(
             'distance', settings.MAP_CLICK_RADIUS))
     except ValueError:
-        raise HttpBadRequestException(
-            'The distance parameter must be a number')
+        raise HttpBadRequestException('The distance parameter must be a number')
 
     plots = Plot.objects.distance(point)\
                         .filter(instance=instance)\
@@ -72,7 +72,16 @@ def update_or_create_plot(request, instance, plot_id=None):
     # The API communicates via nested dictionaries but
     # our internal functions prefer dotted pairs (which
     # is what inline edit form users)
-    request_dict = json.loads(request.body)
+    # Sometimes reading from body fails, so try reading as a file-like object
+    try:
+        body_decoded = request.body.decode()
+    except RawPostDataException:
+        body_decoded = request.read().decode()
+
+    if body_decoded:
+        request_dict = json.loads(body_decoded)
+    else:
+        request_dict = {}
 
     data = {}
 

--- a/opentreemap/api/tests.py
+++ b/opentreemap/api/tests.py
@@ -1884,7 +1884,7 @@ class SigningTest(OTMTestCase):
         acred = APIAccessCredential.create()
         url = ('http://testserver.com/test/blah?'
                'timestamp=%%s&'
-               'k1=4&k2=a&access_key=%s' % acred.access_key)
+               'k1=4&k2=a&access_key=%s' % acred.access_key.decode())
 
         curtime = datetime.datetime.now()
         invalid = curtime - datetime.timedelta(minutes=100)
@@ -1950,14 +1950,14 @@ class SigningTest(OTMTestCase):
 
         url = ('http://testserver.com/test/blah?'
                'timestamp=%%s&'
-               'k1=4&k2=a&access_key=%s' % acred.access_key)
+               'k1=4&k2=a&access_key=%s' % acred.access_key.decode())
 
         req = self.sign_and_send(url % ('%sFAIL' % timestamp),
                                  acred.secret_key)
 
         self.assertEqual(req.status_code, 400)
 
-        req = self.sign_and_send(url % timestamp, acred.secret_key)
+        req = self.sign_and_send(url % timestamp, acred.secret_key.decode())
 
         self.assertRequestWasSuccess(req)
 
@@ -1973,7 +1973,7 @@ class SigningTest(OTMTestCase):
 
         self.assertEqual(req.status_code, 400)
 
-        req = self.sign_and_send('%s&access_key=%s' % (url, acred.access_key),
+        req = self.sign_and_send('%s&access_key=%s' % (url, acred.access_key.decode()),
                                  acred.secret_key)
 
         self.assertRequestWasSuccess(req)
@@ -1988,9 +1988,8 @@ class SigningTest(OTMTestCase):
         req = self.sign_and_send('http://testserver.com/test/blah?'
                                  'timestamp=%s&'
                                  'k1=4&k2=a&access_key=%s' %
-                                 (timestamp, acred.access_key),
-                                 acred.secret_key)
-
+                                 (timestamp, acred.access_key.decode()),
+                                 acred.secret_key.decode())
         self.assertEqual(req.user.pk, peon.pk)
 
 

--- a/opentreemap/api/tests.py
+++ b/opentreemap/api/tests.py
@@ -1569,7 +1569,7 @@ class TreePhotoTest(LocalMediaTestCase):
                                                       self.instance.url_name,
                                                       plot_id)
 
-        with open(path) as img:
+        with open(path, 'rb') as img:
             req = self.factory.post(
                 url, {'name': 'afile', 'file': img})
 
@@ -1622,7 +1622,7 @@ class UserTest(LocalMediaTestCase):
         url = reverse('update_user_photo', kwargs={'version': 3,
                                                    'user_id': peon.pk})
 
-        with open(TreePhotoTest.test_jpeg_path) as img:
+        with open(TreePhotoTest.test_jpeg_path, 'rb') as img:
             req = self.factory.post(
                 url, {'name': 'afile', 'file': img})
 
@@ -1649,7 +1649,7 @@ class UserTest(LocalMediaTestCase):
         grunt = make_user(username='grunt', password='pw')
         grunt.save()
 
-        with open(TreePhotoTest.test_jpeg_path) as img:
+        with open(TreePhotoTest.test_jpeg_path, 'rb') as img:
             req = self.factory.post(
                 url, {'name': 'afile', 'file': img})
 
@@ -1903,7 +1903,7 @@ class SigningTest(OTMTestCase):
         url = "%s/i/plots/1/tree/photo" % API_PFX
 
         def get_sig(path):
-            with open(path) as img:
+            with open(path, 'rb') as img:
                 req = self.factory.post(
                     url, {'name': 'afile', 'file': img})
 

--- a/opentreemap/api/tests.py
+++ b/opentreemap/api/tests.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-from io import StringIO
+from io import BytesIO
 from json import loads, dumps
 from urllib.parse import urlparse
 
@@ -14,6 +14,7 @@ import base64
 import datetime
 import psycopg2
 from unittest.case import skip
+from django_tinsel.exceptions import HttpBadRequestException
 
 from django.db import connection
 from django.contrib.auth.models import AnonymousUser
@@ -96,11 +97,11 @@ def send_json_body(url, body_object, client, method, user=None):
     are posting form data, so you need to manually setup the parameters
     to override that default functionality.
     """
-    body_string = dumps(body_object)
-    body_stream = StringIO(body_string)
+    body_binary_string = dumps(body_object).encode()
+    body_stream = BytesIO(body_binary_string)
     parsed_url = urlparse(url)
     client_params = {
-        'CONTENT_LENGTH': len(body_string),
+        'CONTENT_LENGTH': len(body_binary_string),
         'CONTENT_TYPE': 'application/json',
         'PATH_INFO': _get_path(parsed_url),
         'QUERY_STRING': parsed_url[4],
@@ -375,8 +376,8 @@ class Locations(OTMTestCase):
                 API_PFX, self.instance.url_name))
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.content,
-                         'The max_plots parameter must be '
-                         'a number between 1 and 500')
+                         b'The max_plots parameter must be '
+                         b'a number between 1 and 500')
 
     def test_locations_plots_max_plots_param_cannot_be_greater_than_500(self):
         response = get_signed(
@@ -385,8 +386,8 @@ class Locations(OTMTestCase):
                 API_PFX, self.instance.url_name))
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.content,
-                         'The max_plots parameter must be '
-                         'a number between 1 and 500')
+                         b'The max_plots parameter must be '
+                         b'a number between 1 and 500')
         response = get_signed(
             self.client,
             "%s/instance/%s/locations/0,0/plots?max_plots=500" %
@@ -402,8 +403,8 @@ class Locations(OTMTestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.content,
-                         'The max_plots parameter must be a '
-                         'number between 1 and 500')
+                         b'The max_plots parameter must be a '
+                         b'number between 1 and 500')
         response = get_signed(
             self.client,
             "%s/instance/%s/locations/0,0/plots?max_plots=1" %
@@ -419,7 +420,7 @@ class Locations(OTMTestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.content,
-                         'The distance parameter must be a number')
+                         b'The distance parameter must be a number')
 
         response = get_signed(
             self.client,
@@ -472,7 +473,7 @@ class CreatePlotAndTree(OTMTestCase):
                              data, self.client, self.user)
 
         self.assertEqual(200, response.status_code,
-                         "Create failed:" + response.content)
+                         "Create failed:" + response.content.decode())
 
         # Assert that a plot was added
         self.assertEqual(plot_count + 1, Plot.objects.count())
@@ -509,7 +510,7 @@ class CreatePlotAndTree(OTMTestCase):
         self.assertEqual(400,
                          response.status_code,
                          "Expected creating a million foot "
-                         "tall tree to return 400:" + response.content)
+                         "tall tree to return 400:" + response.content.decode())
 
         body_dict = loads(response.content)
         self.assertTrue('fieldErrors' in body_dict,
@@ -548,7 +549,7 @@ class CreatePlotAndTree(OTMTestCase):
                              data, self.client, self.user)
 
         self.assertEqual(200, response.status_code,
-                         "Create failed:" + response.content)
+                         "Create failed:" + response.content.decode())
 
         # Assert that a plot was added
         self.assertEqual(plot_count + 1, Plot.objects.count())
@@ -1334,8 +1335,8 @@ class Instance(LocalMediaTestCase):
              'sort_key': 'Date'}
         ]
         self.instance.save()
-        self.instance.logo.save(Instance.test_png_name,
-                                File(open(Instance.test_png_path, 'r')))
+        with open(Instance.test_png_path, 'rb') as f:
+            self.instance.logo.save(Instance.test_png_name, f)
 
     def test_returns_config_colors(self):
         request = sign_request_as_user(make_request(), self.user)
@@ -2003,7 +2004,7 @@ class Authentication(OTMTestCase):
         self.assertEqual(ret.status_code, 401)
 
     def test_ok(self):
-        auth = base64.b64encode("jim:password")
+        auth = base64.b64encode(b"jim:password")
         withauth = {"HTTP_AUTHORIZATION": "Basic %s" % auth}
 
         ret = get_signed(self.client, "%s/user" % API_PFX, **withauth)
@@ -2015,14 +2016,14 @@ class Authentication(OTMTestCase):
         ret = get_signed(self.client, "%s/user" % API_PFX, **withauth)
         self.assertEqual(ret.status_code, 401)
 
-        auth = base64.b64encode("foobar")
+        auth = base64.b64encode(b"foobar")
         withauth = {"HTTP_AUTHORIZATION": "Basic %s" % auth}
 
         ret = get_signed(self.client, "%s/user" % API_PFX, **withauth)
         self.assertEqual(ret.status_code, 401)
 
     def test_bad_cred(self):
-        auth = base64.b64encode("jim:passwordz")
+        auth = base64.b64encode(b"jim:passwordz")
         withauth = {"HTTP_AUTHORIZATION": "Basic %s" % auth}
 
         ret = get_signed(self.client, "%s/user" % API_PFX, **withauth)
@@ -2034,7 +2035,7 @@ class Authentication(OTMTestCase):
         ijim.reputation = 1001
         ijim.save()
 
-        auth = base64.b64encode("jim:password")
+        auth = base64.b64encode(b"jim:password")
         withauth = dict(list(self.sign.items()) +
                         [("HTTP_AUTHORIZATION", "Basic %s" % auth)])
 

--- a/opentreemap/api/user.py
+++ b/opentreemap/api/user.py
@@ -138,7 +138,7 @@ def transform_user_request(user_view_fn):
             # You can't directly set a new request body
             # (http://stackoverflow.com/a/22745559)
             request._body = body
-            request._stream = BytesIO(body)
+            request._stream = BytesIO(body.encode())
 
         return user_view_fn(request, *args, **kwargs)
 

--- a/opentreemap/exporter/util.py
+++ b/opentreemap/exporter/util.py
@@ -4,11 +4,11 @@
 def sanitize_unicode_value(value):
     # make sure every text value is of type 'str', coercing unicode
     if isinstance(value, str):
-        return value.encode("utf-8")
-    elif isinstance(value, str):
         return value
+    elif isinstance(value, int):
+        return str(value)
     else:
-        return str(value).encode("utf-8")
+        return value.decode("utf-8")
 
 
 # originally copied from, but now divergent from:

--- a/opentreemap/importer/tasks.py
+++ b/opentreemap/importer/tasks.py
@@ -22,7 +22,7 @@ def _create_rows_for_event(ie, csv_file):
     # so we can show progress. Caller does manual cleanup if necessary.
     reader = utf8_file_to_csv_dictreader(csv_file)
 
-    field_names = [f.strip().decode('utf-8') for f in reader.fieldnames
+    field_names = [f.strip() for f in reader.fieldnames
                    if f.strip().lower() not in ie.ignored_fields()]
     ie.field_order = json.dumps(field_names)
     ie.save()

--- a/opentreemap/importer/tests.py
+++ b/opentreemap/importer/tests.py
@@ -461,7 +461,7 @@ class TreeUdfValidationTest(TreeValidationTestBase):
         i = self.mkrow(row)
         i.validate_row()
         self.assertHasError(i, errors.INVALID_UDF_VALUE,
-                            data="[u'Test date must be formatted as YYYY-MM-DD']")
+                            data="['Test date must be formatted as YYYY-MM-DD']")
 
     def test_choice_udf(self):
         UserDefinedFieldDefinition.objects.create(
@@ -534,13 +534,13 @@ class TreeUdfValidationTest(TreeValidationTestBase):
         i = self.mkrow(row)
         i.validate_row()
         self.assertHasError(i, errors.INVALID_UDF_VALUE,
-                            data="[u'Test multichoice must be valid JSON']")
+                            data="['Test multichoice must be valid JSON']")
 
         row['planting site: test multichoice'] = '"a","b"'
         i = self.mkrow(row)
         i.validate_row()
         self.assertHasError(i, errors.INVALID_UDF_VALUE,
-                            data="[u'Test multichoice must be valid JSON']")
+                            data="['Test multichoice must be valid JSON']")
 
 
 class SpeciesValidationTest(ValidationTest):

--- a/opentreemap/importer/util.py
+++ b/opentreemap/importer/util.py
@@ -34,7 +34,7 @@ def _as_utf8(f):
 
 
 def _guess_dialect_and_reset_read_pointer(f):
-    dialect = csv.Sniffer().sniff(_as_utf8(f).read(4096), delimiters=',\t')
+    dialect = csv.Sniffer().sniff(_as_utf8(f).read(4096).decode(), delimiters=',\t')
     f.seek(0)
     return dialect
 

--- a/opentreemap/importer/util.py
+++ b/opentreemap/importer/util.py
@@ -3,7 +3,7 @@
 
 import codecs
 import csv
-
+from io import StringIO
 
 def _clean_string(s):
     s = s.strip()
@@ -45,5 +45,11 @@ def utf8_file_to_csv_dictreader(f):
     # CSV standard "" to escape a double quote. Excel and LibreOffice
     # use this escape by default when saving as CSV.
     dialect.doublequote = True
-    return csv.DictReader(_as_utf8(f),
+
+    # at this point, the binary filestream must be repackaged to the csv spec,
+    # that is an iterator of unicode strings. time limited a more elegant solution
+    # than allocating memory for up to two copies of the data but we anticipate having
+    # sufficient RAM
+    csv_body = StringIO(f.read().decode())
+    return csv.DictReader(csv_body,
                           dialect=dialect)

--- a/opentreemap/importer/views.py
+++ b/opentreemap/importer/views.py
@@ -707,7 +707,7 @@ def process_csv(request, instance, import_type, **kwargs):
     filename = list(files.keys())[0]
     file_obj = files[filename]
 
-    file_obj = io.BytesIO(decode(file_obj.read()).encode('utf-8'))
+    file_obj = io.BytesIO((file_obj.read().encode('utf-8')))
 
     owner = request.user
     ImportEventModel = get_import_event_model(import_type)

--- a/opentreemap/otm1_migrator/model_processors.py
+++ b/opentreemap/otm1_migrator/model_processors.py
@@ -3,7 +3,6 @@
 
 import os
 import pytz
-from exceptions import NotImplementedError
 
 from django.db.transaction import atomic
 from django.contrib.contenttypes.models import ContentType
@@ -138,7 +137,7 @@ def process_userprofile(migration_rules, migration_event,
 
     photo_full_path = os.path.join(photo_basepath, photo_path)
     try:
-        photo_data = open(photo_full_path)
+        photo_data = open(photo_full_path, 'rb')
     except IOError:
         print("Failed to read photo %s ... SKIPPING USER %s %s" %
               (photo_full_path, user.id, user.username))
@@ -164,7 +163,7 @@ def save_treephoto(migration_rules, migration_event, treephoto_path,
         pk = models.UNBOUND_MODEL_ID
     else:
         image = open(os.path.join(treephoto_path,
-                                  model_dict['fields']['photo']))
+                                  model_dict['fields']['photo']), 'rb')
         treephoto_obj.set_image(image)
         treephoto_obj.map_feature_id = (Tree
                                         .objects

--- a/opentreemap/treemap/audit.py
+++ b/opentreemap/treemap/audit.py
@@ -530,7 +530,7 @@ class Dictable(object):
     def hash(self):
         values = ['%s:%s' % (k, v) for (k, v) in self.as_dict().items()]
         string = '|'.join(values).encode('utf-8')
-        return hashlib.md5(string).hexdigest()
+        return hashlib.md5(string.encode()).hexdigest()
 
 
 class UserTrackable(Dictable):
@@ -1154,7 +1154,7 @@ class Auditable(UserTrackable):
 
         string_to_hash = '%s:%s:%s' % (self._model_name, self.pk, audit_string)
 
-        return hashlib.md5(string_to_hash).hexdigest()
+        return hashlib.md5(string_to_hash.encode()).hexdigest()
 
     @classmethod
     def action_format_string_for_audit(clz, audit):

--- a/opentreemap/treemap/images.py
+++ b/opentreemap/treemap/images.py
@@ -4,7 +4,7 @@
 from PIL import Image
 import hashlib
 import os
-from io import StringIO
+from io import BytesIO
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -27,7 +27,7 @@ def _rotate_image_based_on_exif(img):
 
 
 def _get_file_for_image(image, filename, format):
-    temp = StringIO()
+    temp = BytesIO()
     image.save(temp, format=format)
     temp.seek(0)
     return SimpleUploadedFile(filename, temp.read(),

--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -153,7 +153,7 @@ class InstanceBounds(models.Model):
         try:
             geojson_dict = json.loads(geojson)
         except ValueError as e:
-            raise ValidationError(e.message)
+            raise ValidationError(str(e))
         if geojson_dict['type'] != 'FeatureCollection':
             raise ValidationError('GeoJSON must contain a FeatureCollection')
 

--- a/opentreemap/treemap/instance.py
+++ b/opentreemap/treemap/instance.py
@@ -430,11 +430,11 @@ class Instance(models.Model):
 
     @property
     def geo_rev_hash(self):
-        return hashlib.md5(str(self.geo_rev)).hexdigest()
+        return hashlib.md5(str(self.geo_rev).encode()).hexdigest()
 
     @property
     def universal_rev_hash(self):
-        return hashlib.md5(str(self.universal_rev)).hexdigest()
+        return hashlib.md5(str(self.universal_rev).encode()).hexdigest()
 
     @property
     def center_lat_lng(self):

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -360,7 +360,7 @@ class User(AbstractUniqueEmailUser, Auditable):
 
     @property
     def email_hash(self):
-        return hashlib.sha512(self.email).hexdigest()
+        return hashlib.sha512(self.email.encode()).hexdigest()
 
     def dict(self):
         return {'id': self.pk,

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -822,7 +822,7 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
         for feature in self.nearby_map_features():
             string_to_hash += "," + str(feature.pk)
 
-        return hashlib.md5(string_to_hash).hexdigest()
+        return hashlib.md5(string_to_hash.encode()).hexdigest()
 
     def title(self):
         # Cast allows the map feature subclass to handle generating
@@ -1202,7 +1202,7 @@ class Tree(Convertible, UDFModel, PendingAuditable, ValidationMixin):
         photos = [str(photo.pk) for photo in self.treephoto_set.all()]
         string_to_hash += ":" + ",".join(photos)
 
-        return hashlib.md5(string_to_hash).hexdigest()
+        return hashlib.md5(string_to_hash.encode()).hexdigest()
 
     def add_photo(self, image, user):
         tp = TreePhoto(tree=self, instance=self.instance)

--- a/opentreemap/treemap/templatetags/form_extras.py
+++ b/opentreemap/treemap/templatetags/form_extras.py
@@ -59,19 +59,19 @@ VALID_FIELD_KEYS = ','.join(list(FIELD_MAPPINGS.keys()))
 class Variable(Grammar):
     grammar = (G('"', WORD('^"'), '"') | G("'", WORD("^'"), "'")
                | WORD("a-zA-Z_", "a-zA-Z0-9_."))
-
+    grammar_whitespace_mode = 'optional'
 
 class Label(Grammar):
     grammar = (G('_("', WORD('^"'), '")') | G("_('", WORD("^'"), "')")
                | Variable)
-
+    grammar_whitespace_mode = 'optional'
 
 class InlineEditGrammar(Grammar):
     grammar = (OR(G(OR("field", "create"), OPTIONAL(Label)), "search"),
                "from", Variable, OPTIONAL("for", Variable),
                OPTIONAL("in", Variable), "withtemplate", Variable,
                OPTIONAL("withhelp", Label))
-    grammar_whitespace = True
+    grammar_whitespace_mode = 'optional'
 
 
 _inline_edit_parser = InlineEditGrammar.parser()
@@ -186,8 +186,8 @@ def inline_edit_tag(tag, Node):
     """
     def tag_parser(parser, token):
         try:
-            results = _inline_edit_parser.parse_string(token.contents,
-                                                       reset=True, eof=True)
+            results = _inline_edit_parser.parse_text(token.contents,
+                                                     reset=True, eof=True)
         except ParseError as e:
             raise template.TemplateSyntaxError(
                 'expected format: %s [{label}] from {model.property}'
@@ -224,7 +224,7 @@ def _token_to_variable(token):
     elif token[0] == '"' and token[0] == token[-1] and len(token) >= 2:
         return token[1:-1]
     else:
-        return template.Variable(token)
+        return template.Variable(token.strip())
 
 
 def _resolve_variable(variable, context):

--- a/opentreemap/treemap/tests/__init__.py
+++ b/opentreemap/treemap/tests/__init__.py
@@ -2,7 +2,7 @@
 
 
 import logging
-from io import StringIO
+from io import BytesIO
 import subprocess
 import shutil
 import tempfile
@@ -365,7 +365,7 @@ def make_request(params=None, user=None, instance=None,
 
     extra = {}
     if body:
-        body_stream = StringIO(body)
+        body_stream = BytesIO(body.encode())
         extra['wsgi.input'] = body_stream
         extra['CONTENT_LENGTH'] = len(body)
 

--- a/opentreemap/treemap/tests/__init__.py
+++ b/opentreemap/treemap/tests/__init__.py
@@ -430,7 +430,7 @@ class LocalMediaTestCase(OTMTestCase):
         return path
 
     def load_resource(self, name):
-        return open(self.resource_path(name))
+        return open(self.resource_path(name), 'rb')
 
     def tearDown(self):
         shutil.rmtree(self.photoDir)

--- a/opentreemap/treemap/views/map_feature.py
+++ b/opentreemap/treemap/views/map_feature.py
@@ -371,7 +371,8 @@ def map_feature_hash(request, instance, feature_id, edit=False, tree_id=None):
     if request.user:
         pk = request.user.pk or ''
 
-    return hashlib.md5(feature.hash + ':' + str(pk)).hexdigest()
+    string_to_hash = feature.hash + ':' + str(pk)
+    return hashlib.md5(string_to_hash.encode()).hexdigest()
 
 
 @get_photo_context_and_errors

--- a/opentreemap/treemap/views/tree.py
+++ b/opentreemap/treemap/views/tree.py
@@ -132,4 +132,4 @@ def ecobenefits_hash(request, instance):
 
     string_to_hash = universal_rev + ":" + eco_str + ":" + map_features
 
-    return hashlib.md5(string_to_hash).hexdigest()
+    return hashlib.md5(string_to_hash.encode()).hexdigest()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ amqp==2.2.1
 anyjson==0.3.3
 billiard==3.5.0.3
 boto==2.48.0                             # http://docs.pythonboto.org/en/latest/releasenotes/v2.39.0.html
-celery==4.1.0
+celery==4.3.0
 certifi==2017.7.27.1
 chardet==3.0.4
 # https://docs.djangoproject.com/en/1.10/releases/#id2
@@ -19,7 +19,7 @@ django-redis==4.8.0
 django-registration-redux==1.7
 django-storages==1.6.5
 django-threadedcomments==1.1
-django-tinsel==1.0.1
+django-tinsel==1.0.2
 django-webpack-loader==0.5.0             # https://github.com/owais/django-webpack-loader/releases
 flake8==2.0 # rq.filter: ==2.0
 gunicorn==19.7.1                         # http://docs.gunicorn.org/en/stable/news.html


### PR DESCRIPTION
### Overview
This PR is a first go at fixing the failing tests from the Py2->3 upgrade.
The tests should be fixed for the `exporter` app 🎉 One down.

I touched tests / code across the django apps `api, exporter, importer, treemap`. Except for `exporter`, they continue to have errors. I'm not sure how the test runner selects the order of tests to run because it skipped around these 4 apps when running `./scripts/manage.py test --failfast`

Most of the changes thus far have been about unicode/byte - string translation.
The celery and Django-tinsel upgrades were to fix test-related errors, see commit https://github.com/OpenTreeMap/otm-core/commit/df782b1e40ab988e27bede383616c0587344a2c2

### Notes
In retrospect, I would have worked on one app's tests at a time. My advice to parallelize this work moving forward is just that:
`./scripts/manage.py test <app_name> --failfast`

It's impossible to linearly compare progress for various reasons. But anyway, we're making progress! 

Before:
```
Ran 1115 tests in 275.613s

FAILED (failures=19, errors=305, skipped=23)
```

And this is what remains after related-PRs 😳 
```
Ran 1115 tests in 331.760s

FAILED (failures=26, errors=125, skipped=23)
```
### Testing

In the app VM, pip install the new python dependencies:
`vagrant ssh app -c 'cd /opt/app/core && envdir /etc/otm.d/env pip3 install -r ./requirements.txt'`

Checkout the otm-addons companion branch https://github.com/OpenTreeMap/otm-addons/pull/1566

I suppose you'll want to test each of the apps that was touched and check if any still failling tests are a result of lines of codes touched in this PR.
`./scripts/manage.py test <app_name>`

Also ensure that the changes don't chip away important context just to get tests to work.