### PR TITLE
Fix tests in several apps

### DIFF
--- a/opentreemap/api/auth.py
+++ b/opentreemap/api/auth.py
@@ -59,7 +59,10 @@ def get_signature_for_request(request, secret_key):
         ).digest()
     )
 
-    return sig
+    if sig is None:
+        return sig
+
+    return sig.decode()
 
 
 def create_401unauthorized(body="Unauthorized"):

--- a/opentreemap/api/decorators.py
+++ b/opentreemap/api/decorators.py
@@ -78,7 +78,7 @@ def _check_signature(view_f, require_login):
         if not cred.enabled:
             return create_401unauthorized()
 
-        signed = get_signature_for_request(request, cred.secret_key).decode()
+        signed = get_signature_for_request(request, cred.secret_key)
 
         if len(signed) != len(sig):
             return _bad_request

--- a/opentreemap/api/tests.py
+++ b/opentreemap/api/tests.py
@@ -1884,7 +1884,7 @@ class SigningTest(OTMTestCase):
         acred = APIAccessCredential.create()
         url = ('http://testserver.com/test/blah?'
                'timestamp=%%s&'
-               'k1=4&k2=a&access_key=%s' % acred.access_key)
+               'k1=4&k2=a&access_key=%s' % acred.access_key.decode())
 
         curtime = datetime.datetime.now()
         invalid = curtime - datetime.timedelta(minutes=100)
@@ -1950,14 +1950,14 @@ class SigningTest(OTMTestCase):
 
         url = ('http://testserver.com/test/blah?'
                'timestamp=%%s&'
-               'k1=4&k2=a&access_key=%s' % acred.access_key)
+               'k1=4&k2=a&access_key=%s' % acred.access_key.decode())
 
         req = self.sign_and_send(url % ('%sFAIL' % timestamp),
                                  acred.secret_key)
 
         self.assertEqual(req.status_code, 400)
 
-        req = self.sign_and_send(url % timestamp, acred.secret_key)
+        req = self.sign_and_send(url % timestamp, acred.secret_key.decode())
 
         self.assertRequestWasSuccess(req)
 
@@ -1973,7 +1973,7 @@ class SigningTest(OTMTestCase):
 
         self.assertEqual(req.status_code, 400)
 
-        req = self.sign_and_send('%s&access_key=%s' % (url, acred.access_key),
+        req = self.sign_and_send('%s&access_key=%s' % (url, acred.access_key.decode()),
                                  acred.secret_key)
 
         self.assertRequestWasSuccess(req)
@@ -1988,9 +1988,8 @@ class SigningTest(OTMTestCase):
         req = self.sign_and_send('http://testserver.com/test/blah?'
                                  'timestamp=%s&'
                                  'k1=4&k2=a&access_key=%s' %
-                                 (timestamp, acred.access_key),
-                                 acred.secret_key)
-
+                                 (timestamp, acred.access_key.decode()),
+                                 acred.secret_key.decode())
         self.assertEqual(req.user.pk, peon.pk)
 
 
@@ -2083,7 +2082,7 @@ class UserApiExportsTest(UserExportsTestCase):
 class PasswordResetTest(OTMTestCase):
     def setUp(self):
         self.instance = setupTreemapEnv()
-        self.jim = User.objects.get(username="jim", password="password")
+        self.jim = User.objects.get(username="jim")
 
     def test_send_password_reset_email_url(self):
         url = "%s/send-password-reset-email?email=%s"

--- a/opentreemap/api/tests.py
+++ b/opentreemap/api/tests.py
@@ -1569,7 +1569,7 @@ class TreePhotoTest(LocalMediaTestCase):
                                                       self.instance.url_name,
                                                       plot_id)
 
-        with open(path) as img:
+        with open(path, 'rb') as img:
             req = self.factory.post(
                 url, {'name': 'afile', 'file': img})
 
@@ -1622,7 +1622,7 @@ class UserTest(LocalMediaTestCase):
         url = reverse('update_user_photo', kwargs={'version': 3,
                                                    'user_id': peon.pk})
 
-        with open(TreePhotoTest.test_jpeg_path) as img:
+        with open(TreePhotoTest.test_jpeg_path, 'rb') as img:
             req = self.factory.post(
                 url, {'name': 'afile', 'file': img})
 
@@ -1649,7 +1649,7 @@ class UserTest(LocalMediaTestCase):
         grunt = make_user(username='grunt', password='pw')
         grunt.save()
 
