### PR TITLE
Fix importer app tests

### DIFF
--- a/opentreemap/importer/tasks.py
+++ b/opentreemap/importer/tasks.py
@@ -22,7 +22,7 @@ def _create_rows_for_event(ie, csv_file):
     # so we can show progress. Caller does manual cleanup if necessary.
     reader = utf8_file_to_csv_dictreader(csv_file)
 
-    field_names = [f.strip().decode('utf-8') for f in reader.fieldnames
+    field_names = [f.strip() for f in reader.fieldnames
                    if f.strip().lower() not in ie.ignored_fields()]
     ie.field_order = json.dumps(field_names)
     ie.save()

--- a/opentreemap/importer/tests.py
+++ b/opentreemap/importer/tests.py
@@ -461,7 +461,7 @@ class TreeUdfValidationTest(TreeValidationTestBase):
         i = self.mkrow(row)
         i.validate_row()
         self.assertHasError(i, errors.INVALID_UDF_VALUE,
-                            data="[u'Test date must be formatted as YYYY-MM-DD']")
+                            data="['Test date must be formatted as YYYY-MM-DD']")
 
     def test_choice_udf(self):
         UserDefinedFieldDefinition.objects.create(
@@ -534,13 +534,13 @@ class TreeUdfValidationTest(TreeValidationTestBase):
         i = self.mkrow(row)
         i.validate_row()
         self.assertHasError(i, errors.INVALID_UDF_VALUE,
-                            data="[u'Test multichoice must be valid JSON']")
+                            data="['Test multichoice must be valid JSON']")
 
         row['planting site: test multichoice'] = '"a","b"'
         i = self.mkrow(row)
         i.validate_row()
         self.assertHasError(i, errors.INVALID_UDF_VALUE,
-                            data="[u'Test multichoice must be valid JSON']")
+                            data="['Test multichoice must be valid JSON']")
 
 
 class SpeciesValidationTest(ValidationTest):

--- a/opentreemap/importer/util.py
+++ b/opentreemap/importer/util.py
@@ -3,7 +3,7 @@
 
 import codecs
 import csv
-
+from io import StringIO
 
 def _clean_string(s):
     s = s.strip()
@@ -45,5 +45,11 @@ def utf8_file_to_csv_dictreader(f):
     # CSV standard "" to escape a double quote. Excel and LibreOffice
     # use this escape by default when saving as CSV.
     dialect.doublequote = True
-    return csv.DictReader(_as_utf8(f),
+
+    # at this point, the binary filestream must be repackaged to the csv spec,
+    # that is an iterator of unicode strings. time limited a more elegant solution
+    # than allocating memory for up to two copies of the data but we anticipate having
+    # sufficient RAM
+    csv_body = StringIO(f.read().decode())
+    return csv.DictReader(csv_body,
                           dialect=dialect)


### PR DESCRIPTION
## Overview

This PR fixes failing unit tests in the `importer` django app. Same old story as other PRs, all unit test failures continue to be because of the clarification between Binary vs Unicode encoding.

The more interesting case seen here is that CSV generation is more strict. Before, a temporary file wrapper of a byte stream was considered a valid csv file. Now, it is not. A valid csv file must be an iterator object of unicode strings. So there's a bit of conversion we do to repackage the byte stream into a proper csv. I left an in-line comment that I hope is clear. **Let me know if it could be made clearer**: in-line comments tend to be particularly helpful in infrequently touched codebases like this.

### Testing
`./scripts/manage.sh test importer` should run cleanly and only `treemap` tests should be broken 🌮 

```
Ran 1121 tests in 309.863s

FAILED (failures=18, errors=11, skipped=23)
```