-        with open(TreePhotoTest.test_jpeg_path) as img:
+        with open(TreePhotoTest.test_jpeg_path, 'rb') as img:
             req = self.factory.post(
                 url, {'name': 'afile', 'file': img})
 
@@ -1903,7 +1903,7 @@ class SigningTest(OTMTestCase):
         url = "%s/i/plots/1/tree/photo" % API_PFX
 
         def get_sig(path):
-            with open(path) as img:
+            with open(path, 'rb') as img:
                 req = self.factory.post(
                     url, {'name': 'afile', 'file': img})
 

--- a/opentreemap/api/user.py
+++ b/opentreemap/api/user.py
@@ -138,7 +138,7 @@ def transform_user_request(user_view_fn):
             # You can't directly set a new request body
             # (http://stackoverflow.com/a/22745559)
             request._body = body
-            request._stream = BytesIO(body)
+            request._stream = BytesIO(body.encode())
 
         return user_view_fn(request, *args, **kwargs)
 

--- a/opentreemap/importer/tasks.py
+++ b/opentreemap/importer/tasks.py
@@ -22,7 +22,7 @@ def _create_rows_for_event(ie, csv_file):
     # so we can show progress. Caller does manual cleanup if necessary.
     reader = utf8_file_to_csv_dictreader(csv_file)
 
-    field_names = [f.strip().decode('utf-8') for f in reader.fieldnames
+    field_names = [f.strip() for f in reader.fieldnames
                    if f.strip().lower() not in ie.ignored_fields()]
     ie.field_order = json.dumps(field_names)
     ie.save()

--- a/opentreemap/importer/tests.py
+++ b/opentreemap/importer/tests.py
@@ -461,7 +461,7 @@ class TreeUdfValidationTest(TreeValidationTestBase):
         i = self.mkrow(row)
         i.validate_row()
         self.assertHasError(i, errors.INVALID_UDF_VALUE,
-                            data="[u'Test date must be formatted as YYYY-MM-DD']")
+                            data="['Test date must be formatted as YYYY-MM-DD']")
 
     def test_choice_udf(self):
         UserDefinedFieldDefinition.objects.create(
@@ -534,13 +534,13 @@ class TreeUdfValidationTest(TreeValidationTestBase):
         i = self.mkrow(row)
         i.validate_row()
         self.assertHasError(i, errors.INVALID_UDF_VALUE,
-                            data="[u'Test multichoice must be valid JSON']")
+                            data="['Test multichoice must be valid JSON']")
 
         row['planting site: test multichoice'] = '"a","b"'
         i = self.mkrow(row)
         i.validate_row()
         self.assertHasError(i, errors.INVALID_UDF_VALUE,
-                            data="[u'Test multichoice must be valid JSON']")
+                            data="['Test multichoice must be valid JSON']")
 
 
 class SpeciesValidationTest(ValidationTest):

--- a/opentreemap/importer/util.py
+++ b/opentreemap/importer/util.py
@@ -3,7 +3,7 @@
 
 import codecs
 import csv
-
+from io import StringIO
 
 def _clean_string(s):
     s = s.strip()
@@ -45,5 +45,11 @@ def utf8_file_to_csv_dictreader(f):
     # CSV standard "" to escape a double quote. Excel and LibreOffice
     # use this escape by default when saving as CSV.
     dialect.doublequote = True
-    return csv.DictReader(_as_utf8(f),
+
+    # at this point, the binary filestream must be repackaged to the csv spec,
+    # that is an iterator of unicode strings. time limited a more elegant solution
+    # than allocating memory for up to two copies of the data but we anticipate having
+    # sufficient RAM
+    csv_body = StringIO(f.read().decode())
+    return csv.DictReader(csv_body,
                           dialect=dialect)

--- a/opentreemap/otm1_migrator/model_processors.py
+++ b/opentreemap/otm1_migrator/model_processors.py
@@ -3,7 +3,6 @@
 
 import os
 import pytz
-from exceptions import NotImplementedError
 
 from django.db.transaction import atomic
 from django.contrib.contenttypes.models import ContentType
@@ -138,7 +137,7 @@ def process_userprofile(migration_rules, migration_event,
 
     photo_full_path = os.path.join(photo_basepath, photo_path)
     try:
-        photo_data = open(photo_full_path)
+        photo_data = open(photo_full_path, 'rb')
     except IOError:
         print("Failed to read photo %s ... SKIPPING USER %s %s" %
               (photo_full_path, user.id, user.username))
@@ -164,7 +163,7 @@ def save_treephoto(migration_rules, migration_event, treephoto_path,
         pk = models.UNBOUND_MODEL_ID
     else:
         image = open(os.path.join(treephoto_path,
-                                  model_dict['fields']['photo']))
+                                  model_dict['fields']['photo']), 'rb')
         treephoto_obj.set_image(image)
         treephoto_obj.map_feature_id = (Tree
                                         .objects

--- a/opentreemap/treemap/audit.py
+++ b/opentreemap/treemap/audit.py
@@ -530,7 +530,7 @@ class Dictable(object):
     def hash(self):
         values = ['%s:%s' % (k, v) for (k, v) in self.as_dict().items()]
         string = '|'.join(values).encode('utf-8')
-        return hashlib.md5(string).hexdigest()
+        return hashlib.md5(string.encode()).hexdigest()
 
 
 class UserTrackable(Dictable):
@@ -1154,7 +1154,7 @@ class Auditable(UserTrackable):
 
         string_to_hash = '%s:%s:%s' % (self._model_name, self.pk, audit_string)
 
-        return hashlib.md5(string_to_hash).hexdigest()
+        return hashlib.md5(string_to_hash.encode()).hexdigest()
 
     @classmethod
     def action_format_string_for_audit(clz, audit):

--- a/opentreemap/treemap/models.py
+++ b/opentreemap/treemap/models.py
@@ -822,7 +822,7 @@ class MapFeature(Convertible, UDFModel, PendingAuditable):
         for feature in self.nearby_map_features():
             string_to_hash += "," + str(feature.pk)
 
-        return hashlib.md5(string_to_hash).hexdigest()
+        return hashlib.md5(string_to_hash.encode()).hexdigest()
 
     def title(self):
         # Cast allows the map feature subclass to handle generating
@@ -1202,7 +1202,7 @@ class Tree(Convertible, UDFModel, PendingAuditable, ValidationMixin):
         photos = [str(photo.pk) for photo in self.treephoto_set.all()]
         string_to_hash += ":" + ",".join(photos)
 
-        return hashlib.md5(string_to_hash).hexdigest()
+        return hashlib.md5(string_to_hash.encode()).hexdigest()
 
     def add_photo(self, image, user):
         tp = TreePhoto(tree=self, instance=self.instance)

--- a/opentreemap/treemap/views/map_feature.py
+++ b/opentreemap/treemap/views/map_feature.py
@@ -371,7 +371,8 @@ def map_feature_hash(request, instance, feature_id, edit=False, tree_id=None):
     if request.user:
         pk = request.user.pk or ''
 
-    return hashlib.md5(feature.hash + ':' + str(pk)).hexdigest()
+    string_to_hash = feature.hash + ':' + str(pk)
+    return hashlib.md5(string_to_hash.encode()).hexdigest()
 
 
 @get_photo_context_and_errors

--- a/opentreemap/treemap/views/tree.py
+++ b/opentreemap/treemap/views/tree.py
@@ -132,4 +132,4 @@ def ecobenefits_hash(request, instance):
 
     string_to_hash = universal_rev + ":" + eco_str + ":" + map_features
 
-    return hashlib.md5(string_to_hash).hexdigest()
+    return hashlib.md5(string_to_hash.encode()).hexdigest()


### PR DESCRIPTION
## Overview

This PR fixes all remaining failing tests in the api, otm1_migrator, map_features, stormwater, cloud_management apps. 

The type of fixes continued to be related to binary & unicode encoding of strings or data.

This leaves `treemap` and `importer` to go 🎉 
```
Ran 1121 tests in 322.639s

FAILED (failures=20, errors=32, skipped=23)
```

## Notes
The commit descriptions are less noticeably less robust than their predecessors on parent branches. This is because these fixes are not novel in the type of problem they are fixing. I am inclined to squash some of these commits before merging the parent branch `jf/fix-tests-2to3` into the `python3` feature branch.

### Testing
Run tests for all apps that should be fixed up to this point
`./scripts/manage.sh test stormwater otm1_migrator api map_features cloud_management exporter`

Inversely, running `./scripts/manage.sh test` should return the same output as in this PR's overview.